### PR TITLE
Fail lint patch step when apply fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,9 @@ jobs:
           if git apply --binary --3way "$RUNNER_TEMP/lint_fixes.patch"; then
             echo "applied=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Failed to apply lint fixes patch cleanly. Re-run lint locally or update your branch to resolve conflicts." >&2
+            echo "::error::Failed to apply lint fixes patch cleanly. Re-run lint locally or update your branch to resolve conflicts." >&2
             echo "applied=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
       - name: Commit and push lint fixes (pull request)
         if: ${{ always() && github.event_name == 'pull_request' && steps.lint_patch.outputs.changes == 'true' && steps.apply_lint_patch.outputs.applied != 'false' }}


### PR DESCRIPTION
## Summary
- remove the ref override so CI runs against GitHub's merge commit for pull requests
- capture automatic lint fixes as a patch and apply/push them from a separate checkout of the PR head branch
- keep the existing autofix push behaviour for direct branch pushes
- fail the lint patch apply step when the patch cannot be applied so contributors see an actionable failure

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e950d843348325b0f838704ca9d700