### PR TITLE
Preserve group index history across incremental runs

### DIFF
--- a/src/egregora/processor.py
+++ b/src/egregora/processor.py
@@ -279,8 +279,22 @@ class UnifiedProcessor:
         }
         front_matter = yaml.safe_dump(metadata, sort_keys=False, allow_unicode=True).strip()
 
+        # Merge existing posts on disk with the ones produced in this run so the
+        # index remains cumulative when processing a limited window of days.
+        all_posts: set[Path] = set()
+
+        daily_dir = group_dir / "posts" / "daily"
+        if daily_dir.exists():
+            all_posts.update(
+                path
+                for path in daily_dir.glob("*.md")
+                if path.is_file()
+            )
+
+        all_posts.update(post_paths)
+
         items: list[str] = []
-        for path in sorted(post_paths, key=lambda p: p.stem, reverse=True):
+        for path in sorted(all_posts, key=lambda p: p.stem, reverse=True):
             try:
                 relative = path.relative_to(group_dir)
             except ValueError:


### PR DESCRIPTION
## Summary
- merge existing daily markdown posts with the newly generated ones when rendering a group index so older editions remain listed

## Testing
- not run (dependency environment missing pydantic in base PR)

------
https://chatgpt.com/codex/tasks/task_e_68e69833602083259f152598c6fbf236