### PR TITLE
Add GitHub Actions step to download WhatsApp zips from Google Drive

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,13 @@ jobs:
         run: |
           python -m pip install ".[docs]"
 
+      - name: Download WhatsApp exports
+        if: ${{ secrets.WHATSAPP_ZIPS_DRIVE_URL != '' }}
+        env:
+          DRIVE_URL: ${{ secrets.WHATSAPP_ZIPS_DRIVE_URL }}
+        run: |
+          python tools/download_drive_zips.py "$DRIVE_URL"
+
       - name: Generate weekly/monthly
         run: |
           python tools/build_reports.py

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Se você tem múltiplos dias de conversas para processar:
 
 O script simples usa o mesmo pipeline diário e imprime um resumo ao final. Para mais detalhes, veja [docs/backlog_processing.md](docs/backlog_processing.md)
 
+## 🤖 Integração com GitHub Actions
+
+- Defina o segredo `WHATSAPP_ZIPS_DRIVE_URL` no repositório apontando para a URL compartilhável de uma pasta pública no Google Drive contendo os exports `.zip` do WhatsApp.
+- Durante o workflow `Deploy MkDocs`, o passo `Download WhatsApp exports` baixa automaticamente os arquivos para `data/whatsapp_zips/` usando `tools/download_drive_zips.py` (que faz o download da pasta inteira via `gdown`).
+- Para validar manualmente, execute `python tools/download_drive_zips.py "<url-da-pasta>"` e confirme que os `.zip` foram salvos localmente antes de rodar o pipeline.
+
 ## 🧪 Testes manuais
 
 - Rode `python example_enrichment.py` para validar rapidamente o módulo de enriquecimento (define `GEMINI_API_KEY` antes para executar a análise com o LLM).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dateutil>=2.9",
     "pydantic>=2.6",
     "pydantic-settings>=2.1",
+    "gdown>=5.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/download_drive_zips.py
+++ b/tools/download_drive_zips.py
@@ -1,0 +1,89 @@
+"""Utilities to download WhatsApp exports from a shared Google Drive folder."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import gdown
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download all WhatsApp .zip exports from a public Google Drive folder "
+            "into a target directory."
+        )
+    )
+    parser.add_argument(
+        "drive_url",
+        help="Shareable URL for the Google Drive folder containing WhatsApp exports.",
+    )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default="data/whatsapp_zips",
+        help=(
+            "Directory where the downloaded .zip files will be stored. Defaults to "
+            "'data/whatsapp_zips'."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def download_drive_folder(drive_url: str, destination: Path) -> list[Path]:
+    """Download ``*.zip`` files from *drive_url* into *destination*.
+
+    The folder is first downloaded into a temporary directory to avoid mixing
+    unexpected files with the workspace. Only files with a ``.zip`` extension
+    are moved into *destination*.
+    """
+
+    destination.mkdir(parents=True, exist_ok=True)
+
+    downloaded_files: list[Path] = []
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        gdown.download_folder(  # type: ignore[call-arg]
+            url=drive_url,
+            output=tmp_dir,
+            quiet=False,
+            use_cookies=False,
+        )
+        for zip_path in Path(tmp_dir).rglob("*.zip"):
+            target_path = destination / zip_path.name
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(zip_path), target_path)
+            downloaded_files.append(target_path)
+    return downloaded_files
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    destination = Path(args.output_dir)
+
+    try:
+        downloaded_files = download_drive_folder(args.drive_url, destination)
+    except Exception as exc:  # pragma: no cover - defensive logging for CI
+        print(f"[download_drive_zips] Failed to download folder: {exc}", file=sys.stderr)
+        return 1
+
+    if not downloaded_files:
+        print(
+            "[download_drive_zips] No .zip files were found in the shared folder.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[download_drive_zips] Downloaded {len(downloaded_files)} ZIP files to {destination}"
+    )
+    for file_path in downloaded_files:
+        print(f" - {file_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -288,6 +288,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -529,6 +542,7 @@ source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
     { name = "diskcache" },
+    { name = "gdown" },
     { name = "google-genai" },
     { name = "llama-index-core" },
     { name = "llama-index-embeddings-gemini" },
@@ -553,6 +567,7 @@ docs = [
 requires-dist = [
     { name = "chromadb", specifier = ">=0.5.0" },
     { name = "diskcache", specifier = ">=5.6" },
+    { name = "gdown", specifier = ">=5.2.0" },
     { name = "google-genai", specifier = ">=0.3.0" },
     { name = "llama-index-core", specifier = ">=0.11.0" },
     { name = "llama-index-embeddings-gemini", specifier = ">=0.2.0" },
@@ -710,6 +725,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
+]
+
+[[package]]
+name = "gdown"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/6a/37e6b70c5bda3161e40265861e63b64a86bfc6ca6a8f1c35328a675c84fd/gdown-5.2.0.tar.gz", hash = "sha256:2145165062d85520a3cd98b356c9ed522c5e7984d408535409fd46f94defc787", size = 284647, upload-time = "2024-05-12T06:45:12.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/70/e07c381e6488a77094f04c85c9caf1c8008cdc30778f7019bc52e5285ef0/gdown-5.2.0-py3-none-any.whl", hash = "sha256:33083832d82b1101bdd0e9df3edd0fbc0e1c5f14c9d8c38d2a35bf1683b526d6", size = 18235, upload-time = "2024-05-12T06:45:10.017Z" },
 ]
 
 [[package]]
@@ -2819,6 +2849,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3051,6 +3090,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
 [[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
@@ -3258,6 +3302,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a helper script that downloads WhatsApp ZIP exports from a shared Google Drive folder
- update the gh-pages workflow to install the docs dependencies (with gdown provided by the project) and fetch ZIPs using the new script and `WHATSAPP_ZIPS_DRIVE_URL` secret
- document the new GitHub Actions integration and secret in the README
- add gdown to the project dependencies so the downloader works both locally and in CI

## Testing
- uv run pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e48b1f75c48325958288fe9cf3cbf5