### PR TITLE
Fix README quick start mkdocs plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uvx --from git+https://github.com/franklinbaldo/egregora egregora process \
   whatsapp-export.zip --output=. --timezone='America/New_York'
 
 # Serve your blog (no pip install needed!)
-uvx --with mkdocs-material --with mkdocs-blog-plugin mkdocs serve
+uvx --with mkdocs-material --with mkdocs-blogging-plugin mkdocs serve
 ```
 
 Open http://localhost:8000 to see your AI-generated blog!


### PR DESCRIPTION
## Summary
- update the Quick Start serve command to install `mkdocs-blogging-plugin` instead of the invalid `mkdocs-blog-plugin`
- ensure the documented command installs the plugin required by `mkdocs.yml`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbf9107aa883259ab42f4e34e92839