### PR TITLE
Atualizar status de embeddings do Gemini para RAG no guia de enriquecimento

### DIFF
--- a/docs/pt-BR/developer-guide/CONTENT_ENRICHMENT_DESIGN.md
+++ b/docs/pt-BR/developer-guide/CONTENT_ENRICHMENT_DESIGN.md
@@ -117,10 +117,11 @@ Adicionar ao Egregora uma etapa opcional de **enriquecimento de conteúdos** que
 5. **Banco de conhecimento (RAG)** — integração completa em `src/egregora/rag/` e MCP server dedicado.
 6. **MCP Server** — servidor disponível em `src/egregora/mcp_server/` para Claude e outras ferramentas.
 7. **Respostas tipadas + métricas** — `SummaryResponse/ActionItem` validados com `pydanticai`, métricas (`llm_calls`, `estimated_tokens`, `cache_hits`, `cache_misses`) expostas em `ContentEnricher.metrics`.
+8. **Embeddings do Gemini para RAG** — migração do índice TF-IDF para o modelo `gemini-embedding-001` com cache de embeddings.
 
 ### 🔄 Em desenvolvimento
 
-1. **Embeddings do Gemini para RAG** — migração do índice TF-IDF para o modelo `gemini-embedding-001` com cache de embeddings.
+Nenhum item no momento.
 
 ### ❌ Não planejado
 


### PR DESCRIPTION
## Summary
- mover o item de "Embeddings do Gemini para RAG" para a lista de entregas concluídas do design de enriquecimento de conteúdo
- indicar explicitamente que não há itens em andamento na seção de status para evitar ambiguidade

## Testing
- not run (documentação)

------
https://chatgpt.com/codex/tasks/task_e_68e705cd01148325bd5346e8bcc0ed2e