### PR TITLE
Harden configuration loading and ZIP discovery guards

### DIFF
--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -211,12 +211,6 @@ def _load_toml_data(toml_path: Path) -> dict[str, Any]:
     if not toml_path.is_file():
         raise ValueError(f"Configuration path '{toml_path}' must be a file")
 
-    size = toml_path.stat().st_size
-    if size > _MAX_TOML_BYTES:
-        raise ValueError(
-            f"Configuration file '{toml_path}' exceeds maximum size of {_MAX_TOML_BYTES} bytes"
-        )
-
     with toml_path.open('rb') as fh:
         content = fh.read(_MAX_TOML_BYTES + 1)
 

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -120,19 +120,25 @@ class PipelineConfig:
     @classmethod
     def from_toml(cls, toml_path: Path) -> "PipelineConfig":
         """Load configuration from TOML file."""
-        import tomllib
-        
-        with open(toml_path, 'rb') as f:
-            data = tomllib.load(f)
+
+        data = _load_toml_data(toml_path)
 
         # Parse merges
-        merges = {}
-        for slug, merge_data in data.get('merges', {}).items():
+        merges_raw = data.get('merges', {})
+        if not isinstance(merges_raw, dict):
+            raise ValueError("'merges' section must be a table")
+
+        merges: dict[str, MergeConfig] = {}
+        for slug, merge_data in merges_raw.items():
+            if not isinstance(merge_data, dict):
+                raise ValueError(f"Merge '{slug}' must be a table")
             tag_style = merge_data.get('tag_style', 'emoji')
             if tag_style not in _VALID_TAG_STYLES:
                 raise ValueError(f"Invalid tag_style '{tag_style}' for merge '{slug}'")
 
             groups = merge_data.get('groups', [])
+            if not isinstance(groups, list) or not all(isinstance(g, str) for g in groups):
+                raise ValueError(f"Merge '{slug}' groups must be a list of strings")
             if not groups:
                 raise ValueError(f"Merge '{slug}' must include at least one source group")
 
@@ -147,6 +153,10 @@ class PipelineConfig:
         # Parse directories
         dirs = data.get('directories', {})
         pipeline = data.get('pipeline', {})
+        if not isinstance(dirs, dict):
+            raise ValueError("'directories' section must be a table")
+        if not isinstance(pipeline, dict):
+            raise ValueError("'pipeline' section must be a table")
 
         return cls(
             zips_dir=_ensure_safe_directory(dirs.get('zips_dir', 'data/whatsapp_zips')),
@@ -175,13 +185,57 @@ def _ensure_safe_directory(path_value: Any) -> Path:
     if any(part == ".." for part in candidate.parts):
         raise ValueError(f"Directory path '{candidate}' must not contain '..'")
 
-    base_dir = Path.cwd()
-    resolved = (base_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    base_dir = Path.cwd().resolve()
+    resolved = (
+        (base_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    )
 
-    if not resolved.is_relative_to(base_dir):
+    try:
+        resolved.relative_to(base_dir)
+    except ValueError:  # pragma: no cover - defensive on Path API differences
         raise ValueError(f"Directory path '{candidate}' must reside within the project directory")
 
     return resolved
+
+
+_MAX_TOML_BYTES = 512 * 1024  # 512KB should be plenty for configuration files
+
+
+def _load_toml_data(toml_path: Path) -> dict[str, Any]:
+    """Load TOML data from ``toml_path`` with strict validation."""
+
+    import tomllib
+
+    if not toml_path.exists():
+        raise FileNotFoundError(toml_path)
+    if not toml_path.is_file():
+        raise ValueError(f"Configuration path '{toml_path}' must be a file")
+
+    size = toml_path.stat().st_size
+    if size > _MAX_TOML_BYTES:
+        raise ValueError(
+            f"Configuration file '{toml_path}' exceeds maximum size of {_MAX_TOML_BYTES} bytes"
+        )
+
+    with toml_path.open('rb') as fh:
+        content = fh.read(_MAX_TOML_BYTES + 1)
+
+    if len(content) > _MAX_TOML_BYTES:
+        raise ValueError(
+            f"Configuration file '{toml_path}' exceeds maximum size of {_MAX_TOML_BYTES} bytes"
+        )
+
+    try:
+        decoded = content.decode('utf-8')
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"Configuration file '{toml_path}' must be UTF-8 encoded") from exc
+
+    data = tomllib.loads(decoded)
+
+    if not isinstance(data, dict):
+        raise ValueError("Top-level TOML structure must be a table")
+
+    return data
 
 
 __all__ = [

--- a/src/egregora/group_discovery.py
+++ b/src/egregora/group_discovery.py
@@ -29,6 +29,12 @@ def discover_groups(zips_dir: Path) -> dict[str, list[WhatsAppExport]]:
     groups = defaultdict(list)
     
     for zip_path in sorted(zips_dir.glob("*.zip")):
+        if zip_path.is_symlink():
+            logger.warning("Skipping %s: refusing to follow symlink", zip_path.name)
+            continue
+        if not zip_path.is_file():
+            logger.debug("Skipping %s: not a regular file", zip_path)
+            continue
         try:
             export = _extract_metadata(zip_path)
         except (ValueError, ZipValidationError) as exc:

--- a/tests/test_security_guards.py
+++ b/tests/test_security_guards.py
@@ -1,0 +1,101 @@
+import io
+import zipfile
+from datetime import date
+
+import pytest
+
+from egregora.config import PipelineConfig, _ensure_safe_directory, _load_toml_data
+from egregora.group_discovery import _iter_preview_lines
+from egregora.models import WhatsAppExport
+from egregora.zip_utils import ZipValidationError, validate_zip_contents
+
+try:  # pragma: no cover - defensive import for optional dependency
+    from egregora.parser import parse_export
+except ModuleNotFoundError as exc:  # pragma: no cover - executed only when polars missing
+    PARSER_IMPORT_ERROR = exc
+    parse_export = None  # type: ignore[assignment]
+else:
+    PARSER_IMPORT_ERROR = None
+
+
+def make_export(zip_path, chat_file: str) -> WhatsAppExport:
+    return WhatsAppExport(
+        zip_path=zip_path,
+        group_name="Test Group",
+        group_slug="test-group",
+        export_date=date(2024, 1, 1),
+        chat_file=chat_file,
+        media_files=[],
+    )
+
+
+def test_validate_zip_contents_rejects_path_traversal(tmp_path):
+    zip_path = tmp_path / "bad.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("../evil.txt", "data")
+
+    with zipfile.ZipFile(zip_path) as zf:
+        with pytest.raises(ZipValidationError):
+            validate_zip_contents(zf)
+
+
+def test_iter_preview_lines_rejects_long_lines():
+    long_line = b"x" * 16_385 + b"\n"
+
+    with pytest.raises(ZipValidationError):
+        list(_iter_preview_lines(io.BytesIO(long_line), limit=1))
+
+
+def test_parse_export_rejects_invalid_utf8(tmp_path):
+    if parse_export is None:  # pragma: no cover - depends on optional dependency
+        pytest.skip(f"parser import failed: {PARSER_IMPORT_ERROR}")
+
+    chat_file = "WhatsApp Chat with Test.txt"
+    zip_path = tmp_path / "invalid.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(chat_file, b"\xff\xfe\x00bad")
+
+    export = make_export(zip_path, chat_file)
+
+    with pytest.raises(ZipValidationError):
+        parse_export(export)
+
+
+def test_load_toml_data_rejects_large_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('value = "123456"\n', encoding="utf-8")
+
+    from egregora import config as config_module
+
+    monkeypatch.setattr(config_module, "_MAX_TOML_BYTES", 4)
+
+    with pytest.raises(ValueError):
+        _load_toml_data(config_path)
+
+
+def test_load_toml_data_requires_top_level_table(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("42\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        _load_toml_data(config_path)
+
+
+def test_pipeline_config_from_toml_validates_merges(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [merges.bad]
+        name = "Bad"
+        groups = "not-a-list"
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        PipelineConfig.from_toml(config_path)
+
+
+def test_ensure_safe_directory_rejects_parent_escape():
+    with pytest.raises(ValueError):
+        _ensure_safe_directory("../outside")


### PR DESCRIPTION
## Summary
- validate pipeline configuration files by enforcing size limits, UTF-8 encoding, and table-based structure before constructing merges
- ensure directory settings remain inside the project tree and reject malformed merge definitions loaded from TOML
- refuse symlinked ZIP archives during group discovery and add regression tests covering the new guards

## Testing
- pytest tests/test_security_guards.py

------
https://chatgpt.com/codex/tasks/task_e_68e105969ecc8325a908a17ad529193d