### PR TITLE
Fix quickstart enrichment flag usage

### DIFF
--- a/examples/quickstart/run-example.sh
+++ b/examples/quickstart/run-example.sh
@@ -49,7 +49,7 @@ egregora process \
   --timezone='America/Sao_Paulo' \
   --from-date=2025-01-01 \
   --to-date=2025-01-31 \
-  --enable-enrichment=True
+  --enable-enrichment
 
 # Step 4: Show results
 echo ""


### PR DESCRIPTION
## Summary
- update the quickstart example script to use the boolean flag form for enabling enrichment so it runs without argument parsing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fba6d33b788325b20486ceb4f86d23