### PR TITLE
Add backlog issues for cleanup, docs, and developer experience

### DIFF
--- a/dev/issues/014-consolidate-legacy-pipeline.md
+++ b/dev/issues/014-consolidate-legacy-pipeline.md
@@ -1,0 +1,35 @@
+# Issue #014: Consolidate and Deprecate Legacy `pipeline.py` Module
+
+- **Status**: Proposed
+- **Type**: Refactoring / Technical Debt
+- **Priority**: High
+- **Effort**: Medium
+
+## Problem
+
+The new, DataFrame-native `UnifiedProcessor` in `src/egregora/processor.py` is the path forward documented in ADR-006. The legacy `src/egregora/pipeline.py` module still contains helpers such as `_prepare_transcripts` and `build_llm_input`, creating two overlapping sources of truth for the processing pipeline.
+
+The coexistence of both paths increases maintenance overhead, makes the call graph harder to trace, and creates confusion for contributors who are trying to understand which module should be extended.
+
+## Proposal
+
+1. **Audit `pipeline.py`.** Document every function and classify it as:
+   - Still used by `UnifiedProcessor` (needs a new home).
+   - Obsolete/dead code (ready for deprecation and removal).
+   - Generic helper that should live in a shared utilities module.
+2. **Relocate live helpers.** Move the functions still required by `UnifiedProcessor` into more appropriate modules. For example, transcript munging helpers could become private functions on `UnifiedProcessor` or move into a new `egregora/transcript_utils.py` module, while general-purpose utilities could live under `egregora/utils.py`.
+3. **Add deprecation warnings.** For any remaining legacy entry points that cannot yet be removed, emit `DeprecationWarning` with guidance that developers should migrate to `UnifiedProcessor`.
+4. **Update call sites and tests.** Ensure all callers use the new locations, update imports, and adjust tests accordingly.
+5. **Plan removal.** Once no internal callers rely on `pipeline.py`, delete the module to prevent regressions.
+
+## Expected Benefits
+
+- Eliminates duplicated logic and conflicting abstractions.
+- Establishes `UnifiedProcessor` as the single source of truth for pipeline behavior.
+- Makes onboarding easier by reducing the amount of historical context required.
+- Aligns the codebase with the architecture decisions captured in ADR-006.
+
+## Dependencies
+
+- Understanding of the refactor captured in ADR-006 and how existing commands rely on `UnifiedProcessor`.
+- Coordination with any work that still depends on the legacy pipeline, to avoid breaking users mid-transition.

--- a/dev/issues/015-optional-dependency-groups.md
+++ b/dev/issues/015-optional-dependency-groups.md
@@ -1,0 +1,27 @@
+# Issue #015: Define Formal Optional Dependency Groups
+
+- **Status**: Proposed
+- **Type**: Enhancement / Dependency Management
+- **Priority**: Medium
+- **Effort**: Low
+
+## Problem
+
+`pyproject.toml` currently lists optional tooling (RAG, MCP server, documentation site builders, remote sync utilities) alongside the core runtime dependencies. Contributors installing the project for CLI experimentation must pull in heavyweight extras like `chromadb`, `llama-index-*`, and `mkdocs-*`, and the code does not always provide clear guidance when these optional modules are missing.
+
+## Proposal
+
+1. **Restructure dependency metadata.** Move feature-specific requirements into `[project.optional-dependencies]` groups such as `remote`, `rag`, `mcp`, and expand the existing `docs` extra.
+2. **Improve runtime messaging.** Harden the `try/except ImportError` blocks so users see actionable instructions (e.g., `pip install egregora[rag]`) whenever they invoke a feature whose dependencies are not installed.
+3. **Document installation paths.** Update `README.md` and `docs/developer-guide/index.md` (and any other relevant pages) with examples that demonstrate installing with extras.
+
+## Expected Benefits
+
+- Reduces the default installation footprint.
+- Makes the feature boundaries explicit to both users and maintainers.
+- Provides friendlier UX when optional dependencies are missing.
+
+## Dependencies
+
+- Minor updates to `pyproject.toml` and potentially `uv.lock`.
+- Coordination with documentation maintainers to keep installation instructions consistent across locales.

--- a/dev/issues/016-english-docs-translation.md
+++ b/dev/issues/016-english-docs-translation.md
@@ -1,0 +1,28 @@
+# Issue #016: Complete English Documentation Translation
+
+- **Status**: Proposed
+- **Type**: Documentation
+- **Priority**: High
+- **Effort**: High
+
+## Problem
+
+The documentation structure is bilingual, but most `docs/en/` pages simply redirect to the Portuguese content. English-speaking users and potential contributors cannot rely on the documentation to understand installation, configuration, or the roadmap, which limits the community reach of the project.
+
+## Proposal
+
+1. **Create a translation tracking plan.** Either open a project board or add a checklist to this issue to enumerate all pages that need translation.
+2. **Prioritize critical paths.** Translate the README, quickstart, and user guide first, followed by the developer guide and configuration references. Less critical historical documents (e.g., ADRs) can follow later.
+3. **Establish a maintenance workflow.** Whenever new Portuguese content ships, add a stub in the English tree noting that translation is pending. Encourage contributions by labeling these tasks appropriately.
+4. **Encourage community involvement.** Advertise the translation needs in contributor docs and issue labels (e.g., `help wanted`, `good first issue`).
+
+## Expected Benefits
+
+- Makes the project accessible to a global audience.
+- Improves perceived polish and professionalism.
+- Reduces friction for contributors who are more comfortable in English.
+
+## Dependencies
+
+- Coordination with maintainers to review translated content for accuracy.
+- Potential automation (e.g., mkdocs plugins) to help detect untranslated pages in the future.

--- a/dev/issues/017-init-setup-wizard.md
+++ b/dev/issues/017-init-setup-wizard.md
@@ -1,0 +1,29 @@
+# Issue #017: Implement `egregora init` Interactive Setup Wizard
+
+- **Status**: Proposed
+- **Type**: UX Enhancement
+- **Priority**: High
+- **Effort**: Medium
+
+## Problem
+
+New users currently bootstrap their configuration by copying `egregora.toml.example` and manually pruning it. The file is long, covers advanced scenarios, and is intimidating for first runs. This friction was captured in `dev/issues/002-configuration-ux.md`, and there is still no streamlined path to generate a minimal configuration.
+
+## Proposal
+
+1. **Add a Typer command.** Introduce `egregora init`, using `typer` for prompts and `rich` for friendly output.
+2. **Guide through essentials.** Ask for the minimum viable configuration: WhatsApp ZIP directory, output posts directory, and optional Gemini API key (with a `--demo-mode` flag to skip).
+3. **Generate a trimmed config.** Write a minimal `egregora.toml` with comments pointing to the example file for advanced options.
+4. **Document the workflow.** Update the quickstart and configuration docs to highlight the wizard.
+5. **Future-proof.** Structure the command so additional questions can be toggled on with a `--advanced` flag later.
+
+## Expected Benefits
+
+- Lowers the barrier to the first successful run.
+- Reduces manual editing errors in configuration files.
+- Reinforces the onboarding narrative established in the developer UX issue.
+
+## Dependencies
+
+- Requires alignment with planned demo mode work (issue #001) to ensure consistent messaging.
+- Any telemetry or analytics decisions should account for configuration defaults created by the wizard.

--- a/dev/issues/018-test-coverage-reporting.md
+++ b/dev/issues/018-test-coverage-reporting.md
@@ -1,0 +1,28 @@
+# Issue #018: Add Test Coverage Reporting to CI
+
+- **Status**: Proposed
+- **Type**: Developer Experience
+- **Priority**: Medium
+- **Effort**: Low
+
+## Problem
+
+Although the project has an established pytest suite, the CI workflow does not publish coverage metrics. Without visibility into coverage trends, it is difficult to judge how well critical code paths are protected when reviewing pull requests.
+
+## Proposal
+
+1. **Introduce coverage tooling.** Add `pytest-cov` as a development dependency and ensure it is available in the CI environment.
+2. **Update GitHub Actions.** Modify `.github/workflows/ci.yml` to run `uv run --with pytest pytest --cov=src/egregora --cov-report=xml` so the pipeline produces a coverage report.
+3. **Publish metrics.** Optionally integrate with Codecov or Coveralls by uploading `coverage.xml`, and add a badge to the README for quick visibility.
+4. **Document expectations.** Note in the contributor guide that significant features should maintain or improve coverage.
+
+## Expected Benefits
+
+- Gives reviewers quantifiable insight into test completeness.
+- Encourages contributors to add or extend tests.
+- Helps identify untested modules for future work.
+
+## Dependencies
+
+- Minor updates to `pyproject.toml`/`uv.lock`.
+- Credentials or configuration for the chosen coverage reporting service (if any).

--- a/dev/issues/019-consolidate-test-suite.md
+++ b/dev/issues/019-consolidate-test-suite.md
@@ -1,0 +1,28 @@
+# Issue #019: Consolidate Test Suite and Remove `run_all_tests.py`
+
+- **Status**: Proposed
+- **Type**: Cleanup / Developer Experience
+- **Priority**: Low
+- **Effort**: Low
+
+## Problem
+
+A custom `run_all_tests.py` script duplicates functionality that `pytest` already provides and adds an extra layer for contributors to learn. Some test modules (e.g., `test_enrichment_simple.py`) overlap with more complete suites, suggesting that the test organization could be simplified.
+
+## Proposal
+
+1. **Standardize on pytest.** Ensure every test can be invoked via `uv run pytest` without relying on helper scripts.
+2. **Merge redundant tests.** Fold the "simple" test modules into their comprehensive counterparts to reduce duplication.
+3. **Remove the script.** Delete `run_all_tests.py` once the suite runs cleanly with standard tooling.
+4. **Update documentation.** Reflect the change in `TESTING_PLAN.md`, contributor docs, and any onboarding materials.
+
+## Expected Benefits
+
+- Aligns the project with common Python testing practices.
+- Reduces maintenance overhead for custom tooling.
+- Makes it easier for new contributors to run the suite.
+
+## Dependencies
+
+- Confirmation that CI and local developer workflows already use `pytest`.
+- Coordination with any tooling that invokes `run_all_tests.py` directly (e.g., IDE configurations).


### PR DESCRIPTION
## Summary
- add Issue #014 to drive consolidation and deprecation of the legacy pipeline module
- document Issue #015 to define optional dependency groups and clarify installation paths
- add Issues #016-#019 to capture documentation, onboarding, coverage, and testing cleanup work

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e85863216c8325b94264de0bab7a34