### PR TITLE
Improve pipeline merge validation and WhatsApp date parsing

### DIFF
--- a/src/egregora/models.py
+++ b/src/egregora/models.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Literal
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from .types import GroupSlug
 
@@ -22,15 +24,50 @@ class WhatsAppExport:
     media_files: list[str]  # ["IMG-001.jpg", ...]
 
 
-@dataclass(slots=True)
-class MergeConfig:
+class MergeConfig(BaseModel):
     """Configuration for merging multiple groups into a virtual group."""
 
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
     name: str  # "RC Americas"
-    source_groups: list[GroupSlug]  # ["rc-latam", "rc-brasil"]
+    source_groups: list[GroupSlug] = Field(
+        ...,
+        validation_alias=AliasChoices("source_groups", "groups"),
+        min_length=1,
+    )
     tag_style: Literal["emoji", "brackets", "prefix"] = "emoji"
-    group_emojis: dict[GroupSlug, str] = field(default_factory=dict)  # {"rc-latam": "🌎"}
-    model_override: str | None = None
+    group_emojis: dict[GroupSlug, str] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices("group_emojis", "emojis"),
+    )
+    model_override: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("model_override", "model"),
+    )
+
+    @field_validator("source_groups", mode="before")
+    @classmethod
+    def _coerce_source_groups(cls, value: object) -> list[GroupSlug]:
+        if isinstance(value, list):
+            coerced = [GroupSlug(str(item)) for item in value]
+            if not coerced:
+                msg = "Merge configuration must include at least one source group"
+                raise ValueError(msg)
+            return coerced
+        msg = "source_groups must be provided as a list of strings"
+        raise ValueError(msg)
+
+    @field_validator("group_emojis", mode="before")
+    @classmethod
+    def _coerce_group_emojis(
+        cls, value: object
+    ) -> dict[GroupSlug, str]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            msg = "group_emojis must be a mapping of group slug to emoji"
+            raise ValueError(msg)
+        return {GroupSlug(str(key)): str(val) for key, val in value.items()}
 
 
 @dataclass(slots=True)

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+import pytest
+
+from egregora.date_utils import parse_flexible_date
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("01/05/2024", date(2024, 5, 1)),
+        ("5/1/2024", date(2024, 1, 5)),
+        ("2024-05-01", date(2024, 5, 1)),
+    ],
+)
+def test_parse_flexible_date_accepts_multiple_formats(
+    token: str, expected: date
+) -> None:
+    assert parse_flexible_date(token) == expected
+
+
+def test_parse_flexible_date_handles_timezones() -> None:
+    token = "2024-05-01T00:30:00-03:00"
+    assert parse_flexible_date(token) == date(2024, 5, 1)
+
+
+def test_parse_flexible_date_without_timezone_assumption() -> None:
+    token = "2024-05-01 03:00"
+    assert parse_flexible_date(token, assume_tz_utc=False) == date(2024, 5, 1)
+
+
+def test_parse_flexible_date_returns_none_for_blank_strings() -> None:
+    assert parse_flexible_date("   ") is None
+
+
+def test_parse_flexible_date_returns_none_for_invalid_tokens() -> None:
+    assert parse_flexible_date("not a date") is None

--- a/tests/test_merge_config.py
+++ b/tests/test_merge_config.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from egregora.models import MergeConfig
+from egregora.types import GroupSlug
+
+
+def test_merge_config_accepts_aliases() -> None:
+    config = MergeConfig(
+        name="Virtual",
+        groups=["group-a", "group-b"],
+        emojis={"group-a": "😀"},
+        tag_style="prefix",
+        model="gemini-pro",
+    )
+
+    assert config.source_groups == [GroupSlug("group-a"), GroupSlug("group-b")]
+    assert config.group_emojis == {GroupSlug("group-a"): "😀"}
+    assert config.model_override == "gemini-pro"
+
+
+def test_merge_config_requires_source_groups() -> None:
+    with pytest.raises(ValidationError):
+        MergeConfig(name="Virtual", groups=[])
+
+
+def test_merge_config_rejects_invalid_tag_style() -> None:
+    with pytest.raises(ValidationError):
+        MergeConfig(name="Virtual", groups=["group-a"], tag_style="unknown")
+
+
+def test_merge_config_rejects_invalid_emoji_mapping() -> None:
+    with pytest.raises(ValidationError):
+        MergeConfig(name="Virtual", groups=["group-a"], emojis=["😀"])


### PR DESCRIPTION
## Summary
- migrate `MergeConfig` to a Pydantic model so pipeline merge validation benefits from structured defaults and clearer error messages
- reuse the new model inside `PipelineConfig` to surface detailed validation errors when merges are misconfigured
- tighten WhatsApp date parsing by delegating to `python-dateutil`'s ISO parser and add regression tests for multiple formats and time zones

## Testing
- uv run pytest tests/test_merge_config.py tests/test_date_utils.py tests/test_security_guards.py::test_pipeline_config_from_toml_validates_merges

------
https://chatgpt.com/codex/tasks/task_e_68e6b913867883258373417cb392b47b