### PR TITLE
Standardize anonymized identifier prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Essa funcionalidade garante que as mídias compartilhadas sejam acessíveis dire
 ## 🔐 Privacidade por padrão
 
 - **Anonimização determinística**: telefones e apelidos são convertidos em
-  identificadores como `User-ABCD` antes de qualquer processamento. Use
+  identificadores como `Member-ABCD` antes de qualquer processamento. Use
   `--disable-anonymization` apenas para depuração local.
 - **Instruções rígidas ao LLM**: o prompt enviado ao Gemini reforça que nomes
   próprios, telefones e contatos diretos não devem aparecer na newsletter.

--- a/docs/Anonimizar.md
+++ b/docs/Anonimizar.md
@@ -17,7 +17,7 @@ linguagem para seguir instruções claras.
 WhatsApp ZIP → [Anonimização de autores] → Prompt com instruções de privacidade → Newsletter
 ```
 
-- Telefones e apelidos são convertidos em pseudônimos determinísticos (`User-XXXX`)
+- Telefones e apelidos são convertidos em pseudônimos determinísticos (`Member-XXXX`)
   antes de qualquer processamento.
 - O prompt enviado ao Gemini reforça que a newsletter **não deve** expor nomes,
   telefones ou contatos diretos.

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -18,10 +18,10 @@ Saída típica:
 • Tipo detectado: phone
 • Forma normalizada: +5511912345678
 • Identificadores disponíveis:
-  → human: User-1A2B
+  → human: Member-1A2B
   · short: 1a2b3c4d
   · full: 1a2b3c4d-e5f6-7890-ab12-cdef34567890
-• Formato preferido (human): User-1A2B
+• Formato preferido (human): Member-1A2B
 ```
 
 ### Somente o identificador

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -6,8 +6,8 @@ linguagem, reduzindo a chance de informações sensíveis aparecerem no resultad
 
 ## 1. Anonimização determinística
 
-- Telefones e apelidos são convertidos em identificadores como `User-ABCD` ou
-  `Member-EFGH` usando UUIDv5.
+- Telefones e apelidos são convertidos em identificadores como `Member-ABCD`
+  usando UUIDv5.
 - Nenhum mapeamento é persistido; o algoritmo é puro e repetível.
 - O formato padrão (`human`) é amigável para leitura, mas também é possível
   obter as variantes `short` e `full`.

--- a/src/egregora/anonymizer.py
+++ b/src/egregora/anonymizer.py
@@ -64,20 +64,32 @@ class Anonymizer:
         return uuid_str
 
     @staticmethod
-    def anonymize_phone(phone: str, format: FormatType = "human") -> str:
-        """Return a deterministic pseudonym for ``phone``."""
+    def anonymize_phone(
+        phone: str,
+        format: FormatType = "human",
+        prefix: str = "Member",
+    ) -> str:
+        """Return a deterministic pseudonym for ``phone``.
+
+        ``prefix`` allows configuring the human-friendly prefix to keep the
+        anonymized format aligned with nickname anonymization.
+        """
 
         normalized = Anonymizer.normalize_phone(phone)
         uuid_full = str(uuid.uuid5(Anonymizer.NAMESPACE_PHONE, normalized))
-        return Anonymizer._format_uuid(uuid_full, "User", format)
+        return Anonymizer._format_uuid(uuid_full, prefix, format)
 
     @staticmethod
-    def anonymize_nickname(nickname: str, format: FormatType = "human") -> str:
+    def anonymize_nickname(
+        nickname: str,
+        format: FormatType = "human",
+        prefix: str = "Member",
+    ) -> str:
         """Return a deterministic pseudonym for ``nickname``."""
 
         normalized = Anonymizer.normalize_nickname(nickname)
         uuid_full = str(uuid.uuid5(Anonymizer.NAMESPACE_NICKNAME, normalized))
-        return Anonymizer._format_uuid(uuid_full, "Member", format)
+        return Anonymizer._format_uuid(uuid_full, prefix, format)
 
     @staticmethod
     def anonymize_author(author: str, format: FormatType = "human") -> str:

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -49,7 +49,7 @@ class AnonymizationConfig:
     Attributes:
         enabled: Controls whether author names are converted before prompting.
         output_format: Style of the anonymized identifiers:
-            - ``"human"`` → formato legível (ex.: ``User-A1B2``).
+            - ``"human"`` → formato legível (ex.: ``Member-A1B2``).
             - ``"short"`` → 8 caracteres hexadecimais (ex.: ``a1b2c3d4``).
             - ``"full"`` → UUID completo.
     """

--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -517,7 +517,7 @@ Objetivo:
 - Não inventar nicks. Não resumir links. Não ocultar mensagens relevantes.
 
 🔒 PRIVACIDADE — INSTRUÇÕES CRÍTICAS:
-- Utilize APENAS os identificadores anônimos fornecidos (User-XXXX, Member-XXXX, etc.).
+- Utilize APENAS os identificadores anônimos fornecidos (Member-XXXX, etc.).
 - Nunca repita nomes próprios, telefones completos ou e-mails mencionados NO CONTEÚDO das mensagens.
 - Ao referenciar alguém citado no conteúdo mas sem identificador anônimo, generalize ("um membro", "uma pessoa do grupo").
 - Preserve o sentido original enquanto remove detalhes de contato ou identificação direta.

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -17,9 +17,10 @@ def test_anonymize_phone_is_deterministic() -> None:
     token_b = Anonymizer.anonymize_phone("5511987654321")
 
     assert token_a == token_b
-    assert token_a.startswith("User-")
-    assert len(token_a) == 9
-    assert token_a[5:].isupper()
+    assert token_a.startswith("Member-")
+    suffix = token_a.split("-")[1]
+    assert len(suffix) == 4
+    assert suffix.isupper()
 
 
 def test_anonymize_nickname_uses_member_prefix() -> None:

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -89,7 +89,7 @@ def test_whatsapp_anonymization_comprehensive(temp_dir, whatsapp_real_content):
 
         # Check anonymization worked for user messages
         if any(name in conversation for name in ("Franklin:", "Maria:", "José:", "Ana:")):
-            assert "Member-" in processed or "User-" in processed
+            assert "Member-" in processed
             assert "Franklin" not in processed
             assert "Maria" not in processed
             assert "José" not in processed

--- a/tests/test_privacy_e2e.py
+++ b/tests/test_privacy_e2e.py
@@ -33,8 +33,7 @@ def test_prepare_transcripts_anonymizes_authors(tmp_path) -> None:
     sanitized_text = sanitized[0][1]
 
     assert "João Silva" not in sanitized_text
-    assert "Member-" in sanitized_text
-    assert "User-" in sanitized_text
+    assert sanitized_text.count("Member-") >= 1
     assert "Maria" in sanitized_text  # conteúdo das mensagens permanece intacto
 
 

--- a/tests/test_privacy_prompt.py
+++ b/tests/test_privacy_prompt.py
@@ -73,12 +73,12 @@ def test_system_instruction_includes_privacy_rules(monkeypatch):
 def test_privacy_review_removes_names(monkeypatch):
     _install_pipeline_stubs(monkeypatch)
 
-    client = DummyClient(["User-A1B2 sugeriu algo importante."])
+    client = DummyClient(["Member-A1B2 sugeriu algo importante."])
     reviewed = pipeline._run_privacy_review(
         client,
         model="fake-model",
-        newsletter_text="João (User-A1B2) sugeriu algo.",
+        newsletter_text="João (Member-A1B2) sugeriu algo.",
     )
 
     assert "João" not in reviewed
-    assert "User-A1B2" in reviewed
+    assert "Member-A1B2" in reviewed


### PR DESCRIPTION
## Summary
- use the Member prefix for all anonymized identifiers produced by the anonymizer
- refresh documentation, prompts, and configs to mention the Member prefix consistently
- update the privacy-related tests to expect the unified prefix format

## Testing
- pytest *(fails: missing optional llama_index dependency and helper functions)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c79861cc83258b588e7b2b90236b