### PR TITLE
Follow-up: Prevent backlog smoke test from creating Gemini client

### DIFF
--- a/tests/test_process_backlog_smoke.py
+++ b/tests/test_process_backlog_smoke.py
@@ -41,6 +41,10 @@ def test_process_backlog_generates_posts() -> None:
             side_effect=_offline_defaults,
         ),
         patch(
+            "egregora.generator.PostGenerator._create_client",
+            side_effect=AssertionError("Smoke test should not create an LLM client"),
+        ),
+        patch(
             "egregora.generator.PostGenerator.generate",
             return_value="## Post de teste\nConteúdo sintético.",
         ),


### PR DESCRIPTION
## Summary
- add pre-commit hooks and configure Black/Ruff/Isort/Pyupgrade along with project tool settings and the `egregora-mcp` console script
- hide untranslated English docs from the navigation, refresh README/Portuguese docs for the uv workflow, and ignore runtime cache outputs
- refactor `process_backlog` into a reusable summary, add a smoke test plus CI coverage, sort system filter fixtures, and adjust Polars helpers for compatibility while marking the TF-IDF search module as deprecated
- ensure the backlog smoke test stubs the Gemini client so it remains deterministic and offline-friendly

## Testing
- uv run --with pytest pytest tests/test_process_backlog_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68e663c3e31483259fa9d50222d0ae23