### PR TITLE
fix(prompt): #47 explicitly instruct LLM to preserve URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ cache/
 data/
 egregora.toml
 *.zip:Zone.Identifier
+
+# Test output
+tests/temp_output/

--- a/src/egregora/prompts/system_instruction_base.md
+++ b/src/egregora/prompts/system_instruction_base.md
@@ -48,6 +48,7 @@ Regras de formatação do relatório:
 
 4) Tratamento de links:
    - Sempre inserir o link COMPLETO no ponto exato da narrativa em que ele foi mencionado originalmente.
+   - NUNCA remova URLs. Links são importantes para o contexto.
    - Não encurtar, não mover para rodapé, não omitir.
    - Pode haver uma frase curta de contexto sobre o link SE o contexto não for óbvio.
 

--- a/tests/test_url_preservation.py
+++ b/tests/test_url_preservation.py
@@ -1,0 +1,64 @@
+from datetime import date
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from egregora.config import PipelineConfig
+from egregora.processor import UnifiedProcessor
+
+
+@pytest.fixture
+def config_with_url(tmp_path: Path) -> PipelineConfig:
+    """Config with a dummy zip file containing a URL."""
+    # Create directories inside the project directory to avoid ValueError
+    zips_dir = Path("tests/temp_output/zips")
+    zips_dir.mkdir(parents=True, exist_ok=True)
+    newsletters_dir = Path("tests/temp_output/newsletters")
+    newsletters_dir.mkdir(parents=True, exist_ok=True)
+    media_dir = Path("tests/temp_output/media")
+    media_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create a dummy zip file with a URL
+    zip_path = zips_dir / "Conversa do WhatsApp com Teste.zip"
+    chat_txt_path = tmp_path / "_chat.txt"
+    with open(chat_txt_path, "w") as f:
+        f.write("03/10/2025 09:46 - Franklin: Check this: https://example.com\n")
+
+    with zipfile.ZipFile(zip_path, 'w') as zf:
+        zf.write(chat_txt_path, arcname='_chat.txt')
+
+    return PipelineConfig.with_defaults(
+        zips_dir=zips_dir,
+        newsletters_dir=newsletters_dir,
+        media_dir=media_dir,
+        model="gemini/gemini-1.5-flash-latest",
+    )
+
+
+def test_urls_preserved_in_newsletter(config_with_url: PipelineConfig, monkeypatch):
+    """Verify URLs from WhatsApp are present in the final newsletter."""
+
+    class MockLLMClient:
+        def __init__(self):
+            self.models = self
+        def generate_content_stream(self, model, contents, config):
+            transcript = contents[0].parts[0].text
+            class MockStream:
+                def __init__(self, text):
+                    self.text = text
+                def __iter__(self):
+                    yield self
+            return MockStream(f"Newsletter.\n{transcript}")
+
+    def mock_create_client():
+        return MockLLMClient()
+
+    monkeypatch.setattr("egregora.pipeline.create_client", mock_create_client)
+
+    processor = UnifiedProcessor(config_with_url)
+    results = processor.process_all(days=1)
+
+    newsletter_path = results["_chat"][0]
+    newsletter_text = newsletter_path.read_text()
+    assert "https://example.com" in newsletter_text


### PR DESCRIPTION
This PR fixes a bug where the UnifiedProcessor was not preserving URLs in the generated newsletters. The fix is to explicitly instruct the LLM in the system prompt to never remove URLs.
