### PR TITLE
Add pymdown extensions to docs tooling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,10 @@ nav:
 markdown_extensions:
   - toc:
       permalink: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.details
+  - pymdownx.superfences
 
 docs_dir: docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocs-static-i18n>=1.2",
     "python-dateutil>=2.9",
+    "pymdown-extensions>=10.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -570,6 +570,7 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocs-static-i18n" },
+    { name = "pymdown-extensions" },
     { name = "python-dateutil" },
 ]
 test = [
@@ -594,6 +595,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydantic", marker = "extra == 'test'", specifier = ">=2.6" },
     { name = "pydantic-settings", specifier = ">=2.1" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "python-dateutil", specifier = ">=2.9" },


### PR DESCRIPTION
## Summary
- add `pymdown-extensions` to the MkDocs documentation extra
- enable Material components by wiring the pymdown tasklist, details, and superfences extensions

## Testing
- `uv run --with docs mkdocs serve` *(fails: uv doesn't recognize `--with`, expects package `docs`)*
- `uv run --extra docs mkdocs serve` *(fails: MkDocs can't import the bundled `tools.mkdocs_media_plugin` plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57cf590c48325a602536881978f81