### PR TITLE
Fix MkDocs scaffold and RAG stability (follow-up)

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -250,7 +250,7 @@ class VectorStore:
         # Build SQL query - select all columns plus similarity
         query = f"""
             SELECT
-                *,
+                * EXCLUDE (embedding),
                 array_cosine_similarity(embedding::FLOAT[3072], ?::FLOAT[3072]) AS similarity
             FROM read_parquet('{self.parquet_path}')
             WHERE array_cosine_similarity(embedding::FLOAT[3072], ?::FLOAT[3072]) >= {min_similarity}


### PR DESCRIPTION
## Summary
- update vector store search query to drop embedding column so results align with the search schema

## Testing
- uv run --with pytest --with pytest-asyncio pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68ff9fe6584c83258ff7d1e1da722605