### PR TITLE
feat: secure remote zip source configuration

### DIFF
--- a/egregora.toml.example
+++ b/egregora.toml.example
@@ -17,6 +17,10 @@ model = "gemini-flash-lite-latest"
 timezone = "America/Porto_Velho"
 # Evita processar grupos reais que já fazem parte de um grupo virtual.
 skip_real_if_in_virtual = true
+# Configuração opcional para buscar ZIPs em fonte remota (ex.: Google Drive).
+# Recomenda-se definir `PIPELINE__REMOTE_SOURCE__GDRIVE_URL` via ambiente para manter sigilo.
+# [pipeline.remote_source]
+# gdrive_url = "https://drive.google.com/uc?id=EXEMPLO"
 
 [enrichment]
 # Define se o módulo de enriquecimento está ativo.

--- a/tests/test_remote_source_config.py
+++ b/tests/test_remote_source_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+from egregora.config import PipelineConfig, RemoteSourceConfig
+
+
+def test_remote_source_secret_handling():
+    url = "https://drive.google.com/uc?id=secret"
+    config = PipelineConfig.with_defaults(remote_source={"gdrive_url": url})
+
+    secret = config.remote_source.gdrive_url
+    assert secret is not None
+    assert config.remote_source.get_gdrive_url() == url
+    # Secret should be masked when converted to string or repr
+    assert url not in str(secret)
+    assert url not in repr(secret)
+
+    safe = config.safe_dict()
+    assert safe["remote_source"]["gdrive_url"] == str(secret)
+    assert url not in safe["remote_source"]["gdrive_url"]
+
+    # repr of config should not leak the URL
+    assert url not in repr(config)
+
+
+def test_remote_source_requires_https():
+    with pytest.raises(ValueError):
+        RemoteSourceConfig(gdrive_url="http://example.com/file.zip")
+
+    # Empty strings should be treated as not configured
+    config = RemoteSourceConfig(gdrive_url="   ")
+    assert config.gdrive_url is None


### PR DESCRIPTION
## Summary
- add a RemoteSourceConfig to PipelineConfig so Google Drive ZIP URLs are stored as SecretStr values
- ensure the example TOML documents the optional remote source setting and how to keep it secret
- cover the new behaviour with tests that verify redaction, accessors, and URL validation

## Testing
- uv run --with pytest --with pydantic --with pytest-asyncio python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5030700a483258a2e16a95ec40f10