### PR TITLE
Ensure Codex review comment uses maintainer account

### DIFF
--- a/.github/workflows/pr-codex-review.yml
+++ b/.github/workflows/pr-codex-review.yml
@@ -14,13 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on new pull request
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN }}
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: '@codex code review',
-            });
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_REVIEW_TOKEN }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            -f body='@codex code review'

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The codebase targets Python 3.10+ and relies on `pydantic`, `typer`, and `rich` 
 
 ### CI workflows
 
-- `Request Codex Review`: Comments `@codex code review` on newly opened pull requests via the account associated with the personal access token stored in the `CODEX_REVIEW_TOKEN` repository secret. Set this secret with a classic PAT that has `public_repo` (or `repo` for private repos) scope so the comment is posted from a human-owned account instead of `github-actions`.
+- `Request Codex Review`: Comments `@codex code review` on newly opened pull requests via the account associated with the personal access token stored in the `CODEX_REVIEW_TOKEN` repository secret. The workflow authenticates the GitHub CLI with this token (via `GH_TOKEN`) before issuing the comment so it originates from a human-owned account rather than `github-actions`. Use a classic PAT with `public_repo` (or `repo` for private repos) scope.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update the Codex review workflow to authenticate with the CODEX_REVIEW_TOKEN personal access token so comments originate from a user account
- document the new secret requirement in the README for CI configuration

## Testing
- not run (documentation and workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e6661b62ec8325b7a06fea5a1bed69