### PR TITLE
Add contextual profile analysis utilities

### DIFF
--- a/src/egregora/profiles/__init__.py
+++ b/src/egregora/profiles/__init__.py
@@ -1,0 +1,12 @@
+"""Profile analysis helpers."""
+
+from .profile import ParticipantProfile
+from .prompts import PROFILE_REWRITE_PROMPT, UPDATE_DECISION_PROMPT
+from .updater import ProfileUpdater
+
+__all__ = [
+    "ParticipantProfile",
+    "PROFILE_REWRITE_PROMPT",
+    "UPDATE_DECISION_PROMPT",
+    "ProfileUpdater",
+]

--- a/src/egregora/profiles/profile.py
+++ b/src/egregora/profiles/profile.py
@@ -1,0 +1,186 @@
+"""Data structures representing participant profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Dict, Mapping, Sequence
+
+
+def _format_list(items: Sequence[str]) -> str:
+    if not items:
+        return "- (sem dados observáveis)"
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _format_mapping(mapping: Mapping[str, Any]) -> str:
+    if not mapping:
+        return "- (sem dados observáveis)"
+
+    lines: list[str] = []
+    for key, value in mapping.items():
+        if isinstance(value, (list, tuple, set)):
+            values = ", ".join(str(item) for item in value)
+        else:
+            values = str(value)
+        lines.append(f"- **{key}:** {values}")
+    return "\n".join(lines)
+
+
+@dataclass(slots=True)
+class ParticipantProfile:
+    """Analytical profile for a group participant."""
+
+    member_id: str
+    worldview_summary: str = ""
+    core_interests: Dict[str, Sequence[str] | str] = field(default_factory=dict)
+    thinking_style: str = ""
+    values_and_priorities: list[str] = field(default_factory=list)
+    expertise_areas: Dict[str, Sequence[str] | str] = field(default_factory=dict)
+    contribution_style: str = ""
+    argument_patterns: list[str] = field(default_factory=list)
+    questioning_approach: str = ""
+    intellectual_influences: list[str] = field(default_factory=list)
+    aligns_with: list[str] = field(default_factory=list)
+    debates_with: list[str] = field(default_factory=list)
+    recent_shifts: list[str] = field(default_factory=list)
+    growing_interests: list[str] = field(default_factory=list)
+    interaction_patterns: Dict[str, str] = field(default_factory=dict)
+    last_updated: datetime = field(default_factory=lambda: datetime.now(UTC))
+    analysis_version: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the profile into a JSON-friendly dictionary."""
+
+        return {
+            "member_id": self.member_id,
+            "worldview_summary": self.worldview_summary,
+            "core_interests": self.core_interests,
+            "thinking_style": self.thinking_style,
+            "values_and_priorities": list(self.values_and_priorities),
+            "expertise_areas": self.expertise_areas,
+            "contribution_style": self.contribution_style,
+            "argument_patterns": list(self.argument_patterns),
+            "questioning_approach": self.questioning_approach,
+            "intellectual_influences": list(self.intellectual_influences),
+            "aligns_with": list(self.aligns_with),
+            "debates_with": list(self.debates_with),
+            "recent_shifts": list(self.recent_shifts),
+            "growing_interests": list(self.growing_interests),
+            "interaction_patterns": dict(self.interaction_patterns),
+            "last_updated": self.last_updated.isoformat(),
+            "analysis_version": self.analysis_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ParticipantProfile":
+        """Deserialize a profile from a dictionary."""
+
+        last_updated_raw = data.get("last_updated")
+        if isinstance(last_updated_raw, str):
+            try:
+                last_updated = datetime.fromisoformat(last_updated_raw)
+                if last_updated.tzinfo is None:
+                    last_updated = last_updated.replace(tzinfo=UTC)
+                else:
+                    last_updated = last_updated.astimezone(UTC)
+            except ValueError:
+                last_updated = datetime.now(UTC)
+        elif isinstance(last_updated_raw, datetime):
+            last_updated = (
+                last_updated_raw if last_updated_raw.tzinfo else last_updated_raw.replace(tzinfo=UTC)
+            )
+        else:
+            last_updated = datetime.now(UTC)
+
+        return cls(
+            member_id=str(data.get("member_id")),
+            worldview_summary=str(data.get("worldview_summary", "")),
+            core_interests=dict(data.get("core_interests", {})),
+            thinking_style=str(data.get("thinking_style", "")),
+            values_and_priorities=list(data.get("values_and_priorities", [])),
+            expertise_areas=dict(data.get("expertise_areas", {})),
+            contribution_style=str(data.get("contribution_style", "")),
+            argument_patterns=list(data.get("argument_patterns", [])),
+            questioning_approach=str(data.get("questioning_approach", "")),
+            intellectual_influences=list(data.get("intellectual_influences", [])),
+            aligns_with=list(data.get("aligns_with", [])),
+            debates_with=list(data.get("debates_with", [])),
+            recent_shifts=list(data.get("recent_shifts", [])),
+            growing_interests=list(data.get("growing_interests", [])),
+            interaction_patterns=dict(data.get("interaction_patterns", {})),
+            last_updated=last_updated,
+            analysis_version=int(data.get("analysis_version", 0)),
+        )
+
+    def to_markdown(self) -> str:
+        """Return a human friendly Markdown representation."""
+
+        interests_text = _format_mapping(self.core_interests)
+        expertise_text = _format_mapping(self.expertise_areas)
+        values_text = _format_list(self.values_and_priorities)
+        argument_text = _format_list(self.argument_patterns)
+        influences_text = _format_list(self.intellectual_influences)
+        shifts_text = _format_list(self.recent_shifts)
+        growth_text = _format_list(self.growing_interests)
+
+        participation_timing = self.interaction_patterns.get(
+            "participation_timing", "Em observação"
+        )
+        response_style = self.interaction_patterns.get("response_style", "Em observação")
+        influence_on_group = self.interaction_patterns.get(
+            "influence_on_group", "Em observação"
+        )
+
+        aligns_with = ", ".join(self.aligns_with) if self.aligns_with else "Diversos membros"
+        debates_with = ", ".join(self.debates_with) if self.debates_with else "Diversos membros"
+
+        return (
+            f"# Perfil Analítico: {self.member_id}\n\n"
+            "## 🧠 Visão Geral\n\n"
+            f"{self.worldview_summary or 'Em construção.'}\n\n"
+            "## 🎯 Áreas de Interesse e Perspectiva\n\n"
+            f"{interests_text}\n\n"
+            "## 💭 Estilo de Pensamento\n\n"
+            f"{self.thinking_style or 'Em observação.'}\n\n"
+            "**Padrões de argumentação:**\n"
+            f"{argument_text}\n\n"
+            "**Abordagem às questões:**\n"
+            f"{self.questioning_approach or 'Em observação.'}\n\n"
+            "## 🎓 Áreas de Expertise Demonstrada\n\n"
+            f"{expertise_text}\n\n"
+            "## 💡 Valores e Prioridades Observadas\n\n"
+            f"{values_text}\n\n"
+            "## 🤝 Forma de Contribuir\n\n"
+            f"{self.contribution_style or 'Em observação.'}\n\n"
+            "### Dinâmica de Participação\n\n"
+            f"**Timing de participação:** {participation_timing}\n\n"
+            f"**Estilo de resposta:** {response_style}\n\n"
+            f"**Influência no grupo:** {influence_on_group}\n\n"
+            f"**Alinha-se com:** {aligns_with}\n\n"
+            f"**Debates construtivos com:** {debates_with}\n\n"
+            "## 📚 Influências Intelectuais Aparentes\n\n"
+            f"{influences_text}\n\n"
+            "## 🔄 Evolução Recente\n\n"
+            "**Mudanças de perspectiva:**\n"
+            f"{shifts_text}\n\n"
+            "**Novos interesses emergentes:**\n"
+            f"{growth_text}\n\n"
+            "---\n"
+            f"*Análise gerada pelo Egregora - {self.last_updated.strftime('%Y-%m-%d')}*\n"
+            "*Baseada em participação contextualizada nas discussões do grupo*\n"
+        )
+
+    def update_timestamp(self) -> None:
+        """Refresh the ``last_updated`` timestamp."""
+
+        self.last_updated = datetime.now(UTC)
+
+    def apply_updates(self, **updates: Any) -> None:
+        """Utility method to update multiple fields at once."""
+
+        for key, value in updates.items():
+            if not hasattr(self, key):
+                continue
+            setattr(self, key, value)
+        self.update_timestamp()

--- a/src/egregora/profiles/prompts.py
+++ b/src/egregora/profiles/prompts.py
@@ -1,0 +1,118 @@
+"""Prompt templates used by the profile updater."""
+
+from __future__ import annotations
+
+UPDATE_DECISION_PROMPT = """Você é um analista de perfis de participantes em grupos.
+
+**PERFIL ATUAL de {member_id}:**
+---
+{current_profile}
+---
+
+**CONVERSA COMPLETA DE HOJE:**
+---
+{full_conversation}
+---
+
+**TAREFA**: Analise a **participação de {member_id}** na conversa acima.
+
+Considere:
+- O que {member_id} disse
+- QUANDO {member_id} interveio (início, meio, fim de discussões?)
+- Em RESPOSTA A QUÊ {member_id} participou
+- Como OUTROS reagiram ao que {member_id} disse
+- Se {member_id} iniciou, continuou ou encerrou threads
+- Qualidade e impacto das contribuições no contexto geral
+
+**Vale atualizar se:**
+✅ Demonstrou novo insight ou perspectiva não capturada no perfil
+✅ Interagiu de forma diferente do padrão usual
+✅ Revelou nova expertise ou interesse em contexto
+✅ Mudou dinâmica de discussão de forma notável
+✅ Aprofundou significativamente algo já mencionado
+
+**NÃO vale atualizar se:**
+❌ Participação consistente com perfil atual
+❌ Mensagens rotineiras ou superficiais
+❌ Apenas concordâncias/curtidas sem adicionar substância
+❌ Participação tangencial ao tema principal
+
+Retorne APENAS um JSON:
+{{
+    "should_update": true/false,
+    "reasoning": "Explicação considerando o CONTEXTO da conversa (2-3 frases)",
+    "participation_highlights": [
+        "Destaque 1 da participação em contexto",
+        "Destaque 2 da participação em contexto"
+    ],
+    "interaction_insights": [
+        "Como {member_id} interagiu com outros hoje",
+        "Padrão de participação observado"
+    ]
+}}
+"""
+
+
+PROFILE_REWRITE_PROMPT = """Você é um analista experiente de perfis intelectuais.
+
+Você vai REESCREVER COMPLETAMENTE o perfil de {member_id}.
+
+**PERFIL ANTERIOR:**
+---
+{old_profile}
+---
+
+**CONVERSAS RECENTES (últimas 5 sessões, incluindo hoje):**
+
+{recent_conversations}
+
+**PARTICIPAÇÃO DE {member_id} EM DESTAQUE:**
+{participation_highlights}
+
+**INSIGHTS DE INTERAÇÃO:**
+{interaction_insights}
+
+**CONTEXTO IMPORTANTE:**
+Você está vendo as conversas COMPLETAS, não apenas as mensagens de {member_id}.
+Isso permite analisar:
+- Como {member_id} responde a diferentes tópicos e pessoas
+- Quando e por que {member_id} escolhe participar
+- Como as contribuições de {member_id} influenciam o grupo
+- Padrões de colaboração, debate e concordância
+
+**TAREFA**:
+Reescreva o perfil COMPLETO do zero, incorporando:
+1. Tudo que ainda é válido do perfil anterior
+2. Novas informações das conversas recentes
+3. Insights sobre COMO {member_id} participa (não só O QUÊ diz)
+4. Dinâmica de interações com outros membros
+
+**IMPORTANTE:**
+- Mantenha tom respeitoso e admirativo
+- Seja específico citando CONTEXTO das participações
+- Documente evolução se houver
+- Destaque qualidade das contribuições NO CONTEXTO do grupo
+
+Retorne o JSON completo do novo perfil:
+
+{{
+    "worldview_summary": "Parágrafo incorporando como {member_id} se posiciona nas discussões do grupo...",
+    "core_interests": {{}},
+    "thinking_style": "Incluir como {member_id} desenvolve ideias em interação...",
+    "values_and_priorities": [],
+    "expertise_areas": {{}},
+    "contribution_style": "Detalhar COMO {member_id} contribui: timing, resposta a contextos, impacto...",
+    "argument_patterns": ["Incluir como argumenta EM RESPOSTA a outros"],
+    "questioning_approach": "Como e quando faz perguntas...",
+    "intellectual_influences": [],
+    "aligns_with": ["Member-XXX (em que contextos/tópicos?)"],
+    "debates_with": ["Member-XXX (sobre o quê? Como debate?)"],
+    "recent_shifts": [],
+    "growing_interests": [],
+    "interaction_patterns": {{
+        "participation_timing": "Quando tende a participar?",
+        "response_style": "Como responde a diferentes estímulos?",
+        "influence_on_group": "Que papel desempenha nas discussões?"
+    }}
+}}
+"""

--- a/src/egregora/profiles/updater.py
+++ b/src/egregora/profiles/updater.py
@@ -1,0 +1,182 @@
+"""Logic for determining when and how to update participant profiles."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from google import genai  # type: ignore
+    from google.genai import types  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - allows importing without dependency
+    genai = None  # type: ignore[assignment]
+    types = None  # type: ignore[assignment]
+
+from .profile import ParticipantProfile
+from .prompts import PROFILE_REWRITE_PROMPT, UPDATE_DECISION_PROMPT
+
+
+@dataclass(slots=True)
+class ProfileUpdater:
+    """High level orchestrator that talks to Gemini to maintain profiles."""
+
+    min_messages: int = 2
+    min_words_per_message: int = 15
+
+    async def should_update_profile(
+        self,
+        member_id: str,
+        current_profile: ParticipantProfile | None,
+        full_conversation: str,
+        gemini_client: genai.Client,
+    ) -> Tuple[bool, str, List[str], List[str]]:
+        """Decide if *member_id* warrants a profile refresh."""
+
+        if gemini_client is None:
+            raise RuntimeError(
+                "A dependência opcional 'google-genai' não está instalada ou o cliente não foi inicializado."
+            )
+
+        member_messages = self._extract_member_messages(member_id, full_conversation)
+        meaningful = [msg for msg in member_messages if self._is_meaningful(msg)]
+
+        if len(meaningful) < self.min_messages:
+            return False, "Participação mínima hoje", [], []
+
+        if not current_profile or not current_profile.worldview_summary:
+            return True, "Primeiro perfil sendo criado", [], []
+
+        profile_markdown = current_profile.to_markdown()
+        prompt = UPDATE_DECISION_PROMPT.format(
+            member_id=member_id,
+            current_profile=profile_markdown,
+            full_conversation=full_conversation,
+        )
+
+        response = await gemini_client.models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                temperature=0.3,
+                response_mime_type="application/json",
+            ),
+        )
+
+        raw_text = getattr(response, "text", "")
+        if not raw_text:
+            raise ValueError("Resposta vazia do modelo ao decidir atualização do perfil.")
+
+        try:
+            decision = json.loads(raw_text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Resposta inválida do modelo ao decidir atualização: {exc}")
+
+        return (
+            bool(decision.get("should_update", False)),
+            str(decision.get("reasoning", "")),
+            list(decision.get("participation_highlights", [])),
+            list(decision.get("interaction_insights", [])),
+        )
+
+    async def rewrite_profile(
+        self,
+        member_id: str,
+        old_profile: ParticipantProfile | None,
+        recent_conversations: Sequence[str],
+        participation_highlights: Sequence[str],
+        interaction_insights: Sequence[str],
+        gemini_client: genai.Client,
+    ) -> ParticipantProfile:
+        """Request a full profile rewrite based on recent context."""
+
+        if gemini_client is None:
+            raise RuntimeError(
+                "A dependência opcional 'google-genai' não está instalada ou o cliente não foi inicializado."
+            )
+
+        old_profile_text = (
+            old_profile.to_markdown() if old_profile else "Nenhum perfil anterior registrado."
+        )
+
+        conversations_formatted = self._format_recent_conversations(recent_conversations)
+        highlights_block = self._format_bullets(participation_highlights)
+        insights_block = self._format_bullets(interaction_insights)
+
+        prompt = PROFILE_REWRITE_PROMPT.format(
+            member_id=member_id,
+            old_profile=old_profile_text,
+            recent_conversations=conversations_formatted,
+            participation_highlights=highlights_block,
+            interaction_insights=insights_block,
+        )
+
+        response = await gemini_client.models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                temperature=0.7,
+                response_mime_type="application/json",
+            ),
+        )
+
+        raw_text = getattr(response, "text", "")
+        if not raw_text:
+            raise ValueError("Resposta vazia do modelo ao reescrever o perfil.")
+
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Resposta inválida do modelo ao reescrever o perfil: {exc}")
+
+        analysis_version = (old_profile.analysis_version if old_profile else 0) + 1
+
+        profile = ParticipantProfile(
+            member_id=member_id,
+            worldview_summary=str(payload.get("worldview_summary", "")),
+            core_interests=dict(payload.get("core_interests", {})),
+            thinking_style=str(payload.get("thinking_style", "")),
+            values_and_priorities=list(payload.get("values_and_priorities", [])),
+            expertise_areas=dict(payload.get("expertise_areas", {})),
+            contribution_style=str(payload.get("contribution_style", "")),
+            argument_patterns=list(payload.get("argument_patterns", [])),
+            questioning_approach=str(payload.get("questioning_approach", "")),
+            intellectual_influences=list(payload.get("intellectual_influences", [])),
+            aligns_with=list(payload.get("aligns_with", [])),
+            debates_with=list(payload.get("debates_with", [])),
+            recent_shifts=list(payload.get("recent_shifts", [])),
+            growing_interests=list(payload.get("growing_interests", [])),
+            interaction_patterns=dict(payload.get("interaction_patterns", {})),
+            analysis_version=analysis_version,
+        )
+        profile.update_timestamp()
+        return profile
+
+    def _extract_member_messages(self, member_id: str, conversation: str) -> List[str]:
+        pattern = re.compile(rf"\b{re.escape(member_id)}\s*:\s*(.*)")
+        messages: List[str] = []
+        for line in conversation.splitlines():
+            match = pattern.search(line)
+            if match:
+                messages.append(match.group(1).strip())
+        return messages
+
+    def _is_meaningful(self, message: str) -> bool:
+        words = [chunk for chunk in re.split(r"\s+", message.strip()) if chunk]
+        return len(words) >= self.min_words_per_message
+
+    def _format_recent_conversations(self, conversations: Sequence[str]) -> str:
+        if not conversations:
+            return "(Sem conversas recentes registradas.)"
+
+        formatted: list[str] = []
+        start_index = max(len(conversations) - 5, 0)
+        for idx, conv in enumerate(conversations[start_index:], start=1):
+            formatted.append(f"## Sessão {idx}\n{conv.strip()}\n")
+        return "\n".join(formatted)
+
+    def _format_bullets(self, items: Sequence[str]) -> str:
+        if not items:
+            return "- (Sem registros para hoje.)"
+        return "\n".join(f"- {item}" for item in items)

--- a/tests/test_profile_updater.py
+++ b/tests/test_profile_updater.py
@@ -1,0 +1,86 @@
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from egregora.profiles import ParticipantProfile, ProfileUpdater
+
+
+def test_should_update_profile_requires_meaningful_participation():
+    updater = ProfileUpdater(min_messages=2, min_words_per_message=3)
+    conversation = """
+    09:00 - Member-AAAA: Olá
+    09:05 - Member-BBBB: Vamos começar analisando os dados?
+    09:07 - Member-AAAA: Sim
+    """.strip()
+
+    should_update, reasoning, highlights, insights = asyncio.run(
+        updater.should_update_profile(
+            member_id="Member-AAAA",
+            current_profile=None,
+            full_conversation=conversation,
+            gemini_client=object(),  # not used because of early return
+        )
+    )
+
+    assert not should_update
+    assert reasoning == "Participação mínima hoje"
+    assert highlights == []
+    assert insights == []
+
+
+def test_extract_member_messages_handles_context():
+    updater = ProfileUpdater()
+    conversation = """
+    09:15 - Member-A1B2: Primeira mensagem do dia.
+    09:17 - Member-C3D4: Outra pessoa fala algo.
+    09:20 - Member-A1B2: Responde com mais contexto e detalhes relevantes.
+    """.strip()
+
+    messages = updater._extract_member_messages("Member-A1B2", conversation)
+    assert messages == [
+        "Primeira mensagem do dia.",
+        "Responde com mais contexto e detalhes relevantes.",
+    ]
+
+
+def test_participant_profile_serialization_round_trip():
+    profile = ParticipantProfile(
+        member_id="Member-ABCD",
+        worldview_summary="Analisa temas estratégicos em profundidade.",
+        core_interests={"tecnologia": ["IA", "automação"]},
+        thinking_style="Constrói sínteses a partir de tensões opostas.",
+        values_and_priorities=["equidade", "transparência"],
+        expertise_areas={"economia": "macrotendências"},
+        contribution_style="Atua como facilitador de debates complexos.",
+        argument_patterns=["Questiona premissas implícitas"],
+        questioning_approach="Faz perguntas abertas para mapear possibilidades.",
+        intellectual_influences=["Bell Hooks"],
+        aligns_with=["Member-0001"],
+        debates_with=["Member-0002"],
+        recent_shifts=["Aprofundou foco em política industrial"],
+        growing_interests=["Governança de IA"],
+        interaction_patterns={
+            "participation_timing": "Entra cedo para ancorar discussões.",
+            "response_style": "Escuta antes de sintetizar.",
+            "influence_on_group": "Orientador de rumo estratégico.",
+        },
+        analysis_version=3,
+    )
+
+    data = profile.to_dict()
+    clone = ParticipantProfile.from_dict(data)
+
+    assert clone.member_id == profile.member_id
+    assert clone.worldview_summary == profile.worldview_summary
+    assert clone.core_interests == profile.core_interests
+    assert clone.interaction_patterns == profile.interaction_patterns
+    assert clone.analysis_version == profile.analysis_version
+
+
+def test_participant_profile_markdown_contains_interaction_section():
+    profile = ParticipantProfile(member_id="Member-XYZ")
+    markdown = profile.to_markdown()
+    assert "Dinâmica de Participação" in markdown
+    assert "Timing de participação" in markdown


### PR DESCRIPTION
## Summary
- add a ParticipantProfile dataclass with serialization helpers and markdown export
- introduce prompt templates and a ProfileUpdater that evaluates full-conversation context
- cover the new utilities with unit tests exercising extraction and serialization paths

## Testing
- pytest tests/test_profile_updater.py

------
https://chatgpt.com/codex/tasks/task_e_68e0246597e08325a2a8ca895316ade8