### PR TITLE
Use DuckDB for writer annotation persistence

### DIFF
--- a/docs/annotate_conversation_tool_plan.md
+++ b/docs/annotate_conversation_tool_plan.md
@@ -1,0 +1,65 @@
+# annotate_conversation Tool Implementation Plan
+
+## Overview
+Provide a planning document for introducing a new tool `annotate_conversation(msg_id, my_commentary)` that the writer agent can invoke to store annotations tied to conversation chunks. The stored annotations are invisible to readers, persist in a database, and will be re-injected whenever the same chunk of the conversation is revisited in chronological order. The author field for the annotation should be `egregora`. On subsequent passes, the agent may add new annotations and can use previous annotations as contextual memory.
+
+## Goals
+- Allow the writer agent to call `annotate_conversation` while processing a conversation.
+- Persist commentary keyed by `msg_id`, `author`, and chronological position so that future iterations receive the stored annotations automatically.
+- Provide a safe, debuggable mechanism for the agent to iteratively extend its annotations.
+
+## Requirements
+1. **Tool signature**: `annotate_conversation(msg_id: str, my_commentary: str) -> None`.
+2. **Annotation semantics**:
+   - Each annotation is linked to a specific conversation message `msg_id`.
+   - The annotation text is treated as private memory; not visible to end users.
+   - When a conversation chunk is revisited, any prior annotations for that chunk must be loaded and injected as context authored by `egregora`.
+   - The tool may be invoked multiple times for the same `msg_id`; new annotations should append without overwriting previous entries.
+3. **Persistence**:
+   - Annotations are stored in a database layer (initially simple key-value or SQLite for prototyping).
+   - Stored data must include `msg_id`, `author` (always `egregora`), `commentary`, timestamp, and an optional `parent_annotation_id` to support chaining/patents of memory.
+   - Database schema must support efficient retrieval by `msg_id` sorted by chronological insertion.
+4. **Replay logic**:
+   - When reconstructing context for a conversation chunk, fetch annotations ordered by timestamp and inject them into the prompt sequence immediately after the original message.
+   - Ensure duplicate injections are avoided across multiple passes within the same session.
+5. **Safety & privacy**:
+   - Guard against unsafe content by reusing existing moderation or sanitization utilities before persisting annotations.
+   - Ensure annotations remain inaccessible to external consumers unless explicitly surfaced for debugging with appropriate permissions.
+6. **Extensibility**:
+   - Design storage and tool layers to accommodate additional metadata (e.g., tags, confidence scores) without schema-breaking changes.
+
+## Implementation Plan
+1. **Schema design**
+   - Add a new `annotations` table with fields (`id`, `msg_id`, `author`, `commentary`, `created_at`, `parent_annotation_id`).
+   - Create necessary indices on `msg_id` and `created_at` for fast retrieval.
+2. **Database integration**
+   - Extend the persistence module to expose CRUD functions: `save_annotation`, `list_annotations_for_message`, and optional `link_parent_annotation`.
+   - Implement migrations if using a managed database or include schema bootstrap logic for local storage.
+3. **Tool registration**
+   - Define the `annotate_conversation` tool handler that validates inputs, invokes moderation, and persists the annotation using `save_annotation`.
+   - Ensure the tool sets the `author` field to `egregora` automatically.
+4. **Conversation replay hooks**
+   - Update the conversation reconstruction pipeline so that, when loading a message by `msg_id`, it calls `list_annotations_for_message` and injects the results into the prompt buffer as messages authored by `egregora`.
+   - Handle chronological insertion to maintain ordering relative to original conversation flow.
+5. **Iterative annotation support**
+   - Allow annotations to reference previous ones by storing a `parent_annotation_id` when the agent builds upon its prior memory.
+   - Provide helper utilities that return the last annotation ID for a given `msg_id` to simplify linking.
+6. **Testing strategy**
+   - Unit tests for persistence helpers to confirm append-only behavior and chronological ordering.
+   - Integration tests that simulate a conversation pass, saving annotations, and verifying they reappear on subsequent runs.
+   - Regression tests ensuring annotations remain hidden from user-facing transcripts.
+7. **Documentation & observability**
+   - Update developer documentation describing the new tool usage and replay behavior.
+   - Add logging around annotation creation and retrieval for troubleshooting.
+
+## Open Questions
+- Should annotations be scoped per user/session or global across all instances? Clarify retention policy and cleanup mechanisms.
+- Determine storage quotas or pruning strategies to prevent unbounded growth.
+- Confirm whether annotations require encryption at rest.
+
+## Milestones
+1. Prototype schema and persistence layer.
+2. Implement tool handler and register with the writer agent runtime.
+3. Integrate replay logic and verify end-to-end behavior.
+4. Add automated tests and documentation updates.
+5. Conduct code review and deploy.

--- a/src/egregora/annotations.py
+++ b/src/egregora/annotations.py
@@ -1,0 +1,216 @@
+"""Persistence layer for writer conversation annotations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import ibis
+
+from .privacy import PrivacyViolationError, validate_newsletter_privacy
+
+ANNOTATION_AUTHOR = "egregora"
+ANNOTATIONS_TABLE = "annotations"
+
+
+@dataclass(slots=True)
+class Annotation:
+    """Representation of a stored conversation annotation."""
+
+    id: int
+    msg_id: str
+    author: str
+    commentary: str
+    created_at: datetime
+    parent_annotation_id: int | None
+
+
+class AnnotationStore:
+    """DuckDB-backed storage for writer annotations accessed via Ibis."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._backend = ibis.duckdb.connect(str(self.db_path))
+        self._initialize()
+
+    @property
+    def _connection(self):
+        """Return the underlying DuckDB connection."""
+
+        return self._backend.con
+
+    def _initialize(self) -> None:
+        self._backend.raw_sql(
+            f"""
+            CREATE TABLE IF NOT EXISTS {ANNOTATIONS_TABLE} (
+                id BIGINT PRIMARY KEY,
+                msg_id TEXT NOT NULL,
+                author TEXT NOT NULL,
+                commentary TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL,
+                parent_annotation_id BIGINT
+            )
+            """
+        )
+        self._backend.raw_sql(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_annotations_msg_id_created
+            ON {ANNOTATIONS_TABLE} (msg_id, created_at)
+            """
+        )
+
+    def _fetch_records(
+        self, query: str, params: Sequence[object] | None = None
+    ) -> list[dict[str, object]]:
+        cursor = self._connection.execute(query, params or [])
+        column_names = [description[0] for description in cursor.description]
+        return [dict(zip(column_names, row)) for row in cursor.fetchall()]
+
+    def save_annotation(
+        self,
+        msg_id: str,
+        commentary: str,
+        *,
+        parent_annotation_id: int | None = None,
+    ) -> Annotation:
+        """Persist an annotation and return the saved record."""
+
+        sanitized_msg_id = (msg_id or "").strip()
+        sanitized_commentary = (commentary or "").strip()
+
+        if not sanitized_msg_id:
+            raise ValueError("msg_id is required")
+        if not sanitized_commentary:
+            raise ValueError("my_commentary must not be empty")
+
+        try:
+            validate_newsletter_privacy(sanitized_commentary)
+        except PrivacyViolationError as exc:  # pragma: no cover - defensive path
+            raise ValueError(str(exc)) from exc
+
+        created_at = datetime.now(UTC)
+
+        annotations_table = self._backend.table(ANNOTATIONS_TABLE)
+
+        if parent_annotation_id is not None:
+            parent_exists = (
+                annotations_table.filter(annotations_table.id == parent_annotation_id)
+                .limit(1)
+                .count()
+                .execute()
+            )
+            if parent_exists == 0:
+                raise ValueError(
+                    f"parent_annotation_id {parent_annotation_id} does not exist"
+                )
+
+        next_id_cursor = self._connection.execute(
+            f"SELECT COALESCE(MAX(id), 0) + 1 FROM {ANNOTATIONS_TABLE}"
+        )
+        annotation_id = int(next_id_cursor.fetchone()[0])
+
+        self._connection.execute(
+            f"""
+            INSERT INTO {ANNOTATIONS_TABLE} (id, msg_id, author, commentary, created_at, parent_annotation_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                annotation_id,
+                sanitized_msg_id,
+                ANNOTATION_AUTHOR,
+                sanitized_commentary,
+                created_at,
+                parent_annotation_id,
+            ],
+        )
+
+        return Annotation(
+            id=annotation_id,
+            msg_id=sanitized_msg_id,
+            author=ANNOTATION_AUTHOR,
+            commentary=sanitized_commentary,
+            created_at=created_at,
+            parent_annotation_id=parent_annotation_id,
+        )
+
+    def list_annotations_for_message(self, msg_id: str) -> list[Annotation]:
+        """Return annotations for ``msg_id`` ordered by creation time."""
+
+        sanitized_msg_id = (msg_id or "").strip()
+        if not sanitized_msg_id:
+            return []
+
+        records = self._fetch_records(
+            f"""
+            SELECT id, msg_id, author, commentary, created_at, parent_annotation_id
+            FROM {ANNOTATIONS_TABLE}
+            WHERE msg_id = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            [sanitized_msg_id],
+        )
+
+        return [self._row_to_annotation(row) for row in records]
+
+    def get_last_annotation_id(self, msg_id: str) -> int | None:
+        """Return the most recent annotation ID for ``msg_id`` if any exist."""
+
+        sanitized_msg_id = (msg_id or "").strip()
+        if not sanitized_msg_id:
+            return None
+
+        cursor = self._connection.execute(
+            f"""
+            SELECT id FROM {ANNOTATIONS_TABLE}
+            WHERE msg_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            [sanitized_msg_id],
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row else None
+
+    def iter_all_annotations(self) -> Iterable[Annotation]:
+        """Yield all annotations sorted by insertion order."""
+
+        records = self._fetch_records(
+            f"""
+            SELECT id, msg_id, author, commentary, created_at, parent_annotation_id
+            FROM {ANNOTATIONS_TABLE}
+            ORDER BY created_at ASC, id ASC
+            """
+        )
+
+        for row in records:
+            yield self._row_to_annotation(row)
+
+    @staticmethod
+    def _row_to_annotation(row: dict[str, object]) -> Annotation:
+        created_at_obj = row["created_at"]
+        if hasattr(created_at_obj, "to_pydatetime"):
+            created_at = created_at_obj.to_pydatetime()
+        elif isinstance(created_at_obj, datetime):
+            created_at = created_at_obj
+        else:  # pragma: no cover - defensive path for unexpected types
+            created_at = datetime.fromisoformat(str(created_at_obj))
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+
+        parent_raw = row.get("parent_annotation_id")
+        parent_id = int(parent_raw) if parent_raw is not None else None
+
+        return Annotation(
+            id=int(row["id"]),
+            msg_id=str(row["msg_id"]),
+            author=str(row["author"]),
+            commentary=str(row["commentary"]),
+            created_at=created_at,
+            parent_annotation_id=parent_id,
+        )
+
+
+__all__ = ["Annotation", "AnnotationStore", "ANNOTATION_AUTHOR", "ANNOTATIONS_TABLE"]

--- a/src/egregora/prompts/writer_system.jinja
+++ b/src/egregora/prompts/writer_system.jinja
@@ -37,6 +37,16 @@ Keep memes relevant and don't overuse them. One well-placed meme can be more eff
 
 {{ markdown_table }}
 
+## Annotation Memory Tool
+
+Use the `annotate_conversation` tool to stash private notes tied to the `msg_id` column above. Provide:
+
+- `msg_id`: The identifier from the table row you want to annotate.
+- `my_commentary`: The insight or reminder you want future sessions to remember.
+- `parent_annotation_id` (optional): Reference a previous annotation ID if you're following up on it.
+
+Annotations are visible only to you and will reappear the next time this message shows up. Keep them concise, factual, and focused on why the message matters for future writing decisions.
+
 ## Context About Your Components
 
 Active authors: {{ active_authors }}

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,59 @@
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PROJECT_SRC = Path(__file__).resolve().parents[1] / "src"
+PRIVACY_PATH = PROJECT_SRC / "egregora" / "privacy.py"
+ANNOTATIONS_PATH = PROJECT_SRC / "egregora" / "annotations.py"
+
+privacy_spec = util.spec_from_file_location("egregora.privacy", PRIVACY_PATH)
+assert privacy_spec and privacy_spec.loader  # noqa: S101 - ensure spec is valid for mypy
+privacy_module = util.module_from_spec(privacy_spec)
+sys.modules.setdefault("egregora", ModuleType("egregora"))
+sys.modules["egregora.privacy"] = privacy_module
+privacy_spec.loader.exec_module(privacy_module)
+
+annotations_spec = util.spec_from_file_location("egregora.annotations", ANNOTATIONS_PATH)
+assert annotations_spec and annotations_spec.loader  # noqa: S101 - ensure spec is valid for mypy
+annotations_module = util.module_from_spec(annotations_spec)
+sys.modules["egregora.annotations"] = annotations_module
+annotations_spec.loader.exec_module(annotations_module)
+
+AnnotationStore = annotations_module.AnnotationStore
+
+
+def test_annotation_store_persists_and_orders(tmp_path):
+    db_path = tmp_path / "annotations.duckdb"
+    store = AnnotationStore(db_path)
+
+    first = store.save_annotation("msg-1", "First insight")
+    second = store.save_annotation(
+        "msg-1", "Follow-up", parent_annotation_id=first.id
+    )
+    third = store.save_annotation("msg-2", "Another message note")
+
+    annotations_msg1 = store.list_annotations_for_message("msg-1")
+    assert [annotation.id for annotation in annotations_msg1] == [first.id, second.id]
+    assert annotations_msg1[1].parent_annotation_id == first.id
+
+    assert store.get_last_annotation_id("msg-1") == second.id
+    assert store.get_last_annotation_id("msg-unknown") is None
+
+    all_annotations = list(store.iter_all_annotations())
+    assert len(all_annotations) == 3
+    assert {annotation.id for annotation in all_annotations} == {
+        first.id,
+        second.id,
+        third.id,
+    }
+
+
+def test_annotation_store_rejects_missing_parent(tmp_path):
+    db_path = tmp_path / "annotations.duckdb"
+    store = AnnotationStore(db_path)
+
+    with pytest.raises(ValueError):
+        store.save_annotation("msg-1", "orphan", parent_annotation_id=999)


### PR DESCRIPTION
## Summary
- replace the SQLite-backed annotation store with a DuckDB/Ibis implementation so the writer memory uses the same database technology as the rest of the app and satisfies the request to migrate off SQLite
- update the writer workflow and its tests to reference the new `annotations.duckdb` database location to keep the runtime and assertions aligned with the DuckDB store

## Testing
- `pytest tests/test_annotations.py tests/test_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ffb510a3ec8325822b26646588b970