### PR TITLE
Preserve enrichment duplicates in Ibis union

### DIFF
--- a/src/egregora/enricher.py
+++ b/src/egregora/enricher.py
@@ -536,7 +536,7 @@ async def enrich_dataframe(  # noqa: PLR0912, PLR0913
     ]
 
     enrichment_df = ibis.memtable(normalized_rows, schema=schema)
-    combined = df.union(enrichment_df)
+    combined = df.union(enrichment_df, distinct=False)
     combined = combined.order_by("timestamp")
 
     return combined


### PR DESCRIPTION
## Summary
- update the Ibis enrichment union call to disable distinct semantics so duplicate messages are retained

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcb598d610832589465aee93c8e49a