### PR TITLE
Simplify newsletter RAG index cleanup

### DIFF
--- a/src/egregora/rag/index.py
+++ b/src/egregora/rag/index.py
@@ -154,12 +154,6 @@ class NewsletterRAG:
             for doc in documents:
                 try:
                     index.delete_ref_doc(doc.doc_id, raise_error=False)  # type: ignore[call-arg]
-                except TypeError:
-                    # Older llama-index versions do not accept the keyword argument
-                    try:
-                        index.delete_ref_doc(doc.doc_id)  # type: ignore[call-arg]
-                    except Exception:
-                        continue
                 except Exception:
                     continue
 


### PR DESCRIPTION
## Summary
- always call `delete_ref_doc` with `raise_error=False` during incremental index updates
- rely on a broad exception handler to keep ignoring per-document failures

## Testing
- uv run pytest tests/rag *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e567947d6c8325a17efdb9788bcb22