### PR TITLE
Normalize cache URLs for consistent UUIDs

### DIFF
--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -54,6 +54,22 @@ def test_generate_uuid_normalizes_urls(tmp_path: Path) -> None:
     assert uuid_a != uuid_c
 
 
+def test_generate_uuid_ignores_default_ports(tmp_path: Path) -> None:
+    manager = CacheManager(tmp_path / "cache", size_limit_mb=1)
+
+    http_with_port = "http://example.com:80/path"
+    http_without_port = "http://example.com/path"
+    https_with_port = "https://example.com:443/path"
+    https_without_port = "https://example.com/path"
+
+    assert manager.generate_uuid(http_with_port) == manager.generate_uuid(
+        http_without_port
+    )
+    assert manager.generate_uuid(https_with_port) == manager.generate_uuid(
+        https_without_port
+    )
+
+
 def test_set_and_get_roundtrip(tmp_path: Path) -> None:
     manager = CacheManager(tmp_path / "cache", size_limit_mb=1)
     url = "https://example.com/artigo"


### PR DESCRIPTION
## Summary
- enhance CacheManager URL normalization to drop default HTTP/HTTPS ports while keeping canonical formatting
- ensure query parameters are sorted with doseq handling and preserve userinfo during reconstruction
- add regression test confirming UUIDs are identical when default ports are omitted

## Testing
- uv run pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e50e114e2c83258f43ee769402d88b