### PR TITLE
fix: allow scheduled syncs and protect local body edits

### DIFF
--- a/.github/workflows/sync-dev-issues.yml
+++ b/.github/workflows/sync-dev-issues.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   sync:
-    if: github.actor != 'github-actions[bot]'
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/scripts/issue_sync.py
+++ b/scripts/issue_sync.py
@@ -569,7 +569,7 @@ def sync_existing_issue(
     elif local_changed and not remote_changed:
         chosen_source = "local"
     elif remote_changed and local_changed:
-        remote_time = ensure_remote_body_time()
+        remote_time = ensure_remote_body_time() if remote_body_changed else None
         if remote_time and local_time:
             chosen_source = "remote" if remote_time > local_time else "local"
         elif remote_time:


### PR DESCRIPTION
## Summary
- let the sync workflow execute for scheduled and issue events while still skipping push loops from the bot account
- ensure remote state-only updates do not override newer local body edits during conflict resolution

## Testing
- `uv run pytest` *(fails: uv.lock parsing error due to missing source for codespell)*

------
https://chatgpt.com/codex/tasks/task_e_68e95283ae3083259193cb9dbf063d7a