### PR TITLE
Fix date derivation regression in ensure_message_schema

### DIFF
--- a/src/egregora/schema.py
+++ b/src/egregora/schema.py
@@ -55,9 +55,9 @@ def ensure_message_schema(
     # Start with the input table
     result = df
 
-    # Cast columns to target types (except timestamp which needs special handling)
+    # Cast columns to target types (except timestamp/date which need special handling)
     for name, dtype in target_schema.items():
-        if name == "timestamp":
+        if name in {"timestamp", "date"}:
             continue  # Handle separately below
 
         if name in result.columns:


### PR DESCRIPTION
## Summary
- skip populating the date column with nulls while normalizing message schemas
- preserve existing date casting logic so missing dates are derived from timestamp

## Testing
- pytest tests/test_schema.py *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68fcf32903a8832595e8d37898de9a12