### PR TITLE
Fix enrichment pipeline and RAG server regressions

### DIFF
--- a/src/egregora/processor.py
+++ b/src/egregora/processor.py
@@ -767,7 +767,6 @@ class UnifiedProcessor:
             if self.config.enrichment.enabled:
                 enricher = ContentEnricher(
                     self.config.enrichment,
-                    cache=None,
                 )
                 enrichment_result = asyncio.run(
                     enricher.enrich_dataframe(

--- a/src/egregora/rag_context/server.py
+++ b/src/egregora/rag_context/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import fastmcp as mcp
@@ -40,7 +41,7 @@ def run_server(parquet_path: str | Path):
         console.print(f"🔍 Searching for similar content to: '{query}' (k={k})")
         query_vector = get_embedding(query)
         results = search_func(query_vector, k)
-        return results.write_json(row_oriented=True)
+        return json.dumps(results.to_dicts())
 
     server = mcp.server.server.FastMCP(tools=[search_similar])
     console.print("🚀 Starting FastMCP server on port 8000...")


### PR DESCRIPTION
## Summary
- remove the obsolete cache argument when constructing `ContentEnricher`
- return a JSON string for RAG search results using `json.dumps(results.to_dicts())`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68edac8abae483258bf95729ecc4b7b0