### PR TITLE
Fix schema alignment and dedupe ranking for Ibis transition

### DIFF
--- a/src/egregora/enricher.py
+++ b/src/egregora/enricher.py
@@ -528,8 +528,14 @@ async def enrich_dataframe(  # noqa: PLR0912, PLR0913
     if not new_rows:
         return df
 
-    # Create enrichment table and union with original
-    enrichment_df = ibis.memtable(new_rows)
+    # Create enrichment table with matching schema and union with original
+    schema = df.schema()
+    normalized_rows = [
+        {column: row.get(column) for column in schema.names}
+        for row in new_rows
+    ]
+
+    enrichment_df = ibis.memtable(normalized_rows, schema=schema)
     combined = df.union(enrichment_df)
     combined = combined.order_by("timestamp")
 


### PR DESCRIPTION
## Summary
- normalize enrichment rows against the source table schema before unioning
- ensure deduplication retains the highest-similarity chunk per post using a windowed row number

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc1c5cb6148325868e34e5036d27ec