### PR TITLE
Enable Gemini-based RAG embeddings export in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,43 @@ jobs:
         run: |
           uv run python scripts/process_backlog.py tests/data/zips ./_tmp_posts --force --offline --quiet
           test -d ./_tmp_posts
+      - name: Build RAG embeddings artifact
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+          import shutil
+
+          from egregora.config import PipelineConfig
+          from egregora.rag.index import PostRAG
+
+          pipeline_config = PipelineConfig.from_toml(Path("egregora.toml"))
+          rag_config = pipeline_config.rag
+
+          source_posts = Path("tests/data/rag_posts")
+          cache_root = Path("cache/rag_ci")
+          posts_dir = cache_root / "posts"
+
+          if posts_dir.exists():
+              shutil.rmtree(posts_dir)
+
+          for group_dir in source_posts.iterdir():
+              if not group_dir.is_dir():
+                  continue
+              daily_dir = group_dir / "daily"
+              if not daily_dir.is_dir():
+                  continue
+              target_daily = posts_dir / group_dir.name / "posts" / "daily"
+              target_daily.mkdir(parents=True, exist_ok=True)
+              for markdown in daily_dir.glob("*.md"):
+                  shutil.copy2(markdown, target_daily / markdown.name)
+
+          rag = PostRAG(posts_dir=posts_dir, config=rag_config, cache_dir=cache_root)
+          result = rag.update_index(force_rebuild=True)
+          print(f"Generated {result.get('embedding_rows', 0)} embedding rows at {result.get('embedding_export_path')}")
+          PY
+      - name: Upload RAG embeddings artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rag-post-embeddings
+          path: artifacts/embeddings/post_chunks.parquet
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ data/
 !src/egregora/data/**
 !tests/data/
 !tests/data/**
-egregora.toml
+!egregora.toml
 *.zip:Zone.Identifier
 
 # Test output

--- a/egregora.toml
+++ b/egregora.toml
@@ -1,0 +1,12 @@
+# Configuração padrão do Egregora usada em desenvolvimento e CI.
+# Ajuste os caminhos conforme necessário para o seu ambiente local.
+
+[directories]
+zips_dir = "data/whatsapp_zips"
+posts_dir = "data"
+
+[rag]
+enabled = true
+embedding_model = "models/gemini-embedding-001"
+export_embeddings = true
+embedding_export_path = "artifacts/embeddings/post_chunks.parquet"


### PR DESCRIPTION
## Summary
- create a tracked `egregora.toml` that enables the RAG stack with the Gemini embedding model and exports embeddings to the shared Parquet path so local runs and CI share the same defaults
- adjust the ignore rules so that the committed configuration file is shipped with the repository while keeping generated artifacts ignored
- extend the CI workflow to materialise the sample post index, rebuild the Gemini-backed embeddings, and publish the resulting Parquet file as a reusable artifact for downstream jobs

## Testing
- uv run python - <<'PY'
from pathlib import Path
import shutil

from egregora.config import PipelineConfig
from egregora.rag.index import PostRAG

pipeline_config = PipelineConfig.from_toml(Path("egregora.toml"))
rag_config = pipeline_config.rag

source_posts = Path("tests/data/rag_posts")
cache_root = Path("cache/rag_ci")
posts_dir = cache_root / "posts"

if posts_dir.exists():
    shutil.rmtree(posts_dir)

for group_dir in source_posts.iterdir():
    if not group_dir.is_dir():
        continue
    daily_dir = group_dir / "daily"
    if not daily_dir.is_dir():
        continue
    target_daily = posts_dir / group_dir.name / "posts" / "daily"
    target_daily.mkdir(parents=True, exist_ok=True)
    for markdown in daily_dir.glob("*.md"):
        shutil.copy2(markdown, target_daily / markdown.name)

rag = PostRAG(posts_dir=posts_dir, config=rag_config, cache_dir=cache_root)
result = rag.update_index(force_rebuild=True)
print(result)
print((rag_config.embedding_export_path).resolve())
PY

------
https://chatgpt.com/codex/tasks/task_e_68e6b9494ea883259b05f04750a4eeb3