### PR TITLE
Add default keyword stop words to RAG config

### DIFF
--- a/src/egregora/rag/config.py
+++ b/src/egregora/rag/config.py
@@ -17,6 +17,28 @@ from pydantic import (
 _DEPRECATED_RAG_KEYS = {"use_gemini_embeddings"}
 
 
+def _default_keyword_stop_words() -> tuple[str, ...]:
+    return (
+        "about",
+        "and",
+        "are",
+        "but",
+        "com",
+        "for",
+        "from",
+        "http",
+        "https",
+        "not",
+        "that",
+        "the",
+        "this",
+        "was",
+        "were",
+        "with",
+        "you",
+    )
+
+
 def sanitize_rag_config_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Return ``payload`` without deprecated configuration keys."""
 
@@ -51,6 +73,9 @@ class RAGConfig(BaseModel):
     # Query generation helpers
     max_context_chars: int = 1200
     max_keywords: int = 8
+    keyword_stop_words: tuple[str, ...] | None = Field(
+        default_factory=_default_keyword_stop_words
+    )
     classifier_max_llm_calls: int | None = 200
     classifier_token_budget: int | None = 20000
 
@@ -146,6 +171,15 @@ class RAGConfig(BaseModel):
     @classmethod
     def _coerce_mcp_args(cls, value: Sequence[str]) -> tuple[str, ...]:
         return tuple(str(item) for item in value)
+
+    @field_validator("keyword_stop_words")
+    @classmethod
+    def _coerce_stop_words(
+        cls, value: Sequence[str] | None
+    ) -> tuple[str, ...] | None:
+        if value is None:
+            return None
+        return tuple(str(item).lower() for item in value if item)
 
     @model_validator(mode="after")
     def _validate_overlap_bounds(self) -> "RAGConfig":


### PR DESCRIPTION
## Summary
- add a default keyword stop-word list to `RAGConfig` so query generation can build its extractor
- normalise any supplied stop-word sequences to lowercase tuples during validation

## Testing
- `uv run pytest tests/test_rag_integration.py -k rag` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e663c4b1508325942de3b266def936