### PR TITLE
Fix transcript anonymization bracket handling

### DIFF
--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -43,7 +43,7 @@ TRANSCRIPT_PATTERNS = [
         r"^(?P<prefix>\d{1,2}/\d{1,2}/\d{2,4},\s*\d{1,2}:\d{2}\s[-–—]\s)(?P<author>[^:]+)(?P<separator>:\s*)(?P<message>.*)$"
     ),
     re.compile(
-        r"^\[(?P<prefix>\d{1,2}:\d{2}:\d{2}\]\s)(?P<author>[^:]+)(?P<separator>:\s*)(?P<message>.*)$"
+        r"^(?P<prefix>\[\d{1,2}:\d{2}:\d{2}\]\s)(?P<author>[^:]+)(?P<separator>:\s*)(?P<message>.*)$"
     ),
     re.compile(
         r"^(?P<prefix>\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}\s+[-–—]\s+)(?P<author>[^:]+)(?P<separator>:\s*)(?P<message>.*)$"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from egregora.pipeline import build_llm_input
+from egregora.pipeline import build_llm_input, _anonymize_transcript_line
 
 
 def _build_transcript(day: int) -> tuple[date, str]:
@@ -39,3 +39,13 @@ def test_build_llm_input_uses_plural_label_for_multiple_days() -> None:
     )
 
     assert "TRANSCRITO BRUTO DOS ÚLTIMOS 3 DIAS" in prompt
+
+
+def test_anonymize_transcript_line_preserves_leading_bracket() -> None:
+    result = _anonymize_transcript_line(
+        "[12:34:56] Nome: mensagem",
+        anonymize=True,
+        output_format="human",
+    )
+
+    assert result.startswith("[12:34:56] ")


### PR DESCRIPTION
## Summary
- ensure the square bracket prefix in transcript lines is preserved during anonymization
- add a regression test covering chat lines that begin with a timestamp enclosed in brackets

## Testing
- pytest tests/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e0087f799483258f74059d2f711188