### PR TITLE
Add MkDocs plugin for report generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,10 +21,6 @@ jobs:
         run: |
           python -m pip install ".[docs]"
 
-      - name: Generate weekly/monthly
-        run: |
-          python tools/build_reports.py
-
       - name: Build site
         run: |
           mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ During processing the pipeline materialises a predictable directory tree:
 - `cache/` – Disk-backed enrichment cache to avoid reprocessing URLs.【F:src/egregora/cache_manager.py†L16-L142】
 - `docs/` – MkDocs site that can publish newsletters and reports (`uv run mkdocs serve`).
 
-Enable the bundled MkDocs plugin (`tools.mkdocs_media_plugin`) to expose media under `/media/<slug>/` when deploying the static site.【F:mkdocs.yml†L1-L74】
+Enable the bundled MkDocs plugins to automate publishing tasks: `tools.mkdocs_build_reports_plugin` regenerates the daily/weekly/monthly archives whenever you run `mkdocs build` or `mkdocs serve`, and `tools.mkdocs_media_plugin` exposes media under `/media/<slug>/` when deploying the static site.【F:mkdocs.yml†L56-L74】
 
 ## Retrieval & MCP integrations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ markdown_extensions:
 docs_dir: docs
 
 plugins:
+  - tools.mkdocs_build_reports_plugin
   - search
   - tools.mkdocs_media_plugin:
       source_dir: data/newsletters

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers and MkDocs plugins used by the Egrégora docs build."""

--- a/tools/build_reports.py
+++ b/tools/build_reports.py
@@ -411,7 +411,7 @@ def update_home_latest(config: LanguageConfig, entries: List[Dict[str, object]],
     replace_block(path, "latest", lines)
 
 
-def main() -> None:
+def build_reports() -> None:
     entries = collect_daily_entries()
     weekly_groups, monthly_groups = build_weekly_and_monthly_groups(entries)
 
@@ -431,4 +431,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    build_reports()

--- a/tools/mkdocs_build_reports_plugin.py
+++ b/tools/mkdocs_build_reports_plugin.py
@@ -1,0 +1,17 @@
+"""MkDocs plugin that builds newsletter report indexes before rendering docs."""
+
+from __future__ import annotations
+
+from mkdocs.plugins import BasePlugin
+
+from .build_reports import build_reports
+
+
+class BuildReportsPlugin(BasePlugin):
+    """Ensure aggregated report pages exist ahead of the MkDocs build."""
+
+    def on_pre_build(self, config) -> None:  # type: ignore[override]
+        build_reports()
+
+
+plugin = BuildReportsPlugin()


### PR DESCRIPTION
## Summary
- expose a reusable `build_reports()` helper in `tools.build_reports`
- add a lightweight MkDocs plugin that runs the helper during `on_pre_build`
- rely on the plugin from `mkdocs.yml`, simplify the Pages workflow, and document the change

## Testing
- python tools/build_reports.py *(fails: ModuleNotFoundError: No module named 'dateutil' in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e57cfbaf1483259a5cb317aed72bf6