### PR TITLE
Add Gemini embedding support with caching

### DIFF
--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -56,6 +56,11 @@ class RAGConfig:
         "-m",
         "egregora.mcp_server.server",
     )
+    use_gemini_embeddings: bool = False
+    embedding_model: str = "gemini-embedding-001"
+    embedding_dimension: int = 768
+    embedding_cache_enabled: bool = True
+    use_batch_api: bool = False
 
 
 @dataclass(slots=True)

--- a/src/egregora/rag/core.py
+++ b/src/egregora/rag/core.py
@@ -120,7 +120,11 @@ class NewsletterRAG:
             )
             self._embedder = GeminiEmbedder(embed_config, gemini_client)
             if self.config.embedding_cache_enabled:
-                self._embedding_cache = EmbeddingCache(self.cache_dir)
+                self._embedding_cache = EmbeddingCache(
+                    self.cache_dir,
+                    model=self.config.embedding_model,
+                    dimension=self.config.embedding_dimension,
+                )
 
     # ------------------------------------------------------------------
     # Index management

--- a/src/egregora/rag/embedding_cache.py
+++ b/src/egregora/rag/embedding_cache.py
@@ -1,0 +1,126 @@
+"""Persistent caching utilities for Gemini embeddings."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+@dataclass(slots=True)
+class CachedEmbedding:
+    """Container for cached embedding metadata."""
+
+    dimension: int
+    cached_at: datetime
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {
+            "dimension": self.dimension,
+            "cached_at": self.cached_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "CachedEmbedding":
+        cached_at = payload.get("cached_at")
+        timestamp = datetime.fromisoformat(str(cached_at)) if cached_at else datetime.utcnow()
+        return cls(dimension=int(payload.get("dimension", 0)), cached_at=timestamp)
+
+
+class EmbeddingCache:
+    """Simple file-based cache for embedding vectors."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir / "embeddings"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.index_path = self.cache_dir / "index.json"
+        self._index: dict[str, CachedEmbedding] = self._load_index()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get(self, text: str) -> list[float] | None:
+        """Return a cached embedding for *text* if available."""
+
+        text_hash = self._hash_text(text)
+        entry = self._index.get(text_hash)
+        if not entry:
+            return None
+
+        payload_path = self.cache_dir / f"{text_hash}.json"
+        if not payload_path.exists():
+            return None
+
+        try:
+            payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:  # pragma: no cover - defensive
+            return None
+
+        values = payload.get("embedding")
+        if not isinstance(values, list):
+            return None
+
+        return [float(value) for value in values]
+
+    def set(self, text: str, embedding: Iterable[float]) -> None:
+        """Store *embedding* for *text* in the cache."""
+
+        vector = [float(value) for value in embedding]
+        text_hash = self._hash_text(text)
+        payload_path = self.cache_dir / f"{text_hash}.json"
+
+        payload = {"embedding": vector}
+        payload_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+        self._index[text_hash] = CachedEmbedding(
+            dimension=len(vector),
+            cached_at=datetime.utcnow(),
+        )
+        self._save_index()
+
+    def clear(self) -> None:
+        """Remove all cached embeddings."""
+
+        for path in self.cache_dir.glob("*.json"):
+            if path.name == "index.json":
+                continue
+            path.unlink(missing_ok=True)
+        self._index.clear()
+        self._save_index()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _hash_text(self, text: str) -> str:
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return digest[:32]
+
+    def _load_index(self) -> dict[str, CachedEmbedding]:
+        if not self.index_path.exists():
+            return {}
+
+        try:
+            payload = json.loads(self.index_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:  # pragma: no cover - defensive
+            return {}
+
+        entries = {}
+        for key, value in payload.items():
+            if not isinstance(value, dict):
+                continue
+            entries[key] = CachedEmbedding.from_dict(value)
+        return entries
+
+    def _save_index(self) -> None:
+        payload = {key: entry.to_dict() for key, entry in self._index.items()}
+        self.index_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+
+__all__ = ["EmbeddingCache", "CachedEmbedding"]
+

--- a/src/egregora/rag/embedding_cache.py
+++ b/src/egregora/rag/embedding_cache.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Mapping
 
 
 @dataclass(slots=True)
@@ -16,27 +16,44 @@ class CachedEmbedding:
 
     dimension: int
     cached_at: datetime
+    namespace: str | None = None
 
     def to_dict(self) -> dict[str, str | int]:
-        return {
+        payload: dict[str, str | int] = {
             "dimension": self.dimension,
             "cached_at": self.cached_at.isoformat(),
         }
+        if self.namespace is not None:
+            payload["namespace"] = self.namespace
+        return payload
 
     @classmethod
     def from_dict(cls, payload: Dict[str, object]) -> "CachedEmbedding":
         cached_at = payload.get("cached_at")
         timestamp = datetime.fromisoformat(str(cached_at)) if cached_at else datetime.utcnow()
-        return cls(dimension=int(payload.get("dimension", 0)), cached_at=timestamp)
+        namespace = payload.get("namespace")
+        return cls(
+            dimension=int(payload.get("dimension", 0)),
+            cached_at=timestamp,
+            namespace=str(namespace) if namespace is not None else None,
+        )
 
 
 class EmbeddingCache:
     """Simple file-based cache for embedding vectors."""
 
-    def __init__(self, cache_dir: Path) -> None:
+    def __init__(
+        self,
+        cache_dir: Path,
+        *,
+        model: str,
+        dimension: int,
+        extra: Mapping[str, str | int] | None = None,
+    ) -> None:
         self.cache_dir = cache_dir / "embeddings"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.index_path = self.cache_dir / "index.json"
+        self._namespace = self._build_namespace(model=model, dimension=dimension, extra=extra)
         self._index: dict[str, CachedEmbedding] = self._load_index()
 
     # ------------------------------------------------------------------
@@ -48,6 +65,9 @@ class EmbeddingCache:
         text_hash = self._hash_text(text)
         entry = self._index.get(text_hash)
         if not entry:
+            return None
+
+        if entry.namespace and entry.namespace != self._namespace:
             return None
 
         payload_path = self.cache_dir / f"{text_hash}.json"
@@ -78,6 +98,7 @@ class EmbeddingCache:
         self._index[text_hash] = CachedEmbedding(
             dimension=len(vector),
             cached_at=datetime.utcnow(),
+            namespace=self._namespace,
         )
         self._save_index()
 
@@ -95,8 +116,23 @@ class EmbeddingCache:
     # Internal helpers
     # ------------------------------------------------------------------
     def _hash_text(self, text: str) -> str:
-        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
-        return digest[:32]
+        payload = f"{self._namespace}::{text}"
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        return digest
+
+    def _build_namespace(
+        self,
+        *,
+        model: str,
+        dimension: int,
+        extra: Mapping[str, str | int] | None = None,
+    ) -> str:
+        components = [f"model={model}", f"dimension={dimension}"]
+        if extra:
+            for key in sorted(extra):
+                value = extra[key]
+                components.append(f"{key}={value}")
+        return "|".join(components)
 
     def _load_index(self) -> dict[str, CachedEmbedding]:
         if not self.index_path.exists():
@@ -111,7 +147,10 @@ class EmbeddingCache:
         for key, value in payload.items():
             if not isinstance(value, dict):
                 continue
-            entries[key] = CachedEmbedding.from_dict(value)
+            entry = CachedEmbedding.from_dict(value)
+            if entry.namespace and entry.namespace != self._namespace:
+                continue
+            entries[key] = entry
         return entries
 
     def _save_index(self) -> None:

--- a/src/egregora/rag/embeddings.py
+++ b/src/egregora/rag/embeddings.py
@@ -1,0 +1,116 @@
+"""Gemini embeddings integration for the RAG subsystem."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency during testing
+    from google import genai  # type: ignore
+    from google.genai import types  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully
+    genai = None  # type: ignore[assignment]
+    types = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class EmbeddingConfig:
+    """Configuration options for :class:`GeminiEmbedder`."""
+
+    model: str = "gemini-embedding-001"
+    output_dimensionality: int = 768
+    batch_size: int = 100
+
+
+class GeminiEmbedder:
+    """Helper that proxies embedding requests to the Gemini API."""
+
+    def __init__(self, config: EmbeddingConfig, client: Any) -> None:
+        self.config = config
+        self.client = client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        """Return embeddings for *texts* using the document task type."""
+
+        return [self._embed_text(text, task_type="RETRIEVAL_DOCUMENT") for text in texts]
+
+    def embed_query(self, query: str) -> list[float]:
+        """Return an embedding for the supplied *query*."""
+
+        return self._embed_text(query, task_type="RETRIEVAL_QUERY")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _embed_text(self, text: str, *, task_type: str) -> list[float]:
+        """Call the Gemini API for a single text block."""
+
+        if not text:
+            return []
+
+        response = self._call_embed_content(text, task_type=task_type)
+        return self._extract_values(response)
+
+    def _call_embed_content(self, text: str, *, task_type: str) -> Any:
+        """Invoke ``models.embed_content`` with the appropriate arguments."""
+
+        model = getattr(self.client, "models", self.client)
+        embed_method = getattr(model, "embed_content")
+
+        if types is not None:
+            config = types.EmbedContentConfig(
+                task_type=task_type,
+                output_dimensionality=self.config.output_dimensionality,
+            )
+            return embed_method(
+                model=self.config.model,
+                contents=text,
+                config=config,
+            )
+
+        # Fall back to a simple namespace so tests can run without the SDK.
+        config = SimpleNamespace(
+            task_type=task_type,
+            output_dimensionality=self.config.output_dimensionality,
+        )
+        return embed_method(
+            model=self.config.model,
+            contents=text,
+            config=config,
+        )
+
+    @staticmethod
+    def _extract_values(response: Any) -> list[float]:
+        """Extract the embedding vector from the Gemini response."""
+
+        if response is None:
+            return []
+
+        embedding_obj = getattr(response, "embedding", None)
+        if embedding_obj is not None:
+            values = getattr(embedding_obj, "values", None)
+            if isinstance(values, Iterable):
+                return [float(value) for value in values]
+
+        embeddings = getattr(response, "embeddings", None)
+        if embeddings:
+            first = embeddings[0]
+            values = getattr(first, "values", first)
+            if isinstance(values, Iterable):
+                return [float(value) for value in values]
+
+        # Some client implementations may return mappings or dicts.
+        if isinstance(response, dict):  # pragma: no cover - defensive
+            values = response.get("embedding") or response.get("values")
+            if isinstance(values, Iterable):
+                return [float(value) for value in values]
+
+        return []
+
+
+__all__ = ["EmbeddingConfig", "GeminiEmbedder"]
+

--- a/tests/test_gemini_embeddings.py
+++ b/tests/test_gemini_embeddings.py
@@ -1,0 +1,102 @@
+"""Tests covering the Gemini embedding integration for the RAG subsystem."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from egregora.config import RAGConfig
+from egregora.rag.core import NewsletterRAG
+
+
+class DummyEmbeddingResponse:
+    def __init__(self, values: list[float]):
+        self.embedding = SimpleNamespace(values=values)
+
+
+class DummyModels:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def embed_content(self, *, model: str, contents: str, config) -> DummyEmbeddingResponse:  # type: ignore[override]
+        task_type = getattr(config, "task_type", "RETRIEVAL_DOCUMENT")
+        self.calls.append((model, contents, task_type))
+        base = 1.0 if task_type == "RETRIEVAL_QUERY" else float(len(self.calls))
+        return DummyEmbeddingResponse([base, base + 0.5, base + 1.0])
+
+
+class DummyGeminiClient:
+    def __init__(self) -> None:
+        self.models = DummyModels()
+
+
+def _create_newsletter(directory: Path, name: str, text: str) -> Path:
+    path = directory / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_newsletter_rag_uses_gemini_embeddings(tmp_path: Path) -> None:
+    newsletters_dir = tmp_path / "newsletters"
+    newsletters_dir.mkdir()
+    cache_dir = tmp_path / "cache"
+
+    _create_newsletter(
+        newsletters_dir,
+        "2024-10-01.md",
+        """# Atualizações
+
+Discussão sobre IA e automação.
+""",
+    )
+
+    rag_config = RAGConfig(
+        enabled=True,
+        use_gemini_embeddings=True,
+        min_similarity=0.0,
+        embedding_dimension=3,
+        exclude_recent_days=0,
+    )
+
+    dummy_client = DummyGeminiClient()
+
+    rag = NewsletterRAG(
+        newsletters_dir=newsletters_dir,
+        cache_dir=cache_dir,
+        config=rag_config,
+        gemini_client=dummy_client,
+    )
+
+    rag.update_index(force_reindex=True)
+
+    hits = rag.search(query="automação", top_k=1)
+
+    assert hits, "Expected at least one hit using Gemini embeddings"
+    assert hits[0].score > 0.0
+    assert dummy_client.models.calls, "Embed API should have been invoked"
+
+
+def test_gemini_embeddings_fall_back_without_client(tmp_path: Path) -> None:
+    newsletters_dir = tmp_path / "newsletters"
+    newsletters_dir.mkdir()
+    cache_dir = tmp_path / "cache"
+
+    _create_newsletter(
+        newsletters_dir,
+        "2024-10-02.md",
+        "Conversa sobre aprendizado de máquina",
+    )
+
+    rag_config = RAGConfig(enabled=True, use_gemini_embeddings=True, min_similarity=0.0)
+
+    rag = NewsletterRAG(
+        newsletters_dir=newsletters_dir,
+        cache_dir=cache_dir,
+        config=rag_config,
+        gemini_client=None,
+    )
+
+    rag.update_index(force_reindex=True)
+    hits = rag.search(query="aprendizado", top_k=1)
+
+    assert hits, "Fallback TF-IDF search should still return results"


### PR DESCRIPTION
## Summary
- add Gemini embedding integration with optional caching to NewsletterRAG
- extend RAG configuration for Gemini models and embedding cache controls
- cover Gemini paths with unit tests, including fallback when no client is provided

## Testing
- pytest *(fails: repository tests expect a `temp_dir` fixture that is not defined in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e01a46c0e08325a62cf082a8521e94