### PR TITLE
Handle placeholders during legacy migration

### DIFF
--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -25,6 +25,19 @@ logger = logging.getLogger(__name__)
 
 SINGLE_DIGIT_THRESHOLD = 10
 
+PLACEHOLDER_FILES = {".gitkeep", "index.md", "README.md"}
+
+
+def _contains_real_content(directory: Path) -> bool:
+    """Check if a directory has files other than scaffold placeholders."""
+
+    for child in directory.iterdir():
+        if child.name in PLACEHOLDER_FILES or child.name.startswith("."):
+            continue
+        return True
+
+    return False
+
 
 def _migrate_directory(source: Path, target: Path, label: str) -> None:
     """Move legacy content directory into the current docs tree."""
@@ -42,7 +55,7 @@ def _migrate_directory(source: Path, target: Path, label: str) -> None:
     if not items:
         return
 
-    if target_resolved.exists() and any(target_resolved.iterdir()):
+    if target_resolved.exists() and _contains_real_content(target_resolved):
         logger.debug(
             "Skipping %s migration: target %s already contains content", label, target_resolved
         )

--- a/tests/test_pipeline_migration.py
+++ b/tests/test_pipeline_migration.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from egregora.pipeline import _migrate_directory
+
+
+def test_migrate_directory_moves_when_target_has_placeholders(tmp_path: Path) -> None:
+    site_root = tmp_path
+    legacy_posts = site_root / "posts"
+    legacy_posts.mkdir()
+    (legacy_posts / "post1.md").write_text("content", encoding="utf-8")
+
+    target_dir = site_root / "docs" / "posts"
+    target_dir.mkdir(parents=True)
+    (target_dir / ".gitkeep").write_text("", encoding="utf-8")
+
+    _migrate_directory(legacy_posts, target_dir, "posts")
+
+    assert not legacy_posts.exists()
+    assert (target_dir / "post1.md").exists()
+    assert (target_dir / ".gitkeep").exists()


### PR DESCRIPTION
## Summary
- treat placeholder files as empty so legacy posts migrate into MkDocs docs directories
- add a regression test covering migration when docs/posts only has a .gitkeep sentinel

## Testing
- uv run --with pytest --with pytest-asyncio pytest tests/test_pipeline_migration.py

------
https://chatgpt.com/codex/tasks/task_e_68ff79c4df7c8325945e24b9d1149335