### PR TITLE
Add shared embedding cache helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ __pycache__/
 
 # Cache
 cache/
+!src/egregora/cache/
+!src/egregora/cache/**
 
 # OS generated files
 .DS_Store

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -68,7 +68,7 @@ from egregora.rag.config import RAGConfig
 
 config = RAGConfig(enabled=True, embedding_dimension=768)
 rag = NewsletterRAG(
-    newsletters_dir=Path("data/daily"),
+    newsletters_dir=Path("data/meu-grupo"),
     cache_dir=Path("cache"),
     config=config,
 )
@@ -80,9 +80,10 @@ results = rag.search("automações discutidas", top_k=3)
 
 ## 💾 Cache e Fallback
 
-- Os vetores ficam em `cache/embeddings/` juntamente com metadados do modelo.
-- `CachedGeminiEmbedding` grava cada embedding identificado por hash, evitando
-  custos repetidos de API.
+- Os vetores ficam em `cache/embeddings/` juntamente com metadados do modelo,
+  graças aos utilitários de `egregora.cache`.
+- `CachedGeminiEmbedding` grava cada embedding identificado pelo hash do
+  namespace + texto, evitando custos repetidos de API.
 - Se a API não estiver disponível, o fallback interno usa hashing determinístico
   para produzir vetores estáveis, garantindo que o MCP server continue
   respondendo mesmo offline.

--- a/src/egregora/cache/__init__.py
+++ b/src/egregora/cache/__init__.py
@@ -1,0 +1,129 @@
+"""Shared cache helpers built on top of :mod:`diskcache`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping
+import hashlib
+
+from diskcache import Cache
+
+__all__ = [
+    "CacheMetadata",
+    "build_namespace",
+    "create_cache",
+    "hash_key",
+    "load_vector",
+    "store_vector",
+]
+
+
+@dataclass(slots=True)
+class CacheMetadata:
+    """Minimal metadata stored alongside cached vectors."""
+
+    dimension: int
+    namespace: str
+    cached_at: str
+
+
+def _normalise_extra(extra: Mapping[str, str | int] | None) -> tuple[tuple[str, str], ...]:
+    if not extra:
+        return tuple()
+    items: list[tuple[str, str]] = []
+    for key in sorted(extra):
+        items.append((key, str(extra[key])))
+    return tuple(items)
+
+
+def build_namespace(
+    *,
+    model: str,
+    dimension: int,
+    extra: Mapping[str, str | int] | None = None,
+) -> str:
+    """Return a stable namespace that identifies cached vectors."""
+
+    parts = [("model", model), ("dimension", str(dimension))]
+    parts.extend(_normalise_extra(extra))
+    return "|".join(f"{key}={value}" for key, value in parts)
+
+
+def create_cache(
+    cache_dir: Path | str | None,
+    *,
+    size_limit_mb: int | None = None,
+) -> Cache | None:
+    """Instantiate a :class:`diskcache.Cache` rooted at ``cache_dir``."""
+
+    if cache_dir is None:
+        return None
+    directory = Path(cache_dir).expanduser()
+    directory.mkdir(parents=True, exist_ok=True)
+    kwargs: dict[str, int] = {}
+    if size_limit_mb is not None:
+        kwargs["size_limit"] = max(0, int(size_limit_mb)) * 1024 * 1024
+    return Cache(directory=str(directory), **kwargs)
+
+
+def hash_key(namespace: str, text: str, *, kind: str | None = None) -> str:
+    """Return a SHA256 key for ``text`` scoped to ``namespace``."""
+
+    segments = [namespace]
+    if kind:
+        segments.append(kind)
+    segments.append(text)
+    return hashlib.sha256("::".join(segments).encode("utf-8")).hexdigest()
+
+
+def load_vector(
+    cache: Cache | None,
+    namespace: str,
+    text: str,
+    *,
+    kind: str | None = None,
+) -> list[float] | None:
+    """Load a cached vector if present."""
+
+    if cache is None:
+        return None
+    record = cache.get(hash_key(namespace, text, kind=kind))
+    if not isinstance(record, dict):
+        return None
+    if record.get("namespace") != namespace:
+        return None
+    vector = record.get("vector")
+    if not isinstance(vector, list):
+        return None
+    return [float(value) for value in vector]
+
+
+def store_vector(
+    cache: Cache | None,
+    namespace: str,
+    text: str,
+    values: Iterable[float],
+    *,
+    kind: str | None = None,
+) -> CacheMetadata | None:
+    """Persist ``values`` in ``cache`` when caching is enabled."""
+
+    if cache is None:
+        return None
+    vector = [float(value) for value in values]
+    metadata = CacheMetadata(
+        dimension=len(vector),
+        namespace=namespace,
+        cached_at=datetime.now(timezone.utc).isoformat(),
+    )
+    cache.set(
+        hash_key(namespace, text, kind=kind),
+        {
+            "vector": vector,
+            "namespace": namespace,
+            "metadata": metadata,
+        },
+    )
+    return metadata

--- a/src/egregora/rag/embedding_cache.py
+++ b/src/egregora/rag/embedding_cache.py
@@ -2,22 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
-import hashlib
 
+from ..cache import CacheMetadata, build_namespace, create_cache, load_vector, store_vector
 from diskcache import Cache
-
-
-@dataclass(slots=True)
-class CachedEmbedding:
-    """Metadata associated with a cached embedding vector."""
-
-    dimension: int
-    namespace: str
-    cached_at: str
 
 
 class EmbeddingCache:
@@ -32,76 +21,26 @@ class EmbeddingCache:
         extra: dict[str, str | int] | None = None,
         size_limit_mb: int | None = None,
     ) -> None:
-        self._enabled = cache_dir is not None
-        self._namespace = self._build_namespace(model=model, dimension=dimension, extra=extra)
-        if not self._enabled:
-            self._cache: Cache | None = None
-            return
-
-        directory = Path(cache_dir).expanduser()
-        directory.mkdir(parents=True, exist_ok=True)
-        size_limit = (
-            None if size_limit_mb is None else max(0, int(size_limit_mb)) * 1024 * 1024
-        )
-        self._cache = Cache(directory=str(directory), size_limit=size_limit)
+        self._namespace = build_namespace(model=model, dimension=dimension, extra=extra)
+        self._cache = create_cache(cache_dir, size_limit_mb=size_limit_mb)
 
     def get(self, text: str) -> list[float] | None:
         """Return the cached embedding for ``text`` when available."""
 
-        if not self._enabled or not self._cache:
-            return None
-        key = self._build_key(text)
-        record = self._cache.get(key)
-        if not record:
-            return None
-        if record.get("namespace") != self._namespace:
-            return None
-        vector = record.get("vector")
-        if not isinstance(vector, list):
-            return None
-        return [float(value) for value in vector]
+        return load_vector(self._cache, self._namespace, text)
 
     def set(self, text: str, embedding: Iterable[float]) -> None:
         """Store ``embedding`` for ``text``."""
 
-        if not self._enabled or not self._cache:
-            return
-        vector = [float(value) for value in embedding]
-        record = {
-            "vector": vector,
-            "namespace": self._namespace,
-            "metadata": CachedEmbedding(
-                dimension=len(vector),
-                namespace=self._namespace,
-                cached_at=datetime.now(timezone.utc).isoformat(),
-            ),
-        }
-        self._cache.set(self._build_key(text), record)
+        store_vector(self._cache, self._namespace, text, embedding)
 
     def clear(self) -> None:
         """Remove all cached vectors."""
 
-        if not self._enabled or not self._cache:
+        if not self._cache:
             return
-        for key in list(self._cache.iterkeys()):
+        for key in list(self._cache.iterkeys()):  # type: ignore[attr-defined]
             self._cache.delete(key)
 
-    def _build_key(self, text: str) -> str:
-        digest = hashlib.sha256(f"{self._namespace}::{text}".encode("utf-8")).hexdigest()
-        return digest
 
-    @staticmethod
-    def _build_namespace(
-        *,
-        model: str,
-        dimension: int,
-        extra: dict[str, str | int] | None = None,
-    ) -> str:
-        parts = [f"model={model}", f"dimension={dimension}"]
-        if extra:
-            for key in sorted(extra):
-                parts.append(f"{key}={extra[key]}")
-        return "|".join(parts)
-
-
-__all__ = ["EmbeddingCache", "CachedEmbedding"]
+__all__ = ["EmbeddingCache", "CacheMetadata"]

--- a/tests/test_embedding_cache.py
+++ b/tests/test_embedding_cache.py
@@ -1,0 +1,79 @@
+"""Tests for embedding cache helpers and wrappers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from egregora.cache import build_namespace, create_cache, load_vector, store_vector
+from egregora.rag.embedding_cache import EmbeddingCache
+from egregora.rag.embeddings import CachedGeminiEmbedding
+
+
+@pytest.fixture()
+def cache_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "cache"
+    directory.mkdir()
+    return directory
+
+
+def test_build_namespace_sorts_extra() -> None:
+    namespace = build_namespace(model="gemini", dimension=256, extra={"mode": "online", "tenant": "alpha"})
+    assert namespace == "model=gemini|dimension=256|mode=online|tenant=alpha"
+
+
+def test_low_level_helpers_round_trip(cache_dir: Path) -> None:
+    cache = create_cache(cache_dir)
+    namespace = build_namespace(model="test", dimension=4)
+    text = "hello world"
+
+    assert load_vector(cache, namespace, text) is None
+
+    metadata = store_vector(cache, namespace, text, [1, 2, 3, 4])
+    assert metadata is not None
+    assert metadata.dimension == 4
+
+    stored = load_vector(cache, namespace, text)
+    assert stored == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_embedding_cache_wrapper(cache_dir: Path) -> None:
+    cache = EmbeddingCache(cache_dir, model="gemini", dimension=8)
+    assert cache.get("text") is None
+    cache.set("text", [0.1] * 8)
+    assert cache.get("text") == [pytest.approx(0.1)] * 8
+
+
+def test_cached_gemini_embedding_hits_cache(monkeypatch: pytest.MonkeyPatch, cache_dir: Path) -> None:
+    calls: list[str] = []
+
+    class StubEmbedding:
+        def get_text_embedding(self, text: str) -> list[float]:
+            calls.append(text)
+            return [1.0, 0.0]
+
+        def get_query_embedding(self, text: str) -> list[float]:
+            calls.append(f"query:{text}")
+            return [0.5, 0.5]
+
+    embedding = CachedGeminiEmbedding(
+        model_name="models/gemini-test",
+        dimension=2,
+        cache_dir=cache_dir,
+        api_key=None,
+    )
+    # Override fallback model with stub to count calls.
+    object.__setattr__(embedding, "_embed_model", StubEmbedding())
+
+    first = embedding._get_text_embedding("hello")
+    second = embedding._get_text_embedding("hello")
+    assert first == [1.0, 0.0]
+    assert second == [1.0, 0.0]
+    assert calls == ["hello"]
+
+    query_first = embedding._get_query_embedding("what")
+    query_second = embedding._get_query_embedding("what")
+    assert query_first == [0.5, 0.5]
+    assert query_second == [0.5, 0.5]
+    assert calls == ["hello", "query:what"]


### PR DESCRIPTION
## Summary
- add  module with reusable helpers for namespace hashing, diskcache creation, and vector storage
- refactor  to use the shared helpers and export the metadata class
- document the new layout in  and add regression coverage in 

## Testing
- uv run pytest tests/test_embedding_cache.py
- uv run pytest tests/test_rag_llamaindex.py