### PR TITLE
Fix asyncio import usage in writer tests

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio  # Needed for asyncio.run invoked in tests below.
 import sys
 from importlib import util
 from pathlib import Path


### PR DESCRIPTION
## Summary
- document the need for `asyncio` in `tests/test_writer.py` so the required import stays in place for `asyncio.run`

## Testing
- pytest tests/test_writer.py *(fails: ModuleNotFoundError: No module named 'ibis')*

------
https://chatgpt.com/codex/tasks/task_e_68fd8206a2988325b53b1fea6d886d4b