### PR TITLE
Instrument enrichment metrics and add smoke tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ During processing the pipeline materialises a predictable directory tree:
 - `data/posts/<slug>/media/` – Deduplicated attachments renamed to deterministic UUIDs for stable links.【F:src/egregora/processor.py†L209-L313】
 - `data/posts/<slug>/profiles/` – Markdown dossiers plus JSON archives for participant history.【F:src/egregora/processor.py†L315-L422】
 - `cache/` – Disk-backed enrichment cache to avoid reprocessing URLs.【F:src/egregora/cache_manager.py†L16-L142】
+- `metrics/enrichment_run.csv` – Rolling log with start/end timestamps, relevant counts, domains, and errors for each enrichment run.【F:src/egregora/enrichment.py†L146-L291】
 - `docs/` – MkDocs site that publishes posts via the Material blog plugin alongside the broader knowledge base (`uv run --extra docs --with ./ mkdocs serve`).
 
 Enable the bundled MkDocs plugins to automate publishing tasks: `tools.mkdocs_build_posts_plugin` regenerates the daily/weekly/monthly archives whenever you run `mkdocs build` or `mkdocs serve`, the language-scoped `blog` plugins from Material surface post feeds/archives, and `tools.mkdocs_media_plugin` exposes media under `/media/<slug>/` when deploying the static site.【F:mkdocs.yml†L56-L74】

--- a/docs/en/design_review.md
+++ b/docs/en/design_review.md
@@ -35,6 +35,7 @@ This review captures the current state of the documentation site and highlights 
 ### 5. Contributor Experience
 - Document the build process, preview commands, and translation guidelines in a dedicated contributor page.
 - Encourage small, frequent documentation pull requests to keep both languages in sync.
+- Surface the new enrichment metrics CSV (`metrics/enrichment_run.csv`) in contributor tooling so reviewers can confirm relevance counts and errors without scraping logs.
 
 ## Next Steps
 

--- a/docs/pt-BR/developer-guide/ENRICHMENT_QUICKSTART.md
+++ b/docs/pt-BR/developer-guide/ENRICHMENT_QUICKSTART.md
@@ -28,7 +28,7 @@ Para confirmar que o módulo funciona isoladamente:
 python example_enrichment.py
 ```
 
-O script usa um mini transcript com dois links e imprime a seção enriquecida que seria enviada ao prompt principal. Certifique-se de usar um modelo com suporte a URLs (`gemini-2.0-flash-exp`). Se a chave Gemini não estiver configurada o script continua e sinaliza que está operando offline.
+O script usa um mini transcript com dois links e imprime a seção enriquecida que seria enviada ao prompt principal. Certifique-se de usar um modelo com suporte a URLs (`gemini-2.0-flash-exp`). Se a chave Gemini não estiver configurada o script continua, informa que está em modo offline determinístico e aponta onde o CSV de métricas foi gravado. Para forçar o modo offline durante revisões automatizadas, defina `EGREGORA_ENRICHMENT_OFFLINE=1` antes de executar o script.
 
 ## 2.1 Capacidades do sistema
 
@@ -63,6 +63,8 @@ Saída esperada do processamento real (resumo):
 [OK] Post criada em posts/2024-05-12.md usando dias 2024-05-12.
 ```
 
+Ao final de cada execução um CSV cumulativo é gravado em `metrics/enrichment_run.csv` com timestamps, contagem de itens relevantes/analisados, domínios envolvidos e erros encontrados. Esse arquivo é reutilizado pelo `UnifiedProcessor` e pelo `scripts/process_backlog.py` para emitir um resumo rápido.
+
 > **Dica:** Para pausar o módulo, defina `enabled = false` na seção `[enrichment]` do TOML.
 
 ## 4. Principais parâmetros (`[enrichment]`)
@@ -87,7 +89,12 @@ Saída esperada do processamento real (resumo):
 - **Tempo limite**: se muitos links falharem por timeout, aumente `max_total_enrichment_time` ou reduza `max_links`.
 - **Aproveite o cache**: mantenha o diretório `cache/` versionado para compartilhar resultados entre execuções e evitar custos repetidos.
 
-## 6. Próximos passos
+## 6. Checklist de revisão
+
+- `uv run pytest tests/test_enrichment.py`
+- `uv run pytest tests/test_rag_config_legacy.py`
+
+## 7. Próximos passos
 
 - Consulte `README.md` para visão geral do pipeline completo.
 - Leia `CONTENT_ENRICHMENT_DESIGN.md` para detalhes de arquitetura, trade-offs e roadmap.

--- a/example_enrichment.py
+++ b/example_enrichment.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Minimal enrichment run showcasing Gemini integration or the offline stub."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from egregora.config import EnrichmentConfig
+from egregora.enrichment import ContentEnricher
+
+
+class _OfflineModel:
+    def __init__(self) -> None:
+        payload = os.getenv(
+            "FAKE_GEMINI_RESPONSE",
+            json.dumps(
+                {
+                    "summary": "Resumo offline de exemplo para https://example.com.",
+                    "key_points": [
+                        "Demonstra fluxo sem depender da API.",
+                        "Resultados são determinísticos para testes.",
+                    ],
+                    "tone": "informativo",
+                    "relevance": 3,
+                },
+                ensure_ascii=False,
+            ),
+        )
+        self._payload = payload
+
+    def generate_content(self, model: str, contents: Any, config: Any) -> SimpleNamespace:
+        part = SimpleNamespace(text=self._payload)
+        content = SimpleNamespace(parts=[part])
+        candidate = SimpleNamespace(content=content)
+        return SimpleNamespace(text=self._payload, candidates=[candidate])
+
+
+class _OfflineClient:
+    def __init__(self) -> None:
+        self.models = _OfflineModel()
+
+
+def _ensure_types_stub() -> None:
+    import egregora.enrichment as enrichment_module
+
+    if enrichment_module.types is not None:
+        return
+
+    class _Part:
+        def __init__(self, text: str | None = None, file_uri: str | None = None) -> None:
+            self.text = text
+            self.file_uri = file_uri
+
+        @classmethod
+        def from_text(cls, text: str) -> "_Part":
+            return cls(text=text)
+
+        @classmethod
+        def from_uri(cls, file_uri: str) -> "_Part":
+            return cls(file_uri=file_uri)
+
+    class _Content:
+        def __init__(self, role: str, parts: list[_Part]) -> None:
+            self.role = role
+            self.parts = parts
+
+    class _GenerateContentConfig:
+        def __init__(self, *, temperature: float, response_mime_type: str) -> None:
+            self.temperature = temperature
+            self.response_mime_type = response_mime_type
+
+    enrichment_module.types = SimpleNamespace(
+        Part=_Part,
+        Content=_Content,
+        GenerateContentConfig=_GenerateContentConfig,
+    )
+
+
+def _build_client() -> Any:
+    api_key = (os.getenv("GEMINI_API_KEY") or "").strip()
+    if os.getenv("EGREGORA_ENRICHMENT_OFFLINE"):
+        print("⚠️ Modo offline forçado via EGREGORA_ENRICHMENT_OFFLINE.")
+        return _OfflineClient()
+    if not api_key:
+        print("⚠️ GEMINI_API_KEY ausente — executando em modo offline determinístico.")
+        return _OfflineClient()
+
+    try:
+        from google import genai  # type: ignore
+    except ModuleNotFoundError:
+        print("⚠️ Pacote google-genai indisponível — executando em modo offline determinístico.")
+        return _OfflineClient()
+
+    return genai.Client(api_key=api_key)
+
+
+async def _run_enrichment(client: Any, metrics_path: Path | None) -> int:
+    config = EnrichmentConfig(
+        enabled=True,
+        max_links=2,
+        relevance_threshold=2,
+        metrics_csv_path=metrics_path,
+    )
+    enricher = ContentEnricher(config)
+
+    transcript = "\n".join(
+        [
+            "09:00 - Alice: Olhem este artigo: https://example.com/guia",
+            "09:05 - Bob: Outro link bacana https://example.org/detalhes",
+        ]
+    )
+    result = await enricher.enrich([(date.today(), transcript)], client=client)
+    relevant = result.relevant_items(config.relevance_threshold)
+
+    if not relevant:
+        print("❌ Enriquecimento executado, mas nenhum item atingiu o limiar configurado.")
+        return 1
+
+    print(
+        "✅ {relevant}/{total} item(s) relevantes com duração de {duration:.2f}s.".format(
+            relevant=len(relevant),
+            total=len(result.items),
+            duration=result.duration_seconds,
+        )
+    )
+    prompt_section = result.format_for_prompt(config.relevance_threshold)
+    if prompt_section:
+        print("\n--- Seção pronta para o prompt ---")
+        print(prompt_section)
+
+    if result.metrics and config.metrics_csv_path:
+        print(f"\n📊 Métricas registradas em {config.metrics_csv_path}")
+
+    return 0
+
+
+def main() -> int:
+    _ensure_types_stub()
+    metrics_override = os.getenv("EGREGORA_METRICS_PATH")
+    metrics_path = Path(metrics_override) if metrics_override else Path("metrics/enrichment_run.csv")
+
+    try:
+        client = _build_client()
+        return asyncio.run(_run_enrichment(client, metrics_path))
+    except KeyboardInterrupt:
+        print("⚠️ Execução interrompida pelo usuário.")
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"❌ Falha ao executar o exemplo: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/process_backlog.py
+++ b/scripts/process_backlog.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Simple backlog processor - does the same job with 95% less code."""
 
+import csv
 import re
 import shutil
 import sys
@@ -54,14 +55,52 @@ def process_backlog(zip_dir: str, output_dir: str, force: bool = False):
     for slug, paths in sorted(results.items()):
         print(f"  • {slug}: {len(paths)} post(s)")
 
+    metrics_path = processor.config.enrichment.metrics_csv_path
+    if metrics_path:
+        latest = _load_latest_metrics(Path(metrics_path))
+        if latest:
+            print("\n📈 Último enriquecimento registrado:")
+            print(
+                "  - Início: {started_at} (duração {duration_seconds}s)".format(
+                    started_at=latest.get("started_at", "?"),
+                    duration_seconds=latest.get("duration_seconds", "?"),
+                )
+            )
+            print(
+                "  - Relevantes/Analisados: {relevant_items}/{analyzed_items} (limiar ≥{threshold})".format(
+                    relevant_items=latest.get("relevant_items", "0"),
+                    analyzed_items=latest.get("analyzed_items", "0"),
+                    threshold=latest.get("threshold", "?"),
+                )
+            )
+            domains = latest.get("domains") or "-"
+            print(f"  - Domínios: {domains}")
+            errors = latest.get("errors") or "-"
+            print(f"  - Erros: {errors}")
+
+
+def _load_latest_metrics(path: Path) -> dict[str, str] | None:
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+    except (OSError, csv.Error):
+        return None
+
+    if not rows:
+        return None
+    return rows[-1]
+
 
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Simple WhatsApp backlog processor")
     parser.add_argument("zip_dir", help="Directory containing ZIP files")
     parser.add_argument("output_dir", help="Output directory for posts")
     parser.add_argument("--force", action="store_true", help="Overwrite existing files")
-    
+
     args = parser.parse_args()
     process_backlog(args.zip_dir, args.output_dir, args.force)

--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -72,6 +72,16 @@ class EnrichmentConfig(BaseModel):
         ),
     )
     max_total_enrichment_time: float = 120.0
+    metrics_csv_path: Path | None = Field(
+        default_factory=lambda: Path("metrics/enrichment_run.csv")
+    )
+
+    @field_validator("metrics_csv_path", mode="before")
+    @classmethod
+    def _validate_metrics_path(cls, value: Any) -> Path | None:
+        if value is None or value == "":
+            return None
+        return Path(value)
 
 
 class AnonymizationConfig(BaseModel):

--- a/src/egregora/processor.py
+++ b/src/egregora/processor.py
@@ -396,6 +396,18 @@ class UnifiedProcessor:
                 enrichment_section = enrichment_result.format_for_prompt(
                     self.config.enrichment.relevance_threshold
                 )
+                metrics = enrichment_result.metrics
+                if metrics:
+                    domains = ", ".join(metrics.domains) if metrics.domains else "-"
+                    logger.info(
+                        "    [Enriquecimento] %d/%d itens relevantes (≥%d) em %.2fs; domínios=%s; erros=%d",
+                        metrics.relevant_items,
+                        metrics.analyzed_items,
+                        metrics.threshold,
+                        metrics.duration_seconds,
+                        domains,
+                        metrics.error_count,
+                    )
 
             # RAG
             rag_context = None

--- a/src/egregora/rag/config.py
+++ b/src/egregora/rag/config.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 _DEPRECATED_RAG_KEYS = {"use_gemini_embeddings"}
 
@@ -28,9 +36,10 @@ def _default_mcp_args() -> tuple[str, ...]:
     )
 
 
-@dataclass(slots=True)
-class RAGConfig:
+class RAGConfig(BaseModel):
     """Configuration for post retrieval powered by LlamaIndex."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
     enabled: bool = False
 
@@ -46,7 +55,7 @@ class RAGConfig:
     # MCP integration
     use_mcp: bool = True
     mcp_command: str = "uv"
-    mcp_args: tuple[str, ...] = field(default_factory=_default_mcp_args)
+    mcp_args: tuple[str, ...] = Field(default_factory=_default_mcp_args)
 
     # Chunking parameters (tokens)
     chunk_size: int = 1800
@@ -56,15 +65,91 @@ class RAGConfig:
     embedding_model: str = "models/gemini-embedding-001"
     embedding_dimension: int = 768
     enable_cache: bool = True
-    cache_dir: Path = field(default_factory=lambda: Path("cache/embeddings"))
+    cache_dir: Path = Field(default_factory=lambda: Path("cache/embeddings"))
     export_embeddings: bool = False
-    embedding_export_path: Path = field(
-        default_factory=lambda: Path("artifacts/embeddings/post_chunks.parquet")
-    )
+    embedding_export_path: Path = Field(
+        default_factory=lambda: Path("artifacts/embeddings/post_chunks.parquet"))
 
     # Vector store
     vector_store_type: str = "simple"
-    persist_dir: Path = field(default_factory=lambda: Path("cache/vector_store"))
+    persist_dir: Path = Field(default_factory=lambda: Path("cache/vector_store"))
     collection_name: str = "posts"
+
+    @field_validator("top_k", "max_keywords")
+    @classmethod
+    def _validate_positive_int(
+        cls, value: Any, info: ValidationInfo
+    ) -> int:
+        ivalue = int(value)
+        if ivalue < 1:
+            raise ValueError(f"{info.field_name} must be greater than zero")
+        return ivalue
+
+    @field_validator("exclude_recent_days")
+    @classmethod
+    def _validate_non_negative(cls, value: Any) -> int:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise ValueError("exclude_recent_days must be zero or a positive integer")
+        return ivalue
+
+    @field_validator("max_context_chars")
+    @classmethod
+    def _validate_context_chars(cls, value: Any) -> int:
+        ivalue = int(value)
+        if ivalue < 1:
+            raise ValueError("max_context_chars must be greater than zero")
+        return ivalue
+
+    @field_validator("min_similarity")
+    @classmethod
+    def _validate_similarity(cls, value: Any) -> float:
+        fvalue = float(value)
+        if not 0 <= fvalue <= 1:
+            raise ValueError("min_similarity must be between 0 and 1")
+        return fvalue
+
+    @field_validator("chunk_size")
+    @classmethod
+    def _validate_chunk_size(cls, value: Any) -> int:
+        ivalue = int(value)
+        if ivalue < 1:
+            raise ValueError("chunk_size must be greater than zero")
+        return ivalue
+
+    @field_validator("chunk_overlap")
+    @classmethod
+    def _validate_overlap(
+        cls, value: Any, _info: ValidationInfo
+    ) -> int:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise ValueError("chunk_overlap must be zero or positive")
+        return ivalue
+
+    @field_validator("embedding_dimension")
+    @classmethod
+    def _validate_embedding_dimension(cls, value: Any) -> int:
+        ivalue = int(value)
+        if ivalue < 1:
+            raise ValueError("embedding_dimension must be greater than zero")
+        return ivalue
+
+    @field_validator("cache_dir", "embedding_export_path", "persist_dir")
+    @classmethod
+    def _ensure_path(cls, value: Any) -> Path:
+        return Path(value)
+
+    @field_validator("mcp_args")
+    @classmethod
+    def _coerce_mcp_args(cls, value: Sequence[str]) -> tuple[str, ...]:
+        return tuple(str(item) for item in value)
+
+    @model_validator(mode="after")
+    def _validate_overlap_bounds(self) -> "RAGConfig":
+        if self.chunk_overlap >= self.chunk_size:
+            raise ValueError("chunk_overlap must be smaller than chunk_size")
+        return self
+
 
 __all__ = ["RAGConfig", "sanitize_rag_config_payload"]

--- a/tests/stubs/google/__init__.py
+++ b/tests/stubs/google/__init__.py
@@ -1,0 +1,1 @@
+# Stub package to satisfy example_enrichment smoke tests.

--- a/tests/stubs/google/genai/__init__.py
+++ b/tests/stubs/google/genai/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+from typing import Any
+
+from . import types
+
+
+class _FakeModel:
+    def __init__(self) -> None:
+        default_payload = json.dumps(
+            {
+                "summary": "Stubbed summary from fake Gemini client.",
+                "key_points": [
+                    "Resposta estática para validar integração.",
+                    "Utilize FAKE_GEMINI_RESPONSE para customizar.",
+                ],
+                "tone": "amigável",
+                "relevance": 3,
+            },
+            ensure_ascii=False,
+        )
+        self._payload = os.getenv("FAKE_GEMINI_RESPONSE", default_payload)
+
+    def generate_content(self, model: str, contents: Any, config: Any) -> SimpleNamespace:
+        part = types.Part.from_text(self._payload)
+        content = types.Content(role="user", parts=[part])
+        candidate = SimpleNamespace(content=content)
+        return SimpleNamespace(text=self._payload, candidates=[candidate])
+
+
+class Client:
+    def __init__(self, api_key: str | None = None, **_: Any) -> None:
+        self.api_key = api_key
+        self.models = _FakeModel()
+
+
+__all__ = ["Client", "types"]

--- a/tests/stubs/google/genai/types.py
+++ b/tests/stubs/google/genai/types.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Part:
+    text: str | None = None
+    file_uri: str | None = None
+
+    @classmethod
+    def from_text(cls, text: str) -> "Part":
+        return cls(text=text)
+
+    @classmethod
+    def from_uri(cls, file_uri: str) -> "Part":
+        return cls(file_uri=file_uri)
+
+
+@dataclass
+class Content:
+    role: str
+    parts: List[Part]
+
+
+@dataclass
+class GenerateContentConfig:
+    temperature: float
+    response_mime_type: str
+
+
+__all__ = ["Part", "Content", "GenerateContentConfig"]


### PR DESCRIPTION
## Summary
- instrument the enrichment pipeline to capture metrics, log structured summaries, and persist them to metrics/enrichment_run.csv
- add an offline-friendly example_enrichment.py script, reusable Gemini stubs, and dedicated smoke/integration tests exercising real transcripts and response parsing
- migrate RAGConfig to a pydantic BaseModel with clear validation errors and update documentation/README to surface the new metrics workflow and review checklist

## Testing
- `uv run python -m pytest tests/test_enrichment.py`
- `uv run python -m pytest tests/test_rag_config_legacy.py`


------
https://chatgpt.com/codex/tasks/task_e_68e5ed02dfb0832598901e4a8c321e55