### PR TITLE
Fix CRLF handling in attachment detection

### DIFF
--- a/src/egregora/media_extractor.py
+++ b/src/egregora/media_extractor.py
@@ -368,7 +368,12 @@ class MediaExtractor:
         directional_pattern = "[\\u200e\\u200f\\u202a\\u202b\\u202c\\u202d\\u202e]"
 
         processed = (
-            lines.with_columns(pl.col("__line").str.split("\n").alias("__line_segments"))
+            lines.with_columns(
+                pl.col("__line")
+                .str.replace_all("\r", "")
+                .str.split("\n")
+                .alias("__line_segments")
+            )
             .explode("__line_segments")
             .filter(pl.col("__line_segments").is_not_null())
             .with_columns(


### PR DESCRIPTION
## Summary
- strip carriage returns from message lines before splitting so CRLF transcripts lose attachment markers correctly

## Testing
- uv run pytest tests/test_media_extractor.py *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68f85c83add883259f7052d1c2fc52c5