### PR TITLE
Fix ibis regressions in parser, schema, and ranking store

### DIFF
--- a/src/egregora/parser.py
+++ b/src/egregora/parser.py
@@ -251,7 +251,7 @@ def parse_multiple(exports: Sequence[WhatsAppExport]) -> Table:
     # Concatenate all frames using union
     combined = frames[0]
     for frame in frames[1:]:
-        combined = combined.union(frame)
+        combined = combined.union(frame, distinct=False)
 
     return ensure_message_schema(combined.order_by("timestamp"))
 

--- a/src/egregora/ranking/store.py
+++ b/src/egregora/ranking/store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import duckdb
 import ibis
+import ibis.expr.datatypes as dt
 from ibis.expr.types import Table
 
 logger = logging.getLogger(__name__)
@@ -263,7 +264,17 @@ class RankingStore:
 
         # Convert to Ibis Table, handling empty results
         if not result:
-            return ibis.memtable([])
+            return ibis.memtable(
+                [],
+                schema=ibis.schema(
+                    {
+                        "profile_id": dt.string,
+                        "timestamp": dt.Timestamp(timezone=None),
+                        "comment": dt.string,
+                        "stars": dt.int64,
+                    }
+                ),
+            )
 
         # Convert to list of dicts for Ibis
         rows = [

--- a/src/egregora/schema.py
+++ b/src/egregora/schema.py
@@ -49,14 +49,8 @@ def ensure_message_schema(
 
     # Handle empty DataFrame
     if df.count().execute() == 0:
-        # Create empty table with correct schema
-        conn = ibis.get_backend(df)
-        return conn.create_table(
-            "_temp_empty",
-            schema=ibis.schema(target_schema),
-            temp=True,
-            overwrite=True,
-        )
+        # Create empty table with correct schema without relying on backend internals
+        return ibis.memtable([], schema=ibis.schema(target_schema))
 
     # Start with the input table
     result = df


### PR DESCRIPTION
## Summary
- ensure concatenating multiple exports preserves duplicate rows by disabling union deduplication
- return schema-conformant empty tables without depending on ibis internals
- provide an explicit schema for empty ranking comment queries so downstream code continues to work

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc2a62e2288325a1eb4eb57f9ae1af