### PR TITLE
Scope media outputs to group directories

### DIFF
--- a/src/egregora/processor.py
+++ b/src/egregora/processor.py
@@ -247,9 +247,13 @@ class UnifiedProcessor:
         daily_dir = group_dir / "daily"
         daily_dir.mkdir(parents=True, exist_ok=True)
 
+        profiles_base = group_dir / "profiles"
+        profiles_base.mkdir(parents=True, exist_ok=True)
+
+        (group_dir / "media").mkdir(parents=True, exist_ok=True)
+
         profile_repository = None
         if self.config.profiles.enabled and self._profile_updater:
-            profiles_base = group_dir / "profiles"
             profile_repository = ProfileRepository(
                 data_dir=profiles_base / "json",
                 docs_dir=profiles_base,
@@ -265,7 +269,7 @@ class UnifiedProcessor:
         target_dates = available_dates[-days:] if days else available_dates
 
         results = []
-        extractor = MediaExtractor(self.config.media_dir)
+        extractor = MediaExtractor(group_dir, group_scoped=True)
 
         exports_by_date: dict[date, list] = {}
         for export in source.exports:

--- a/tests/test_profile_generation.py
+++ b/tests/test_profile_generation.py
@@ -133,4 +133,6 @@ def test_profile_generation_writes_json_and_markdown(monkeypatch: pytest.MonkeyP
     assert profile_data["member_id"] in generated_text
     assert "[!NOTE]" in generated_text
 
+    assert (group_dir / "media").exists()
+
     shutil.rmtree(workspace, ignore_errors=True)

--- a/tests/test_unified_processor_media_extraction.py
+++ b/tests/test_unified_processor_media_extraction.py
@@ -71,7 +71,7 @@ def test_unified_processor_extracts_media(config_with_media: PipelineConfig, mon
     results = processor.process_all(days=1)
 
     # Verify media directory exists
-    media_output_dir = config_with_media.media_dir / "_chat" / "media"
+    media_output_dir = config_with_media.newsletters_dir / "_chat" / "media"
     assert media_output_dir.exists()
 
     # Verify media files extracted


### PR DESCRIPTION
## Summary
- place extracted media under each group's newsletter directory to keep artifacts self-contained
- allow MediaExtractor to operate in a group-scoped mode without breaking shared-directory workflows
- adjust processor/tests to expect per-group media folders alongside profiles

## Why
- copying a single group folder should carry all newsletters, media, and profile assets without chasing shared paths
- keeping compatibility for shared media directories avoids breaking existing CLI usage

## Testing
- uv run --extra test pytest