### PR TITLE
Add workflow to request Codex review on new PRs

### DIFF
--- a/.github/workflows/pr-codex-review.yml
+++ b/.github/workflows/pr-codex-review.yml
@@ -1,0 +1,26 @@
+name: Request Codex Review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on new pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@codex code review',
+            });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs when a pull request is opened
- automatically comment "@codex code review" on the new pull request to request a review

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5bf4f94008325896f7ed60c924586