### PR TITLE
Fix RAG search arrow table handling

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -282,8 +282,7 @@ class VectorStore:
 
         try:
             # Execute query
-            result_reader = self.conn.execute(query, params).arrow()
-            result_table = result_reader.read_all()
+            result_table = self.conn.execute(query, params).arrow()
             df = (
                 ibis.memtable(result_table.to_pydict(), schema=SEARCH_RESULT_SCHEMA)
                 if result_table.num_rows > 0


### PR DESCRIPTION
## Summary
- use the DuckDB `arrow()` table directly in `VectorStore.search` to avoid raising AttributeError and returning empty results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff7c2ebcdc83259c91aba8b1dbde7e