### PR TITLE
Fix ranking CLI initialization and update ELO after comparisons

### DIFF
--- a/src/egregora/cli.py
+++ b/src/egregora/cli.py
@@ -20,7 +20,7 @@ from .editor_agent import run_editor_session
 from .model_config import ModelConfig, load_site_config
 from .pipeline import process_whatsapp_export
 from .ranking.agent import run_comparison
-from .ranking.elo import get_posts_to_compare, initialize_ratings
+from .ranking.elo import get_posts_to_compare
 from .ranking.store import RankingStore
 from .site_scaffolding import ensure_mkdocs_project
 
@@ -239,7 +239,7 @@ def _run_ranking_session(config: RankingCliConfig, gemini_key: str | None):  # n
         console.print("[red]No posts found to rank[/red]")
         raise typer.Exit(1)
 
-    newly_initialized = initialize_ratings(store, post_ids)
+    newly_initialized = store.initialize_ratings(post_ids)
     if newly_initialized > 0:
         console.print(f"[green]Initialized {newly_initialized} new posts with ELO 1500[/green]")
 

--- a/src/egregora/ranking/agent.py
+++ b/src/egregora/ranking/agent.py
@@ -8,6 +8,7 @@ from google import genai
 from google.genai import types as genai_types
 from rich.console import Console
 
+from .elo import calculate_elo_update
 from .store import RankingStore
 
 console = Console()
@@ -428,6 +429,19 @@ def run_comparison(  # noqa: PLR0913
         comment_b=comment_b,
         stars_b=stars_b,
     )
+
+    # Update ELO ratings
+    rating_a = store.get_rating(post_a_id)
+    rating_b = store.get_rating(post_b_id)
+
+    if rating_a is None or rating_b is None:
+        msg = "Missing ratings for posts despite initialization"
+        raise ValueError(msg)
+
+    new_elo_a, new_elo_b = calculate_elo_update(
+        rating_a["elo_global"], rating_b["elo_global"], winner
+    )
+    store.update_ratings(post_a_id, post_b_id, new_elo_a, new_elo_b)
 
     return {
         "winner": winner,


### PR DESCRIPTION
## Summary
- call RankingStore.initialize_ratings directly from the CLI to avoid passing the store into the helper
- recompute and persist ELO ratings after each comparison so subsequent matches reflect prior outcomes

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68fb75cbb5288325bd5c90b05b34e5bd