### PR TITLE
Harden enrichment URL hygiene and MCP error reporting

### DIFF
--- a/src/egregora/mcp_server/server.py
+++ b/src/egregora/mcp_server/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -88,6 +89,9 @@ else:  # pragma: no cover - fallback when dependency missing
 
 
 DEFAULT_KEYWORD_MODEL = "gemini-2.0-flash-exp"
+
+
+logger = logging.getLogger(__name__)
 
 
 class RAGServer:
@@ -409,8 +413,17 @@ async def handle_call_tool(  # noqa: PLR0911
             return [TextContent(type="text", text="\n".join(lines))]
 
         return [TextContent(type="text", text=f"Tool desconhecida: {name}")]
-    except Exception as exc:  # pragma: no cover - defensive logging
-        return [TextContent(type="text", text=f"Erro ao executar tool: {exc}")]
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Erro interno ao executar a tool %s", name)
+        return [
+            TextContent(
+                type="text",
+                text=(
+                    "Erro interno ao executar a ferramenta. "
+                    "Verifique os logs do servidor para mais detalhes."
+                ),
+            )
+        ]
 
 
 @read_resource()


### PR DESCRIPTION
## Summary
- hash and redact URL credentials before caching or logging enrichment references to avoid exposing secrets
- factor the enrichment dataframe preparation into smaller helpers and replace magic numbers with named constants for readability and configurability
- sanitize MCP tool failures by logging details server-side while returning a generic client-facing error message

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e73004a3008325b9002e9d3485f580