### PR TITLE
Resolve pyproject dependency conflict when adopting firebase branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "polars>=0.20",
     "typer>=0.12.0",
     "rich>=13.7.0",
-<<<<<<< HEAD
-    "diskcache>=5.6",
+    "diskcache>=5.6.0",
     "python-dateutil>=2.9",
     "pydantic>=2.6",
     "pydantic-settings>=2.1",
@@ -36,9 +35,6 @@ docs = [
     "mkdocs-static-i18n>=1.2",
     "python-dateutil>=2.9",
     "pymdown-extensions>=10.0",
-=======
-    "diskcache>=5.6.0",
->>>>>>> refactor/phase1-foundation
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- replace the lingering merge conflict markers in `pyproject.toml` left from the firebase merge
- keep the newer dependency additions from the work branch while honoring the firebase requirement for `diskcache>=5.6.0`
- ensure the dependency list now reflects the intended unified state of both branches so future merges stay clean

## Testing
- not run (dependency list edit only)


------
https://chatgpt.com/codex/tasks/task_e_68e72c5766048325b5e49a176bfec5f5