### PR TITLE
Add pt-BR guide placeholders linking to English docs

### DIFF
--- a/docs/pt-BR/developer-guide/CODE_ANALYSIS.md
+++ b/docs/pt-BR/developer-guide/CODE_ANALYSIS.md
@@ -1,0 +1,3 @@
+# Resumo da Análise de Código
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/CODE_ANALYSIS.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/CONTENT_ENRICHMENT_DESIGN.md
+++ b/docs/pt-BR/developer-guide/CONTENT_ENRICHMENT_DESIGN.md
@@ -1,0 +1,3 @@
+# Design de Enriquecimento de Conteúdo
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/CONTENT_ENRICHMENT_DESIGN.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/ENRICHMENT_QUICKSTART.md
+++ b/docs/pt-BR/developer-guide/ENRICHMENT_QUICKSTART.md
@@ -1,0 +1,3 @@
+# Guia Rápido de Enriquecimento
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/ENRICHMENT_QUICKSTART.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/PHILOSOPHY.md
+++ b/docs/pt-BR/developer-guide/PHILOSOPHY.md
@@ -1,0 +1,3 @@
+# Filosofia de Arquitetura
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/PHILOSOPHY.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/backlog_processing.md
+++ b/docs/pt-BR/developer-guide/backlog_processing.md
@@ -1,0 +1,3 @@
+# Processamento de Backlog
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/backlog_processing.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/embeddings.md
+++ b/docs/pt-BR/developer-guide/embeddings.md
@@ -1,0 +1,3 @@
+# Estratégia de Embeddings
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/embeddings.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/mcp-rag.md
+++ b/docs/pt-BR/developer-guide/mcp-rag.md
@@ -1,0 +1,3 @@
+# Integração MCP RAG
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/mcp-rag.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/merged-groups.md
+++ b/docs/pt-BR/developer-guide/merged-groups.md
@@ -1,0 +1,3 @@
+# Fluxo de Grupos Mesclados
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/merged-groups.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/plan.md
+++ b/docs/pt-BR/developer-guide/plan.md
@@ -1,0 +1,3 @@
+# Plano de Refatoração
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/plan.md) para obter a documentação completa.

--- a/docs/pt-BR/developer-guide/privacy-implementation.md
+++ b/docs/pt-BR/developer-guide/privacy-implementation.md
@@ -1,0 +1,3 @@
+# Plano de Implementação de Privacidade
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/developer-guide/privacy-implementation.md) para obter a documentação completa.

--- a/docs/pt-BR/user-guide/discover.md
+++ b/docs/pt-BR/user-guide/discover.md
@@ -1,0 +1,3 @@
+# Autodescoberta de Identificadores
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/user-guide/discover.md) para obter a documentação completa.

--- a/docs/pt-BR/user-guide/privacy.md
+++ b/docs/pt-BR/user-guide/privacy.md
@@ -1,0 +1,3 @@
+# Privacidade
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/user-guide/privacy.md) para obter a documentação completa.

--- a/docs/pt-BR/user-guide/profiles.md
+++ b/docs/pt-BR/user-guide/profiles.md
@@ -1,0 +1,3 @@
+# Índice de Perfis
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/user-guide/profiles.md) para obter a documentação completa.

--- a/docs/pt-BR/user-guide/zip-naming.md
+++ b/docs/pt-BR/user-guide/zip-naming.md
@@ -1,0 +1,3 @@
+# Guia de Nomes ZIP do WhatsApp
+
+A tradução desta página ainda não está disponível em português. Consulte a [versão em inglês](../../en/user-guide/zip-naming.md) para obter a documentação completa.


### PR DESCRIPTION
## Summary
- add placeholder pt-BR developer guide pages that direct readers to the English originals until translations are ready
- add placeholder pt-BR user guide pages so the localized navigation no longer leads to 404s

## Testing
- `uv run mkdocs build` *(fails: `mkdocs` executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57fdd61308325afecb3cf79c861a5