### PR TITLE
Update MkDocs metadata for documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,9 @@
 site_name: Egrégora Documentation
 site_description: >-
   Multi-language knowledge base for the Egrégora WhatsApp reporting pipeline, including user guides, developer notes, and automated newsletters.
-site_url: https://SEU_USUARIO.github.io/SEU_REPO
-repo_url: https://github.com/SEU_USUARIO/SEU_REPO
+site_url: https://franklinbaldo.github.io/egregora/
+repo_url: https://github.com/franklinbaldo/egregora
+edit_uri: edit/main/docs/
 
 theme:
   name: material
@@ -66,40 +67,42 @@ docs_dir: docs
 
 plugins:
   - search
-  - tools.mkdocs_media_plugin:
+  - media-files:
       source_dir: data/newsletters
       target_dir: media
   - i18n:
-      default_language: en
       docs_structure: folder
-      languages:
-        en: English
-        pt-BR: Português (Brasil)
-      nav_translations:
-        pt-BR:
-          Home: Início
-          User Guide: Guia de Usuário
-          Overview: Visão Geral
-          Identifier Self-Discovery: Autodescoberta de Identificadores
-          Privacy Overview: Privacidade
-          Profiles Directory: Índice de Perfis
-          WhatsApp ZIP Naming Guide: Guia de Nomes ZIP do WhatsApp
-          Reports: Relatórios
-          Daily: Diários
-          Weekly: Semanais
-          Monthly: Mensais
-          Developer Guide: Guia de Desenvolvimento
-          Architecture Philosophy: Filosofia de Arquitetura
-          Code Analysis: Análise de Código
-          Enrichment Quickstart: Guia Rápido de Enriquecimento
-          Backlog Processing: Processamento de Backlog
-          Content Enrichment Design: Design de Enriquecimento de Conteúdo
-          Embedding Strategy: Estratégia de Embeddings
-          Merged Groups Workflow: Fluxo de Grupos Mesclados
-          MCP RAG Integration: Integração MCP RAG
-          Privacy Implementation Plan: Plano de Implementação de Privacidade
-          Refactoring Plan: Plano de Refatoração
-          Design Review: Revisão de Design
       reconfigure_material: true
-      material_alternate: true
       fallback_to_default: true
+      languages:
+        - locale: en
+          name: English
+          default: true
+          build: true
+        - locale: pt-BR
+          name: Português (Brasil)
+          build: true
+          nav_translations:
+            Home: Início
+            User Guide: Guia de Usuário
+            Overview: Visão Geral
+            Identifier Self-Discovery: Autodescoberta de Identificadores
+            Privacy Overview: Privacidade
+            Profiles Directory: Índice de Perfis
+            WhatsApp ZIP Naming Guide: Guia de Nomes ZIP do WhatsApp
+            Reports: Relatórios
+            Daily: Diários
+            Weekly: Semanais
+            Monthly: Mensais
+            Developer Guide: Guia de Desenvolvimento
+            Architecture Philosophy: Filosofia de Arquitetura
+            Code Analysis: Análise de Código
+            Enrichment Quickstart: Guia Rápido de Enriquecimento
+            Backlog Processing: Processamento de Backlog
+            Content Enrichment Design: Design de Enriquecimento de Conteúdo
+            Embedding Strategy: Estratégia de Embeddings
+            Merged Groups Workflow: Fluxo de Grupos Mesclados
+            MCP RAG Integration: Integração MCP RAG
+            Privacy Implementation Plan: Plano de Implementação de Privacidade
+            Refactoring Plan: Plano de Refatoração
+            Design Review: Revisão de Design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ docs = [
 [project.scripts]
 egregora = "egregora.__main__:run"
 
+[project.entry-points."mkdocs.plugins"]
+media-files = "tools.mkdocs_media_plugin:MediaFilesPlugin"
+
 [build-system]
 requires = ["hatchling>=1.21.0"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- point MkDocs configuration to the public GitHub Pages URL and repository, adding an edit_uri to the docs folder
- register the custom media files plugin as a MkDocs entry point and update the i18n plugin configuration to the current schema

## Testing
- `PYTHONPATH=. uv run --extra docs mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68e57cee57e48325883ffd87e08a219b