### PR TITLE
Simplify privacy flow by removing double LLM review

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ Essa funcionalidade garante que as mídias compartilhadas sejam acessíveis dire
   `--disable-anonymization` apenas para depuração local.
 - **Instruções rígidas ao LLM**: o prompt enviado ao Gemini reforça que nomes
   próprios, telefones e contatos diretos não devem aparecer na newsletter.
-- **Revisão opcional**: habilite `--double-check-newsletter` para acionar uma
-  segunda chamada ao LLM, que revisa e limpa a newsletter. É possível escolher um
-  modelo dedicado com `--review-model` ou confiar na revisão humana.
+- **Revisão humana quando necessário**: para newsletters sensíveis, mantenha uma
+  leitura final manual antes do envio.
 - **Autodescoberta**: cada pessoa pode calcular o próprio identificador com
   `uv run egregora discover "<telefone ou apelido>"` ou consultar
   `docs/discover.md` para exemplos completos.

--- a/docs/Anonimizar.md
+++ b/docs/Anonimizar.md
@@ -2,13 +2,12 @@
 
 ## 📋 Visão Geral
 
-A privacidade no Egregora agora se apoia em duas camadas automáticas e uma etapa
-opcional de revisão. O objetivo é minimizar a complexidade técnica e confiar na
-robustez dos modelos modernos de linguagem para seguir instruções claras.
+A privacidade no Egregora agora se apoia em duas camadas automáticas. O objetivo
+é minimizar a complexidade técnica e confiar na robustez dos modelos modernos de
+linguagem para seguir instruções claras.
 
 1. **Anonimização determinística** (Camada 1)
 2. **Instruções explícitas ao LLM** (Camada 2)
-3. **Revisão opcional** via segunda chamada ao LLM ou validação humana
 
 ---
 
@@ -16,15 +15,13 @@ robustez dos modelos modernos de linguagem para seguir instruções claras.
 
 ```
 WhatsApp ZIP → [Anonimização de autores] → Prompt com instruções de privacidade → Newsletter
-                                                      ↘ (opcional) Revisão automática ↗
 ```
 
 - Telefones e apelidos são convertidos em pseudônimos determinísticos (`User-XXXX`)
   antes de qualquer processamento.
 - O prompt enviado ao Gemini reforça que a newsletter **não deve** expor nomes,
   telefones ou contatos diretos.
-- Quando necessário, o pipeline pode fazer uma segunda chamada ao LLM com um
-  prompt simples de revisão ou encaminhar para revisão humana.
+- Para newsletters sensíveis, mantenha uma revisão humana antes do envio.
 
 Esse arranjo cobre 80–90% das necessidades de privacidade sem depender de
 heurísticas frágeis, listas manuais de nomes ou regex complexas.
@@ -37,9 +34,7 @@ heurísticas frágeis, listas manuais de nomes ou regex complexas.
    reais.
 2. **Menos código, menos riscos**: nenhuma camada de regex ou heurística precisa
    ser mantida.
-3. **Revisão quando necessário**: se o time quiser uma verificação adicional,
-   basta ligar o modo de segunda passagem.
-4. **Transparência para quem participa**: qualquer pessoa pode descobrir o seu
+3. **Transparência para quem participa**: qualquer pessoa pode descobrir o seu
    identificador anônimo localmente.
 
 ---
@@ -58,45 +53,15 @@ heurísticas frágeis, listas manuais de nomes ou regex complexas.
 - Aplica a anonimização linha a linha usando uma regex leve apenas para detectar
   o autor do transcript.
 - O prompt principal já contém instruções rígidas de privacidade.
-- Quando `PrivacyConfig.double_check_newsletter` está habilitado, uma segunda
-  chamada ao Gemini revisa a newsletter para remover traços residuais de PII.
-
-### `src/egregora/config.py`
-
-- Define `PrivacyConfig` com dois campos:
-  - `double_check_newsletter`: ativa/desativa a segunda passagem automática.
-  - `review_model`: permite escolher um modelo diferente para a revisão
-    (por padrão reutiliza o mesmo modelo da geração).
 
 ### `src/egregora/__main__.py`
 
-- Mantém as flags de anonimização e adiciona:
-  - `--double-check-newsletter`
-  - `--review-model`
-- Removeu opções relacionadas a regex ou filtros heurísticos.
+- Mantém as flags de anonimização para depuração local.
 
 ### `docs/discover.md`
 
 - Continua ensinando como qualquer pessoa pode calcular o próprio identificador
   anônimo usando a CLI ou exemplos na documentação.
-
----
-
-## 🔁 Fluxo de Revisão Opcional
-
-Quando a flag `--double-check-newsletter` está ativa, o pipeline executa:
-
-```python
-revised = _run_privacy_review(
-    client,
-    model=config.privacy.review_model or config.model,
-    newsletter_text=newsletter_text,
-)
-```
-
-O prompt de revisão solicita explicitamente que o modelo remova nomes próprios,
-telefones, e-mails e endereços. Caso nada precise ser alterado, o modelo deve
-retornar o texto original, mantendo o processo determinístico.
 
 ---
 
@@ -114,8 +79,8 @@ retornar o texto original, mantendo o processo determinístico.
   telefones, nomes ou frases específicas.
 - **Mais confiança**: o comportamento depende de instruções claras ao LLM,
   alinhado com as capacidades atuais de modelos como o Gemini 2.0.
-- **Flexibilidade**: equipes que precisam de uma camada extra podem habilitar a
-  revisão automática ou recorrer a revisão humana.
+- **Flexibilidade**: equipes que precisam de uma camada extra podem manter uma
+  revisão humana antes da publicação.
 - **Clareza para usuários**: a documentação reflete exatamente o que o sistema
   faz — nada oculto, nada mágico.
 
@@ -124,8 +89,8 @@ retornar o texto original, mantendo o processo determinístico.
 ## 🚀 Próximos Passos
 
 1. Monitorar execuções reais para validar a taxa de falso-positivo/negativo da
-   revisão automática.
-2. Ajustar a instrução de revisão conforme feedback.
+   etapa automatizada.
+2. Ajustar as instruções do prompt conforme feedback.
 3. Documentar recomendações de revisão humana (checklist simples) para casos em
    que a newsletter trate de temas muito sensíveis.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,8 +1,8 @@
 # 🛡️ Sistema de Privacidade
 
 O Egregora segue uma abordagem enxuta para proteger informações pessoais. O
-processo prioriza anonimização determinística e instruções claras ao modelo de
-linguagem, recorrendo a uma segunda revisão apenas quando necessário.
+processo combina anonimização determinística com instruções claras ao modelo de
+linguagem, reduzindo a chance de informações sensíveis aparecerem no resultado.
 
 ## 1. Anonimização determinística
 
@@ -22,15 +22,10 @@ linguagem, recorrendo a uma segunda revisão apenas quando necessário.
 - A efetividade típica observada com modelos modernos (como Gemini 2.0) fica na
   casa de 80–90% sem nenhuma filtragem adicional.
 
-## Revisão opcional
+## Revisão recomendada
 
-- Quando necessário, habilite `--double-check-newsletter` para executar uma
-  segunda chamada ao LLM revisando a newsletter gerada.
-- O prompt de revisão pede para remover números de telefone, e-mails, nomes
-  próprios e endereços físicos, devolvendo exatamente o mesmo texto quando nada
-  precisa ser alterado.
-- Também é possível manter uma revisão humana como etapa final para newsletters
-  extremamente sensíveis.
+- Para newsletters sensíveis, mantenha uma leitura humana antes do envio.
+- Ajuste o prompt principal conforme necessário para reforçar políticas internas.
 
 ## Autodescoberta segura
 
@@ -50,8 +45,6 @@ from egregora.config import PipelineConfig
 
 config = PipelineConfig.with_defaults()
 config.anonymization.output_format = "short"
-config.privacy.double_check_newsletter = True
-config.privacy.review_model = "gemini-1.5-flash"
 ```
 
 Essas opções afetam tanto a execução via CLI quanto o uso como biblioteca.

--- a/src/egregora/__main__.py
+++ b/src/egregora/__main__.py
@@ -128,18 +128,6 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Formato dos identificadores anônimos (padrão: human).",
     )
-    parser.add_argument(
-        "--double-check-newsletter",
-        action="store_true",
-        help="Executa uma segunda chamada ao LLM para revisar a newsletter em busca de PII.",
-    )
-    parser.add_argument(
-        "--review-model",
-        type=str,
-        default=None,
-        help="Modelo opcional utilizado na revisão de privacidade (padrão: mesmo da geração).",
-    )
-
     subparsers = parser.add_subparsers(dest="command")
     discover_parser = subparsers.add_parser(
         "discover",
@@ -198,11 +186,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         config.anonymization.enabled = False
     if args.anonymization_format:
         config.anonymization.output_format = args.anonymization_format
-    if args.double_check_newsletter:
-        config.privacy.double_check_newsletter = True
-    if args.review_model:
-        config.privacy.review_model = args.review_model
-
     enrichment = config.enrichment
     if args.enable_enrichment:
         enrichment.enabled = True

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -59,14 +59,6 @@ class AnonymizationConfig:
 
 
 @dataclass(slots=True)
-class PrivacyConfig:
-    """Configuration for optional newsletter privacy reviews."""
-
-    double_check_newsletter: bool = False
-    review_model: str | None = None
-
-
-@dataclass(slots=True)
 class PipelineConfig:
     """Runtime configuration for the newsletter pipeline."""
 
@@ -80,7 +72,6 @@ class PipelineConfig:
     cache: CacheConfig
     anonymization: AnonymizationConfig
     rag: RAGConfig
-    privacy: PrivacyConfig
 
     @classmethod
     def with_defaults(
@@ -95,7 +86,6 @@ class PipelineConfig:
         cache: CacheConfig | None = None,
         anonymization: AnonymizationConfig | None = None,
         rag: RAGConfig | None = None,
-        privacy: PrivacyConfig | None = None,
         media_dir: Path | None = None,
     ) -> "PipelineConfig":
         """Create a configuration using project defaults."""
@@ -113,7 +103,6 @@ class PipelineConfig:
                 copy.deepcopy(anonymization) if anonymization else AnonymizationConfig()
             ),
             rag=(copy.deepcopy(rag) if rag else RAGConfig()),
-            privacy=(copy.deepcopy(privacy) if privacy else PrivacyConfig()),
         )
 
 
@@ -248,7 +237,6 @@ __all__ = [
     "CacheConfig",
     "EnrichmentConfig",
     "PipelineConfig",
-    "PrivacyConfig",
     "RAGConfig",
     "load_backlog_config",
 ]

--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -74,18 +74,6 @@ TRANSCRIPT_PATTERNS = [
     ),
 ]
 
-REVIEW_SYSTEM_PROMPT = r"""
-Você é um revisor de privacidade. Seu papel é garantir que nenhuma informação
-pessoal direta permaneça na newsletter. Remova ou generalize:
-- Nomes próprios de pessoas físicas.
-- Números de telefone ou outros identificadores de contato.
-- E-mails ou endereços.
-
-Não invente fatos novos e preserve o sentido do texto. Se o conteúdo já estiver
-adequado, devolva exatamente o mesmo texto.
-"""
-
-
 def _anonymize_transcript_line(
     line: str, *, anonymize: bool, output_format: FormatType
 ) -> str:
@@ -321,48 +309,6 @@ def _collect_rag_context(config: PipelineConfig, transcripts_sample: str) -> str
             )
 
     return _collect_rag_context_local(config, transcripts_sample)
-
-
-def _run_privacy_review(
-    client: genai.Client,
-    *,
-    model: str,
-    newsletter_text: str,
-) -> str:
-    """Request a second-pass privacy review from the configured LLM."""
-
-    review_prompt = (
-        "Revise a newsletter e remova nomes próprios, números de telefone, "
-        "endereços de e-mail ou outras referências diretas a contato. "
-        "Generalize informações sensíveis quando necessário. Se nada "
-        "precisar ser alterado, devolva o texto exatamente como recebido.\n\n"
-        "<<<NEWSLETTER_ORIGINAL>>>\n"
-        f"{newsletter_text}\n"
-        "<<<FIM>>>"
-    )
-
-    contents = [
-        types.Content(
-            role="user",
-            parts=[types.Part.from_text(text=review_prompt)],
-        )
-    ]
-
-    review_config = types.GenerateContentConfig(
-        system_instruction=[types.Part.from_text(text=REVIEW_SYSTEM_PROMPT.strip())]
-    )
-
-    output_lines: list[str] = []
-    for chunk in client.models.generate_content_stream(
-        model=model,
-        contents=contents,
-        config=review_config,
-    ):
-        if chunk.text:
-            output_lines.append(chunk.text)
-
-    reviewed = "".join(output_lines).strip()
-    return reviewed or newsletter_text
 
 
 def _require_google_dependency() -> None:
@@ -847,27 +793,6 @@ def _generate_newsletter_from_archives(
 
     newsletter_text = "".join(output_lines).strip()
     output_path = config.newsletters_dir / f"{today.isoformat()}.md"
-
-    if config.privacy.double_check_newsletter:
-        review_model = config.privacy.review_model or config.model
-        revised = _run_privacy_review(
-            llm_client,
-            model=review_model,
-            newsletter_text=newsletter_text,
-        )
-        if revised != newsletter_text:
-            _emit(
-                "[Privacidade] Revisão adicional removeu dados sensíveis.",
-                logger=logger,
-                batch_mode=batch_mode,
-            )
-            newsletter_text = revised
-        else:
-            _emit(
-                "[Privacidade] Revisão adicional não encontrou ajustes.",
-                logger=logger,
-                batch_mode=batch_mode,
-            )
 
     output_path.write_text(newsletter_text, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- remove the optional privacy double-check flow from the pipeline and configuration
- streamline the CLI and documentation to reflect the simpler two-layer privacy model

## Testing
- pytest *(fails: missing optional llama_index dependency and legacy helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68e07c42baf883258af35a08dbae3943