### PR TITLE
Adjust enrichment tests for new AnalysisResult schema

### DIFF
--- a/example_enrichment.py
+++ b/example_enrichment.py
@@ -23,11 +23,16 @@ class _OfflineModel:
             json.dumps(
                 {
                     "summary": "Resumo offline de exemplo para https://example.com.",
-                    "key_points": [
+                    "topics": [
                         "Demonstra fluxo sem depender da API.",
                         "Resultados são determinísticos para testes.",
                     ],
-                    "tone": "informativo",
+                    "actions": [
+                        {
+                            "description": "Compartilhar insights com o time",
+                            "owner": "time",
+                        }
+                    ],
                     "relevance": 3,
                 },
                 ensure_ascii=False,

--- a/tests/stubs/google/genai/__init__.py
+++ b/tests/stubs/google/genai/__init__.py
@@ -13,11 +13,16 @@ class _FakeModel:
         default_payload = json.dumps(
             {
                 "summary": "Stubbed summary from fake Gemini client.",
-                "key_points": [
+                "topics": [
                     "Resposta estática para validar integração.",
                     "Utilize FAKE_GEMINI_RESPONSE para customizar.",
                 ],
-                "tone": "amigável",
+                "actions": [
+                    {
+                        "description": "Revisar conteúdo compartilhado",
+                        "owner": "time",
+                    }
+                ],
                 "relevance": 3,
             },
             ensure_ascii=False,

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -19,8 +19,13 @@ def _build_analysis(model: str = "gemini-test") -> dict[str, object]:
         "analyzed_at": timestamp,
         "enrichment": {
             "summary": "Resumo de teste",
-            "key_points": ["um", "dois"],
-            "tone": "informativo",
+            "topics": ["um", "dois"],
+            "actions": [
+                {
+                    "description": "Compartilhar com a equipe",
+                    "owner": "Alice",
+                }
+            ],
             "relevance": 4,
             "raw_response": "{}",
         },

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -372,8 +372,13 @@ def test_example_enrichment_script_runs_with_stub(tmp_path):
     env["FAKE_GEMINI_RESPONSE"] = json.dumps(
         {
             "summary": "Smoke test response",
-            "key_points": ["Ponto 1"],
-            "tone": "claro",
+            "topics": ["Ponto 1"],
+            "actions": [
+                {
+                    "description": "Revisar notas compartilhadas",
+                    "owner": "time",
+                }
+            ],
             "relevance": 3,
         },
         ensure_ascii=False,


### PR DESCRIPTION
## Summary
- update the enrichment test fixtures and offline stubs to emit topics/actions instead of legacy key_points/tone fields
- refresh the cache manager tests to match the AnalysisResult topics/actions structure

## Testing
- not run (environment missing optional dependency `pydantic`)


------
https://chatgpt.com/codex/tasks/task_e_68e66fc073b083258f891e95f905f6f5