### PR TITLE
Use union_all semantics when appending vector store chunks

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -94,7 +94,7 @@ class VectorStore:
         if self.parquet_path.exists():
             # Read existing and append
             existing_df = ibis.read_parquet(self.parquet_path)
-            combined_df = existing_df.union(chunks_df)
+            combined_df = existing_df.union(chunks_df, distinct=False)
             existing_count = existing_df.count().execute()
             new_count = chunks_df.count().execute()
             logger.info(f"Appending {new_count} chunks to existing {existing_count} chunks")


### PR DESCRIPTION
## Summary
- ensure appending to the vector store uses a non-distinct union so duplicates are preserved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fced0bb89483258e9060dad1280574