### PR TITLE
feat: extract and link WhatsApp media attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 
 # uv build artifacts
 /dist/
+
+# Extracted WhatsApp media
+/media/

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -93,6 +93,7 @@ class PipelineConfig:
 
     zips_dir: Path
     newsletters_dir: Path
+    media_dir: Path
     group_name: str
     model: str
     timezone: tzinfo
@@ -116,12 +117,14 @@ class PipelineConfig:
         anonymization: AnonymizationConfig | None = None,
         rag: RAGConfig | None = None,
         privacy: PrivacyConfig | None = None,
+        media_dir: Path | None = None,
     ) -> "PipelineConfig":
         """Create a configuration using project defaults."""
 
         return cls(
             zips_dir=(zips_dir or Path("data/whatsapp_zips")).expanduser(),
             newsletters_dir=(newsletters_dir or Path("newsletters")).expanduser(),
+            media_dir=(media_dir or Path("media")).expanduser(),
             group_name=group_name or DEFAULT_GROUP_NAME,
             model=model or DEFAULT_MODEL,
             timezone=timezone or ZoneInfo(DEFAULT_TIMEZONE),

--- a/src/egregora/media_extractor.py
+++ b/src/egregora/media_extractor.py
@@ -1,0 +1,173 @@
+"""Utilities for extracting and referencing WhatsApp media files."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import zipfile
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Dict
+
+MEDIA_TYPE_BY_EXTENSION = {
+    # Images
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".png": "image",
+    ".gif": "image",
+    ".webp": "image",
+    # Videos
+    ".mp4": "video",
+    ".mov": "video",
+    ".3gp": "video",
+    ".avi": "video",
+    ".mkv": "video",
+    # Audio
+    ".opus": "audio",
+    ".ogg": "audio",
+    ".mp3": "audio",
+    ".m4a": "audio",
+    ".aac": "audio",
+    ".wav": "audio",
+    # Documents and others
+    ".pdf": "document",
+    ".doc": "document",
+    ".docx": "document",
+    ".ppt": "document",
+    ".pptx": "document",
+    ".xls": "document",
+    ".xlsx": "document",
+    ".csv": "document",
+    ".txt": "document",
+    ".zip": "document",
+}
+
+
+@dataclass(slots=True)
+class MediaFile:
+    """Represents a media file extracted from a WhatsApp export."""
+
+    filename: str
+    media_type: str
+    source_path: str
+    dest_path: Path
+    relative_path: str
+
+
+class MediaExtractor:
+    """Extracts WhatsApp media files and rewrites transcript references."""
+
+    _attachment_pattern = re.compile(
+        r"\u200e?([\w\-()\s]+?\.[a-z0-9]{1,6})\s*\(arquivo anexado\)",
+        re.IGNORECASE,
+    )
+
+    def __init__(self, media_base_dir: Path) -> None:
+        self.media_base_dir = media_base_dir
+        self.media_base_dir.mkdir(parents=True, exist_ok=True)
+
+    def extract_media_from_zip(
+        self,
+        zip_path: Path,
+        newsletter_date: date,
+    ) -> Dict[str, MediaFile]:
+        """Extract supported media files from *zip_path* into a dated directory."""
+
+        extracted: Dict[str, MediaFile] = {}
+        target_dir = self.media_base_dir / newsletter_date.isoformat()
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(zip_path, "r") as zipped:
+            for info in zipped.infolist():
+                if info.is_dir():
+                    continue
+
+                filename = Path(info.filename).name
+                media_type = self._detect_media_type(filename)
+                if media_type is None:
+                    continue
+
+                if filename in extracted:
+                    continue
+
+                dest_path, stored_name = self._resolve_destination(target_dir, filename)
+
+                if not dest_path.exists():
+                    with zipped.open(info, "r") as source, open(dest_path, "wb") as target:
+                        shutil.copyfileobj(source, target)
+
+                relative_path = str(Path("media") / newsletter_date.isoformat() / stored_name)
+                extracted[filename] = MediaFile(
+                    filename=stored_name,
+                    media_type=media_type,
+                    source_path=info.filename,
+                    dest_path=dest_path,
+                    relative_path=relative_path,
+                )
+
+        return extracted
+
+    def _detect_media_type(self, filename: str) -> str | None:
+        extension = Path(filename).suffix.lower()
+        return MEDIA_TYPE_BY_EXTENSION.get(extension)
+
+    @staticmethod
+    def replace_media_references(text: str, media_files: Dict[str, MediaFile]) -> str:
+        """Replace WhatsApp attachment markers with Markdown references."""
+
+        if not media_files:
+            return text
+
+        def replacement(match: re.Match[str]) -> str:
+            raw_name = match.group(1).strip()
+            media = MediaExtractor._lookup_media(raw_name, media_files)
+            if media is None:
+                return match.group(0)
+
+            markdown = MediaExtractor._format_markdown_reference(media)
+            return f"{markdown} _(arquivo anexado)_"
+
+        return MediaExtractor._attachment_pattern.sub(replacement, text)
+
+    @staticmethod
+    def _lookup_media(filename: str, media_files: Dict[str, MediaFile]) -> MediaFile | None:
+        canonical = Path(filename).name
+        if canonical in media_files:
+            return media_files[canonical]
+
+        lowercase = canonical.lower()
+        for key, media in media_files.items():
+            if Path(key).name.lower() == lowercase:
+                return media
+            if media.filename.lower() == lowercase:
+                return media
+        return None
+
+    @staticmethod
+    def _format_markdown_reference(media: MediaFile) -> str:
+        if media.media_type == "image":
+            return f"![{media.filename}]({media.relative_path})"
+        if media.media_type == "video":
+            return f"[🎥 {media.filename}]({media.relative_path})"
+        if media.media_type == "audio":
+            return f"[🔊 {media.filename}]({media.relative_path})"
+        if media.media_type == "document":
+            return f"[📄 {media.filename}]({media.relative_path})"
+        return f"[{media.filename}]({media.relative_path})"
+
+    @staticmethod
+    def _resolve_destination(directory: Path, filename: str) -> tuple[Path, str]:
+        base_path = directory / filename
+        if not base_path.exists():
+            return base_path, filename
+
+        stem = Path(filename).stem
+        suffix = Path(filename).suffix
+        counter = 2
+        while True:
+            candidate_name = f"{stem}-{counter}{suffix}"
+            candidate_path = directory / candidate_name
+            if not candidate_path.exists():
+                return candidate_path, candidate_name
+            counter += 1

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -69,6 +69,7 @@ def test_whatsapp_anonymization_comprehensive(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Test various WhatsApp message formats
@@ -106,6 +107,7 @@ def test_message_type_preservation(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     complex_conversation = TestDataGenerator.create_complex_conversation()
@@ -132,6 +134,7 @@ def test_multi_day_processing(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     multi_day_content = TestDataGenerator.create_multi_day_content()
@@ -154,6 +157,7 @@ def test_anonymization_consistency(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Multiple messages from the same author
@@ -183,6 +187,7 @@ def test_edge_cases_handling(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     edge_cases = TestDataGenerator.create_edge_cases()

--- a/tests/test_framework/conftest.py
+++ b/tests/test_framework/conftest.py
@@ -48,6 +48,7 @@ def sample_config(temp_dir: Path) -> PipelineConfig:
     return PipelineConfig.with_defaults(
         zips_dir=temp_dir / "zips",
         newsletters_dir=temp_dir / "newsletters",
+        media_dir=temp_dir / "media",
         group_name="Test Group",
     )
 

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from egregora.media_extractor import MediaExtractor, MediaFile
+
+
+def test_extract_media_from_zip_creates_files(tmp_path) -> None:
+    zip_path = Path("tests/data/Conversa do WhatsApp com Teste.zip")
+    extractor = MediaExtractor(tmp_path / "media")
+
+    media_files = extractor.extract_media_from_zip(zip_path, date(2025, 10, 3))
+
+    assert "IMG-20251002-WA0004.jpg" in media_files
+    media = media_files["IMG-20251002-WA0004.jpg"]
+    assert media.dest_path.exists()
+    assert media.relative_path == "media/2025-10-03/IMG-20251002-WA0004.jpg"
+
+
+def test_replace_media_references_converts_to_markdown() -> None:
+    media = MediaFile(
+        filename="IMG-20251002-WA0004.jpg",
+        media_type="image",
+        source_path="IMG-20251002-WA0004.jpg",
+        dest_path=Path("media/2025-10-03/IMG-20251002-WA0004.jpg"),
+        relative_path="media/2025-10-03/IMG-20251002-WA0004.jpg",
+    )
+    text = (
+        "03/10/2025 09:46 - Franklin: \u200eIMG-20251002-WA0004.jpg (arquivo anexado)"
+    )
+
+    updated = MediaExtractor.replace_media_references(
+        text,
+        {"IMG-20251002-WA0004.jpg": media},
+    )
+
+    assert "![IMG-20251002-WA0004.jpg](media/2025-10-03/IMG-20251002-WA0004.jpg)" in updated
+    assert "_(arquivo anexado)_" in updated

--- a/tests/test_newsletter_generation.py
+++ b/tests/test_newsletter_generation.py
@@ -80,6 +80,7 @@ def test_newsletter_generation_with_whatsapp_data(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=zips_dir,
         newsletters_dir=newsletters_dir,
+        media_dir=temp_dir / "media",
         group_name="Teste Group"
     )
     
@@ -109,6 +110,7 @@ def test_transcript_preparation_with_anonymization(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Test with anonymization enabled
@@ -206,6 +208,7 @@ def test_newsletter_customization_options(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
         group_name="Custom Group Name"
     )
     
@@ -231,6 +234,7 @@ def test_newsletter_error_handling(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir / "nonexistent",  # Nonexistent directory
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Test with missing zip directory

--- a/tests/test_newsletter_simple.py
+++ b/tests/test_newsletter_simple.py
@@ -25,6 +25,7 @@ def test_whatsapp_transcript_preparation(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Real WhatsApp conversation
@@ -160,6 +161,7 @@ def test_multi_day_transcript_processing(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Create multi-day transcripts
@@ -209,6 +211,7 @@ def test_whatsapp_content_with_special_characters(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # WhatsApp content with various special elements
@@ -244,6 +247,7 @@ def test_anonymization_consistency_across_days(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir,
         newsletters_dir=temp_dir,
+        media_dir=temp_dir / "media",
     )
     
     # Same person across multiple days
@@ -277,6 +281,7 @@ def test_config_validation_with_whatsapp_setup(temp_dir):
     config = PipelineConfig.with_defaults(
         zips_dir=temp_dir / "zips",
         newsletters_dir=temp_dir / "newsletters",
+        media_dir=temp_dir / "media",
         group_name="WhatsApp Test Group"
     )
     

--- a/tests/test_privacy_e2e.py
+++ b/tests/test_privacy_e2e.py
@@ -14,6 +14,7 @@ def test_prepare_transcripts_anonymizes_authors(tmp_path) -> None:
     config = PipelineConfig.with_defaults(
         zips_dir=tmp_path,
         newsletters_dir=tmp_path,
+        media_dir=tmp_path / "media",
     )
 
     transcripts = [
@@ -41,6 +42,7 @@ def test_prepare_transcripts_noop_when_disabled(tmp_path) -> None:
     config = PipelineConfig.with_defaults(
         zips_dir=tmp_path,
         newsletters_dir=tmp_path,
+        media_dir=tmp_path / "media",
     )
     config.anonymization.enabled = False
 

--- a/tests/test_rag_integration.py
+++ b/tests/test_rag_integration.py
@@ -75,6 +75,7 @@ def test_rag_config_validation(temp_dir):
         config = PipelineConfig.with_defaults(
             zips_dir=temp_dir,
             newsletters_dir=temp_dir,
+            media_dir=temp_dir / "media",
         )
         config.rag = rag_config
         

--- a/tests/test_whatsapp_integration.py
+++ b/tests/test_whatsapp_integration.py
@@ -17,13 +17,19 @@ def test_whatsapp_zip_processing(tmp_path) -> None:
     zip_path = Path("tests/data/Conversa do WhatsApp com Teste.zip")
     
     # Test zip reading
-    result = read_zip_texts(zip_path)
-    
+    media_dir = tmp_path / "media"
+    result = read_zip_texts(
+        zip_path,
+        archive_date=date(2025, 10, 3),
+        media_dir=media_dir,
+    )
+
     # Verify content is extracted correctly
     assert "Franklin: Teste de grupo" in result
     assert "Franklin: 🐱" in result
     assert "Franklin: Legal esse vídeo" in result
-    assert "IMG-20251002-WA0004.jpg (arquivo anexado)" in result
+    assert "![IMG-20251002-WA0004.jpg](media/2025-10-03/IMG-20251002-WA0004.jpg)" in result
+    assert (media_dir / "2025-10-03" / "IMG-20251002-WA0004.jpg").exists()
     assert "https://youtu.be/Nkhp-mb6FRc" in result
 
 
@@ -32,6 +38,7 @@ def test_whatsapp_format_anonymization(tmp_path) -> None:
     config = PipelineConfig.with_defaults(
         zips_dir=tmp_path,
         newsletters_dir=tmp_path,
+        media_dir=tmp_path / "media",
     )
     
     # WhatsApp format: DD/MM/YYYY HH:MM - Author: Message
@@ -66,12 +73,17 @@ def test_whatsapp_real_data_end_to_end(tmp_path) -> None:
     zip_path = Path("tests/data/Conversa do WhatsApp com Teste.zip")
     
     # Read the zip
-    content = read_zip_texts(zip_path)
+    content = read_zip_texts(
+        zip_path,
+        archive_date=date(2025, 10, 3),
+        media_dir=tmp_path / "media",
+    )
     
     # Create config
     config = PipelineConfig.with_defaults(
         zips_dir=tmp_path,
         newsletters_dir=tmp_path,
+        media_dir=tmp_path / "media",
     )
     
     # Process with anonymization


### PR DESCRIPTION
## Summary
- add a configurable media directory and extractor to pull non-text WhatsApp attachments out of zip exports
- update the newsletter pipeline to save media assets, rewrite transcript references to Markdown links, and ensure the output directory exists
- cover the new media workflow with focused unit tests and adjust existing fixtures to point at temporary media folders

## Testing
- `pytest tests/test_media_extractor.py tests/test_whatsapp_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68e02bda95248325bab5e57c91c61a4e