### PR TITLE
Fix lint dependency sync and guard issue state conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install uv
         run: pip install uv
       - name: Sync dependencies
-        run: uv sync --extra docs --extra lint
-        run: uv sync --extra docs --extra test
+        run: uv sync --extra docs --extra lint --extra test
       - name: Lint Markdown
         run: |
           set -o errexit

--- a/scripts/issue_sync.py
+++ b/scripts/issue_sync.py
@@ -12,6 +12,7 @@ Synchronization strategy
 
   - ``github_issue`` – GitHub issue number associated with the file.
   - ``github_state`` – ``open`` or ``closed``.
+  - ``github_state_synced`` – last GitHub state seen during synchronization.
   - ``last_synced`` – timestamp of the last synchronization (ISO 8601).
   - ``sync_hash`` – SHA-256 hash of the Markdown body at last synchronization.
 
@@ -52,7 +53,13 @@ from urllib import error, request
 
 
 ISSUES_DIR_DEFAULT = Path("dev/issues")
-METADATA_ORDER = ("github_issue", "github_state", "last_synced", "sync_hash")
+METADATA_ORDER = (
+    "github_issue",
+    "github_state",
+    "github_state_synced",
+    "last_synced",
+    "sync_hash",
+)
 
 LOGGER = logging.getLogger("egregora.issue_sync")
 
@@ -98,6 +105,10 @@ def slugify(text: str, *, fallback: str = "issue") -> str:
 
 def compute_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def normalize_state(value: str | None) -> str:
+    return "closed" if str(value or "open").lower() == "closed" else "open"
 
 
 def read_metadata(text: str) -> tuple[dict[str, str], str]:
@@ -201,6 +212,7 @@ class LocalIssue:
     header_line: str
     title: str
     desired_state: str
+    synced_state: str
     issue_number: int | None
     local_identifier: str | None
     last_synced: datetime | None
@@ -214,8 +226,7 @@ class LocalIssue:
 
     @property
     def stored_state(self) -> str:
-        state = self.metadata.get("github_state", "open").lower()
-        return "closed" if state == "closed" else "open"
+        return normalize_state(self.metadata.get("github_state"))
 
 
 def load_local_issues(directory: Path) -> list[LocalIssue]:
@@ -236,7 +247,10 @@ def load_local_issues(directory: Path) -> list[LocalIssue]:
             header_line = "# Untitled issue"
         title = extract_title(header_line)
         identifier = extract_local_identifier(header_line)
-        desired_state = metadata.get("github_state", "open").lower()
+        desired_state = normalize_state(metadata.get("github_state"))
+        synced_state = normalize_state(
+            metadata.get("github_state_synced") or metadata.get("github_state")
+        )
         issue_number = None
         raw_number = metadata.get("github_issue")
         if raw_number:
@@ -256,7 +270,8 @@ def load_local_issues(directory: Path) -> list[LocalIssue]:
                 content_hash=compute_hash(body),
                 header_line=header_line,
                 title=title,
-                desired_state="closed" if desired_state == "closed" else "open",
+                desired_state=desired_state,
+                synced_state=synced_state,
                 issue_number=issue_number,
                 local_identifier=identifier,
                 last_synced=last_synced,
@@ -363,6 +378,7 @@ def parse_remote_content(
 def write_issue_file(issue: LocalIssue) -> None:
     metadata = issue.metadata.copy()
     metadata["github_state"] = issue.desired_state
+    metadata["github_state_synced"] = issue.synced_state
     if issue.issue_number is not None:
         metadata["github_issue"] = str(issue.issue_number)
     if issue.last_synced is not None:
@@ -420,6 +436,8 @@ def create_local_issue_from_remote(
     content = parse_remote_content(remote)
     remote_body_updated = get_remote_body_update_time(remote, token=token)
 
+    remote_state = normalize_state(remote.get("state"))
+
     issue = LocalIssue(
         path=path,
         metadata={"github_issue": str(remote["number"]), "github_state": remote["state"]},
@@ -427,7 +445,8 @@ def create_local_issue_from_remote(
         content_hash=compute_hash(content),
         header_line=content.splitlines()[0],
         title=extract_title(content.splitlines()[0]),
-        desired_state=remote["state"],
+        desired_state=remote_state,
+        synced_state=remote_state,
         issue_number=int(remote["number"]),
         local_identifier=extract_local_identifier(content.splitlines()[0]),
         last_synced=remote_body_updated,
@@ -478,12 +497,13 @@ def update_remote_issue(
     *,
     title: str,
     body: str,
-    state: str,
+    state: str | None = None,
 ) -> dict:
     url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
     payload = {"title": title, "body": body}
-    if state in {"open", "closed"}:
-        payload["state"] = state
+    if state is not None:
+        normalized = normalize_state(state)
+        payload["state"] = normalized
     data, _ = github_request(url, token=token, method="PATCH", payload=payload)
     return data
 
@@ -507,13 +527,33 @@ def sync_existing_issue(
     local: LocalIssue,
     remote: dict,
 ) -> None:
-    remote_state = remote.get("state", "open")
+    remote_state = normalize_state(remote.get("state"))
     remote_content = parse_remote_content(remote, local_identifier=local.local_identifier)
     remote_hash = compute_hash(remote_content)
 
     stored_hash = local.sync_hash
     local_changed = stored_hash is None or local.content_hash != stored_hash
-    remote_changed = stored_hash is None or remote_hash != stored_hash
+    remote_body_changed = stored_hash is None or remote_hash != stored_hash
+
+    remote_updated_time = parse_iso8601(remote.get("updated_at"))
+    local_state_changed = local.desired_state != local.synced_state
+    remote_state_changed = (
+        remote_state != local.synced_state
+        and (
+            remote_updated_time is None
+            or local.last_synced is None
+            or remote_updated_time > local.last_synced
+        )
+    )
+    remote_changed = remote_body_changed or remote_state_changed
+
+    local_time = (
+        get_file_modification_time(local.path)
+        or local.modified_time
+        or local.commit_time
+    )
+    if local_time:
+        local.modified_time = local_time
 
     remote_body_updated: datetime | None = None
 
@@ -529,13 +569,6 @@ def sync_existing_issue(
     elif local_changed and not remote_changed:
         chosen_source = "local"
     elif remote_changed and local_changed:
-        local_time = (
-            get_file_modification_time(local.path)
-            or local.modified_time
-            or local.commit_time
-        )
-        if local_time:
-            local.modified_time = local_time
         remote_time = ensure_remote_body_time()
         if remote_time and local_time:
             chosen_source = "remote" if remote_time > local_time else "local"
@@ -552,6 +585,7 @@ def sync_existing_issue(
         local.content = remote_content
         local.content_hash = remote_hash
         local.desired_state = remote_state
+        local.synced_state = remote_state
         local.last_synced = ensure_remote_body_time() or _now_utc()
         local.sync_hash = remote_hash
         write_issue_file(local)
@@ -561,17 +595,24 @@ def sync_existing_issue(
         return
 
     if chosen_source == "local":
+        state_to_send: str | None
+        if local_state_changed or not remote_state_changed:
+            state_to_send = local.desired_state
+        else:
+            state_to_send = None
         response = update_remote_issue(
             repo,
             token,
             local.issue_number or int(remote["number"]),
             title=local.header_line.lstrip("#").strip() or local.title,
             body=local.body_for_github,
-            state=local.desired_state,
+            state=state_to_send,
         )
         remote_updated = parse_iso8601(response.get("updated_at")) or _now_utc()
+        response_state = normalize_state(response.get("state"))
         local.last_synced = remote_updated
-        local.desired_state = response.get("state", local.desired_state)
+        local.desired_state = response_state
+        local.synced_state = response_state
         local.sync_hash = compute_hash(local.content)
         write_issue_file(local)
         _log_info(
@@ -582,6 +623,7 @@ def sync_existing_issue(
     if chosen_source == "none":
         # Ensure metadata is up-to-date even when no content changed.
         local.desired_state = remote_state
+        local.synced_state = remote_state
         if remote_changed:
             local.last_synced = ensure_remote_body_time() or local.last_synced
         local.sync_hash = remote_hash
@@ -600,10 +642,11 @@ def sync_local_without_remote(
         body=local.body_for_github,
     )
     issue_number = int(response["number"])
-    remote_state = response.get("state", "open")
+    remote_state = normalize_state(response.get("state"))
     remote_updated = parse_iso8601(response.get("updated_at")) or _now_utc()
     local.issue_number = issue_number
     local.desired_state = remote_state
+    local.synced_state = remote_state
     local.last_synced = remote_updated
     local.sync_hash = compute_hash(local.content)
     write_issue_file(local)
@@ -618,7 +661,9 @@ def sync_local_without_remote(
             body=local.body_for_github,
             state=local.stored_state,
         )
-        local.desired_state = response.get("state", local.stored_state)
+        updated_state = normalize_state(response.get("state", local.stored_state))
+        local.desired_state = updated_state
+        local.synced_state = updated_state
         local.last_synced = parse_iso8601(response.get("updated_at")) or remote_updated
         local.sync_hash = compute_hash(local.content)
         write_issue_file(local)


### PR DESCRIPTION
## Summary
- ensure the CI workflow installs docs, lint, and test extras together so lint jobs have their dependencies
- persist the last synced GitHub issue state in metadata and use it to detect remote state changes during conflict resolution
- avoid overwriting remote issue state unless the local metadata explicitly diverges, keeping local files and metadata up to date

## Testing
- python -m compileall scripts/issue_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68e94deecb3c8325bf0e4e1b07e92141