### PR TITLE
Add privacy prompt instructions and CLI safeguards

### DIFF
--- a/src/egregora/__main__.py
+++ b/src/egregora/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Sequence
 from zoneinfo import ZoneInfo
@@ -167,7 +168,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "discover":
-        result = discover_identifier(args.value)
+        value = args.value.strip()
+        if not value:
+            print("Erro: informe um telefone ou apelido válido.", file=sys.stderr)
+            return 1
+
+        try:
+            result = discover_identifier(value)
+        except ValueError as exc:
+            print(f"Erro: {exc}", file=sys.stderr)
+            return 1
+
         if args.quiet:
             print(result.get(args.format))
         else:

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -61,7 +61,15 @@ class EnrichmentConfig:
 
 @dataclass(slots=True)
 class AnonymizationConfig:
-    """Configuration for author anonymization."""
+    """Configuration for author anonymization.
+
+    Attributes:
+        enabled: Controls whether author names are converted before prompting.
+        output_format: Style of the anonymized identifiers:
+            - ``"human"`` → formato legível (ex.: ``User-A1B2``).
+            - ``"short"`` → 8 caracteres hexadecimais (ex.: ``a1b2c3d4``).
+            - ``"full"`` → UUID completo.
+    """
 
     enabled: bool = True
     output_format: FormatType = "human"

--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -85,6 +85,9 @@ def _prepare_transcripts(
     """Return transcripts with authors anonymized when enabled."""
 
     sanitized: list[tuple[date, str]] = []
+    anonymized_authors: set[str] = set()
+    processed_lines = 0
+
     for transcript_date, raw_text in transcripts:
         if not config.anonymization.enabled or not raw_text:
             sanitized.append((transcript_date, raw_text))
@@ -106,7 +109,25 @@ def _prepare_transcripts(
             )
             processed_parts.append(anonymized + newline)
 
+            processed_lines += 1
+            for pattern in TRANSCRIPT_PATTERNS:
+                match = pattern.match(line)
+                if not match:
+                    continue
+
+                author = match.group("author").strip()
+                if author:
+                    anonymized_authors.add(author)
+                break
+
         sanitized.append((transcript_date, "".join(processed_parts)))
+
+    if config.anonymization.enabled:
+        print(
+            "[Anonimização] "
+            f"{len(anonymized_authors)} remetentes anonimizados em {processed_lines} linhas. "
+            f"Formato: {config.anonymization.output_format}."
+        )
 
     return sanitized
 
@@ -315,6 +336,12 @@ Objetivo:
 - Inserir CADA LINK COMPARTILHADO no ponto exato em que ele é mencionado (link completo, clicável). Não agrupar links no final.
 - EXPLICITAR subentendidos, tensões, mudanças de posição e contextos. Não deixar implícito o que está acontecendo em cada momento.
 - Não inventar nicks. Não resumir links. Não ocultar mensagens relevantes.
+
+🔒 PRIVACIDADE — INSTRUÇÕES CRÍTICAS:
+- Utilize APENAS os identificadores anônimos fornecidos (User-XXXX, Member-XXXX, etc.).
+- Nunca repita nomes próprios, telefones completos ou e-mails mencionados NO CONTEÚDO das mensagens.
+- Ao referenciar alguém citado no conteúdo mas sem identificador anônimo, generalize ("um membro", "uma pessoa do grupo").
+- Preserve o sentido original enquanto remove detalhes de contato ou identificação direta.
 
 Regras de formatação do relatório:
 1) Cabeçalho:

--- a/tests/test_privacy_prompt.py
+++ b/tests/test_privacy_prompt.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import egregora.pipeline as pipeline
+
+
+class DummyPart:
+    def __init__(self, text: str):
+        self.text = text
+
+    @classmethod
+    def from_text(cls, *, text: str):
+        return cls(text=text)
+
+
+class DummyContent:
+    def __init__(self, *, role: str, parts: list[DummyPart]):
+        self.role = role
+        self.parts = parts
+
+
+class DummyGenerateContentConfig:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _install_pipeline_stubs(monkeypatch):
+    stub_types = SimpleNamespace(
+        Part=DummyPart,
+        Content=DummyContent,
+        GenerateContentConfig=DummyGenerateContentConfig,
+    )
+    monkeypatch.setattr(pipeline, "types", stub_types)
+    monkeypatch.setattr(pipeline, "genai", object())
+
+
+class DummyChunk:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class DummyModelAPI:
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+
+    def generate_content_stream(self, *, model: str, contents, config):  # noqa: ANN001
+        for text in self._responses:
+            yield DummyChunk(text)
+
+
+class DummyClient:
+    def __init__(self, responses: list[str]):
+        self.models = DummyModelAPI(responses)
+
+
+def test_system_instruction_includes_privacy_rules(monkeypatch):
+    _install_pipeline_stubs(monkeypatch)
+
+    instruction = pipeline.build_system_instruction()
+    assert instruction, "system instruction should not be empty"
+
+    system_text = instruction[0].text
+    assert "PRIVACIDADE — INSTRUÇÕES CRÍTICAS" in system_text
+    assert "Nunca repita nomes próprios" in system_text
+    assert "identificadores anônimos" in system_text
+
+
+def test_privacy_review_removes_names(monkeypatch):
+    _install_pipeline_stubs(monkeypatch)
+
+    client = DummyClient(["User-A1B2 sugeriu algo importante."])
+    reviewed = pipeline._run_privacy_review(
+        client,
+        model="fake-model",
+        newsletter_text="João (User-A1B2) sugeriu algo.",
+    )
+
+    assert "João" not in reviewed
+    assert "User-A1B2" in reviewed


### PR DESCRIPTION
## Summary
- add anonymization logging and privacy guardrails to the newsletter pipeline
- document anonymization identifier formats and validate discover CLI input
- cover privacy prompt behaviour with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df3e79ccbc8325b3cb4df7230f2ec6