### PR TITLE
Improve transcript header and dependency handling

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,41 @@
+"""Tests for the newsletter pipeline helpers."""
+
+from __future__ import annotations
+
+from datetime import date, timezone
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from egregora.pipeline import build_llm_input
+
+
+def _build_transcript(day: int) -> tuple[date, str]:
+    return date(2025, 1, day), f"Mensagem do dia {day}."
+
+
+def test_build_llm_input_uses_singular_label_for_one_day() -> None:
+    prompt = build_llm_input(
+        group_name="Grupo Teste",
+        timezone=timezone.utc,
+        transcripts=[_build_transcript(1)],
+        previous_newsletter=None,
+    )
+
+    assert "TRANSCRITO BRUTO DO ÚLTIMO DIA" in prompt
+
+
+def test_build_llm_input_uses_plural_label_for_multiple_days() -> None:
+    prompt = build_llm_input(
+        group_name="Grupo Teste",
+        timezone=timezone.utc,
+        transcripts=[
+            _build_transcript(1),
+            _build_transcript(2),
+            _build_transcript(3),
+        ],
+        previous_newsletter=None,
+    )
+
+    assert "TRANSCRITO BRUTO DOS ÚLTIMOS 3 DIAS" in prompt


### PR DESCRIPTION
## Summary
- defer google-genai usage until runtime so helper utilities can be imported without the dependency installed
- adjust the transcript section heading to reflect the actual number of days included in the prompt
- add unit tests covering the prompt header wording for singular and plural transcript windows

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68df14768abc83259cb55ebe43bbb1ee