### PR TITLE
Fix RAG config normalization regression

### DIFF
--- a/src/egregora/config.py
+++ b/src/egregora/config.py
@@ -357,7 +357,7 @@ class PipelineTomlSettingsSource(TomlConfigSettingsSource):
 
         rag_section = raw.get("rag")
         if isinstance(rag_section, Mapping):
-            payload["rag"] = dict(rag_section)
+            payload["rag"] = sanitize_rag_config_payload(rag_section)
         elif rag_section is not None:
             payload["rag"] = rag_section
 


### PR DESCRIPTION
## Summary
- restore `sanitize_rag_config_payload` when loading `[rag]` settings from `egregora.toml`
- ensure legacy key aliases and type coercions continue to work for existing configurations

## Testing
- not run (reason: not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8516cf5a08325a453e5598cab95fc