### PR TITLE
Configure pytest python path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 devenv = true
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]


### PR DESCRIPTION
## Summary
- configure pytest to include the src directory on the module search path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02f9202d08325afacc6f95d0b7252