### PR TITLE
feat: make media links portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Além do enriquecimento de links, o Egregora agora extrai automaticamente mídia
 2.  **Substituição**: Marcadores como `IMG-20251003-WA0001.jpg (arquivo anexado)` são substituídos por links Markdown para a mídia extraída (ex: `![IMG-20251003-WA0001.jpg](media/2025-10-03/IMG-20251003-WA0001.jpg)`).
 3.  **Preservação**: O nome do arquivo original é mantido para fácil referência.
 
+> Dica: ao publicar via MkDocs, habilite o plugin `tools.mkdocs_media_plugin` (já configurado em `mkdocs.yml`) e defina `media_url_prefix = "/media"` no TOML para que os links apontem para o diretório público.
+
 Essa funcionalidade garante que as mídias compartilhadas sejam acessíveis diretamente na newsletter gerada, enriquecendo ainda mais o contexto.
 
 ## 🔐 Privacidade por padrão

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,9 @@ markdown_extensions:
       permalink: true
 
 docs_dir: docs
+
+plugins:
+  - search
+  - tools.mkdocs_media_plugin:
+      source_dir: media
+      target_dir: media

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -100,6 +100,7 @@ class PipelineConfig(BaseSettings):
         default_factory=lambda: _ensure_safe_directory("data/daily")
     )
     media_dir: Path = Field(default_factory=lambda: _ensure_safe_directory("media"))
+    media_url_prefix: str | None = None
     model: str = DEFAULT_MODEL
     timezone: ZoneInfo = Field(default_factory=lambda: ZoneInfo(DEFAULT_TIMEZONE))
     llm: LLMConfig = Field(default_factory=LLMConfig)
@@ -217,6 +218,7 @@ class PipelineConfig(BaseSettings):
         zips_dir: Path | None = None,
         newsletters_dir: Path | None = None,
         media_dir: Path | None = None,
+        media_url_prefix: str | None = None,
         model: str | None = None,
         timezone: tzinfo | None = None,
         llm: LLMConfig | dict[str, Any] | None = None,
@@ -237,6 +239,8 @@ class PipelineConfig(BaseSettings):
             payload["media_dir"] = media_dir
         if model is not None:
             payload["model"] = model
+        if media_url_prefix is not None:
+            payload["media_url_prefix"] = media_url_prefix
         if timezone is not None:
             payload["timezone"] = timezone
         if llm is not None:
@@ -271,7 +275,7 @@ class PipelineConfig(BaseSettings):
 
         pipeline = data.get("pipeline", {})
         if isinstance(pipeline, dict):
-            for key in ("model", "skip_real_if_in_virtual"):
+            for key in ("model", "skip_real_if_in_virtual", "media_url_prefix"):
                 value = pipeline.get(key)
                 if value is not None:
                     payload[key] = value

--- a/src/egregora/media_extractor.py
+++ b/src/egregora/media_extractor.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import zipfile
 from dataclasses import dataclass
 from datetime import date
-from pathlib import Path
-from typing import Dict
+from pathlib import Path, PurePosixPath
+from typing import Dict, Iterable
 
 MEDIA_TYPE_BY_EXTENSION = {
     # Images
@@ -62,17 +63,25 @@ class MediaExtractor:
         r"\u200e?([\w\-()\s]+?\.[a-z0-9]{1,6})\s*\(arquivo anexado\)",
         re.IGNORECASE,
     )
+    _directional_marks = re.compile(r"[\u200e\u200f\u202a-\u202e]")
 
     def __init__(self, media_base_dir: Path) -> None:
         self.media_base_dir = media_base_dir
         self.media_base_dir.mkdir(parents=True, exist_ok=True)
 
-    def extract_media_from_zip(
+    def extract_specific_media_from_zip(
         self,
         zip_path: Path,
         newsletter_date: date,
+        filenames: Iterable[str],
     ) -> Dict[str, MediaFile]:
-        """Extract supported media files from *zip_path* into a dated directory."""
+        """Extract only ``filenames`` from *zip_path* into ``newsletter_date`` directory."""
+
+        cleaned_targets = {
+            self._clean_attachment_name(name): name for name in filenames if name
+        }
+        if not cleaned_targets:
+            return {}
 
         extracted: Dict[str, MediaFile] = {}
         target_dir = self.media_base_dir / newsletter_date.isoformat()
@@ -83,22 +92,28 @@ class MediaExtractor:
                 if info.is_dir():
                     continue
 
-                filename = Path(info.filename).name
-                media_type = self._detect_media_type(filename)
+                original_name = Path(info.filename).name
+                cleaned_name = self._clean_attachment_name(original_name)
+                if cleaned_name not in cleaned_targets:
+                    continue
+
+                media_type = self._detect_media_type(cleaned_name)
                 if media_type is None:
                     continue
 
-                if filename in extracted:
+                if cleaned_name in extracted:
                     continue
 
-                dest_path, stored_name = self._resolve_destination(target_dir, filename)
+                dest_path, stored_name = self._resolve_destination(
+                    target_dir, cleaned_name
+                )
 
                 if not dest_path.exists():
                     with zipped.open(info, "r") as source, open(dest_path, "wb") as target:
                         shutil.copyfileobj(source, target)
 
                 relative_path = str(Path("media") / newsletter_date.isoformat() / stored_name)
-                extracted[filename] = MediaFile(
+                extracted[cleaned_name] = MediaFile(
                     filename=stored_name,
                     media_type=media_type,
                     source_path=info.filename,
@@ -108,12 +123,40 @@ class MediaExtractor:
 
         return extracted
 
+    def extract_media_from_zip(
+        self,
+        zip_path: Path,
+        newsletter_date: date,
+    ) -> Dict[str, MediaFile]:
+        """Extract all recognised media files from *zip_path*."""
+
+        with zipfile.ZipFile(zip_path, "r") as zipped:
+            filenames = [
+                Path(info.filename).name
+                for info in zipped.infolist()
+                if not info.is_dir()
+                and self._detect_media_type(
+                    self._clean_attachment_name(Path(info.filename).name)
+                )
+            ]
+
+        return self.extract_specific_media_from_zip(
+            zip_path,
+            newsletter_date,
+            filenames,
+        )
+
     def _detect_media_type(self, filename: str) -> str | None:
         extension = Path(filename).suffix.lower()
         return MEDIA_TYPE_BY_EXTENSION.get(extension)
 
     @staticmethod
-    def replace_media_references(text: str, media_files: Dict[str, MediaFile]) -> str:
+    def replace_media_references(
+        text: str,
+        media_files: Dict[str, MediaFile],
+        *,
+        public_paths: Dict[str, str] | None = None,
+    ) -> str:
         """Replace WhatsApp attachment markers with Markdown references."""
 
         if not media_files:
@@ -125,36 +168,134 @@ class MediaExtractor:
             if media is None:
                 return match.group(0)
 
-            markdown = MediaExtractor._format_markdown_reference(media)
+            canonical = MediaExtractor._clean_attachment_name(media.filename)
+            path = (
+                public_paths.get(canonical)
+                if public_paths and canonical in public_paths
+                else media.relative_path
+            )
+
+            markdown = MediaExtractor._format_markdown_reference(media, path)
             return f"{markdown} _(arquivo anexado)_"
 
         return MediaExtractor._attachment_pattern.sub(replacement, text)
 
+    @classmethod
+    def find_attachment_names(cls, text: str) -> set[str]:
+        """Return sanitized attachment filenames referenced in *text*."""
+
+        return {
+            cls._clean_attachment_name(match.group(1).strip())
+            for match in cls._attachment_pattern.finditer(text)
+        }
+
+    @staticmethod
+    def format_media_section(
+        media_files: Dict[str, MediaFile],
+        *,
+        public_paths: Dict[str, str] | None = None,
+    ) -> str | None:
+        """Return a Markdown bullet list describing the shared media."""
+
+        if not media_files:
+            return None
+
+        lines: list[str] = []
+        for key in sorted(media_files):
+            media = media_files[key]
+            label = media.filename
+            path = (
+                public_paths.get(key)
+                if public_paths and key in public_paths
+                else media.relative_path
+            )
+            if media.media_type == "image":
+                rendered = f"![{label}]({path})"
+            elif media.media_type == "video":
+                rendered = f"[🎥 {label}]({path})"
+            elif media.media_type == "audio":
+                rendered = f"[🔊 {label}]({path})"
+            elif media.media_type == "document":
+                rendered = f"[📄 {label}]({path})"
+            else:
+                rendered = f"[{label}]({path})"
+            lines.append(f"- {rendered}")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def build_public_paths(
+        media_files: Dict[str, MediaFile],
+        *,
+        relative_to: Path | None = None,
+        url_prefix: str | None = None,
+    ) -> Dict[str, str]:
+        """Return paths suitable for linking from a newsletter."""
+
+        if not media_files:
+            return {}
+
+        results: Dict[str, str] = {}
+
+        if url_prefix:
+            absolute = url_prefix.startswith("/")
+            cleaned_prefix = url_prefix.strip("/")
+            prefix_path = PurePosixPath(cleaned_prefix) if cleaned_prefix else None
+
+            for key, media in media_files.items():
+                suffix_parts = list(PurePosixPath(media.relative_path).parts)
+                if suffix_parts and suffix_parts[0] == "media":
+                    suffix_parts = suffix_parts[1:]
+                suffix = PurePosixPath(*suffix_parts)
+                if prefix_path is not None:
+                    combined = prefix_path.joinpath(suffix)
+                else:
+                    combined = suffix
+                path = combined.as_posix()
+                results[key] = f"/{path}" if absolute else path
+            return results
+
+        if relative_to is not None:
+            base_dir = Path(relative_to)
+            for key, media in media_files.items():
+                rel_path = os.path.relpath(media.dest_path, base_dir)
+                results[key] = PurePosixPath(rel_path).as_posix()
+            return results
+
+        for key, media in media_files.items():
+            results[key] = media.relative_path
+
+        return results
+
     @staticmethod
     def _lookup_media(filename: str, media_files: Dict[str, MediaFile]) -> MediaFile | None:
-        canonical = Path(filename).name
+        canonical = MediaExtractor._clean_attachment_name(Path(filename).name)
         if canonical in media_files:
             return media_files[canonical]
 
         lowercase = canonical.lower()
         for key, media in media_files.items():
-            if Path(key).name.lower() == lowercase:
-                return media
-            if media.filename.lower() == lowercase:
+            candidate = MediaExtractor._clean_attachment_name(Path(key).name)
+            if candidate.lower() == lowercase or media.filename.lower() == lowercase:
                 return media
         return None
 
     @staticmethod
-    def _format_markdown_reference(media: MediaFile) -> str:
+    def _format_markdown_reference(media: MediaFile, path: str) -> str:
         if media.media_type == "image":
-            return f"![{media.filename}]({media.relative_path})"
+            return f"![{media.filename}]({path})"
         if media.media_type == "video":
-            return f"[🎥 {media.filename}]({media.relative_path})"
+            return f"[🎥 {media.filename}]({path})"
         if media.media_type == "audio":
-            return f"[🔊 {media.filename}]({media.relative_path})"
+            return f"[🔊 {media.filename}]({path})"
         if media.media_type == "document":
-            return f"[📄 {media.filename}]({media.relative_path})"
-        return f"[{media.filename}]({media.relative_path})"
+            return f"[📄 {media.filename}]({path})"
+        return f"[{media.filename}]({path})"
+
+    @classmethod
+    def _clean_attachment_name(cls, filename: str) -> str:
+        cleaned = cls._directional_marks.sub("", filename)
+        return cleaned.strip()
 
     @staticmethod
     def _resolve_destination(directory: Path, filename: str) -> tuple[Path, str]:

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -40,3 +40,32 @@ def test_replace_media_references_converts_to_markdown() -> None:
 
     assert "![IMG-20251002-WA0004.jpg](media/2025-10-03/IMG-20251002-WA0004.jpg)" in updated
     assert "_(arquivo anexado)_" in updated
+
+
+def test_build_public_paths_relative(tmp_path) -> None:
+    zip_path = Path("tests/data/Conversa do WhatsApp com Teste.zip")
+    extractor = MediaExtractor(tmp_path / "media")
+
+    media_files = extractor.extract_media_from_zip(zip_path, date(2025, 10, 3))
+
+    output_dir = tmp_path / "docs" / "reports"
+    output_dir.mkdir(parents=True)
+
+    public_paths = MediaExtractor.build_public_paths(media_files, relative_to=output_dir)
+    path = public_paths["IMG-20251002-WA0004.jpg"]
+
+    assert path.startswith("../../media/2025-10-03/")
+    assert path.endswith("IMG-20251002-WA0004.jpg")
+
+
+def test_build_public_paths_with_prefix(tmp_path) -> None:
+    zip_path = Path("tests/data/Conversa do WhatsApp com Teste.zip")
+    extractor = MediaExtractor(tmp_path / "media")
+
+    media_files = extractor.extract_media_from_zip(zip_path, date(2025, 10, 3))
+
+    public_paths = MediaExtractor.build_public_paths(media_files, url_prefix="/media")
+    path = public_paths["IMG-20251002-WA0004.jpg"]
+
+    assert path.startswith("/media/2025-10-03/")
+    assert path.endswith("IMG-20251002-WA0004.jpg")

--- a/tools/mkdocs_media_plugin.py
+++ b/tools/mkdocs_media_plugin.py
@@ -1,0 +1,43 @@
+"""MkDocs plugin to expose the extracted media directory."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from mkdocs.config import config_options
+from mkdocs.plugins import BasePlugin
+
+
+class MediaFilesPlugin(BasePlugin):
+    """Copy the repository ``media/`` directory into the built site."""
+
+    config_scheme = (
+        ("source_dir", config_options.Type(str, default="media")),
+        ("target_dir", config_options.Type(str, default="media")),
+    )
+
+    def on_post_build(self, config) -> None:  # type: ignore[override]
+        source = Path(self.config["source_dir"])
+        if not source.exists():
+            return
+
+        target = Path(config["site_dir"]) / self.config["target_dir"]
+        if target.exists():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, target)
+
+    def on_serve(self, server, config, builder):  # type: ignore[override]
+        source = Path(self.config["source_dir"])
+        if source.exists():
+            server.watch(str(source), builder)
+        return server
+
+
+def on_config(config):
+    """Keep MkDocs from trying to instantiate without using the plugin name."""
+    return config
+
+
+plugin = MediaFilesPlugin()


### PR DESCRIPTION
## Summary
- add optional `media_url_prefix` so newsletters can link to shared media directories
- compute public paths when rewriting media references and sections
- add a MkDocs plugin and docs to publish the `media/` directory

## Testing
- UV_CACHE_DIR=.uv-cache uv run --with pytest pytest tests/test_media_extractor.py
