### PR TITLE
Fix ibis string assembly and backend setup

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -61,6 +61,8 @@ class VectorStore:
         self.parquet_path = parquet_path
         self.conn = duckdb.connect(":memory:")
         self._init_vss()
+        self._backend = ibis.duckdb.connect()
+        ibis.set_backend(self._backend)
 
     def _init_vss(self):
         """Initialize DuckDB VSS extension."""


### PR DESCRIPTION
## Summary
- use ibis.concat to assemble week and month period labels without relying on string `+`
- initialize a DuckDB ibis backend for the vector store so ibis operations can execute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcf6458ca48325ace89b70e132e715