### PR TITLE
Remove deprecated read_zip_texts helper

### DIFF
--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -346,15 +346,6 @@ def read_zip_texts_and_media(
         transcript = MediaExtractor.replace_media_references(transcript, media_files)
 
     return transcript, media_files
-
-
-def read_zip_texts(zippath: Path) -> str:
-    """Backward-compatible helper that returns only the transcript text."""
-
-    transcript, _ = read_zip_texts_and_media(zippath)
-    return transcript
-
-
 def load_previous_newsletter(news_dir: Path, reference_date: date) -> tuple[Path, str | None]:
     """Load yesterday's newsletter if it exists."""
 
@@ -390,7 +381,6 @@ __all__ = [
     "find_date_in_name",
     "list_zip_days",
     "load_previous_newsletter",
-    "read_zip_texts",
     "read_zip_texts_and_media",
     "select_recent_archives",
     "_anonymize_transcript_line",

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from egregora.config import PipelineConfig
 from egregora.pipeline import (
-    read_zip_texts,
+    read_zip_texts_and_media,
     _prepare_transcripts,
     list_zip_days,
     find_date_in_name,
@@ -39,7 +39,7 @@ def test_zip_processing_whatsapp_format(temp_dir, whatsapp_zip_path):
         zip_path = whatsapp_zip_path
     
     # Test zip reading
-    content = read_zip_texts(zip_path)
+    content, _ = read_zip_texts_and_media(zip_path)
     
     # Validate content
     assert len(content) > 0

--- a/tests/test_framework/helpers.py
+++ b/tests/test_framework/helpers.py
@@ -9,7 +9,7 @@ import re
 from typing import Any, Dict, List, Tuple
 
 from egregora.config import PipelineConfig
-from egregora.pipeline import read_zip_texts, _prepare_transcripts
+from egregora.pipeline import read_zip_texts_and_media, _prepare_transcripts
 
 
 def create_test_zip(content: str, zip_path: Path, filename: str = "conversation.txt") -> None:
@@ -115,7 +115,8 @@ def load_real_whatsapp_transcript(zip_path: Path) -> str:
     if not zip_path.exists():
         raise FileNotFoundError(f"WhatsApp export not found: {zip_path}")
 
-    return read_zip_texts(zip_path)
+    transcript, _ = read_zip_texts_and_media(zip_path)
+    return transcript
 
 
 def summarize_whatsapp_content(content: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- remove the legacy read_zip_texts helper to keep read_zip_texts_and_media as the unified API
- adjust core pipeline and testing helpers to use read_zip_texts_and_media and unpack transcripts as needed

## Testing
- uv run pytest tests/test_core_pipeline.py tests/test_framework *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e567bbcd0c832596854578fd47a7b3