### PR TITLE
Ensure message IDs ignore ordering

### DIFF
--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -111,7 +111,7 @@ def _escape_table_cell(value: Any) -> str:
     return text.replace("\n", "<br>")
 
 
-def _compute_message_id(_: int, row: Mapping[str, Any]) -> str:
+def _compute_message_id(row: Mapping[str, Any]) -> str:
     """Derive a deterministic identifier for a conversation row."""
 
     parts: list[str] = []
@@ -188,10 +188,7 @@ def _build_conversation_markdown(
     df = dataframe.copy()
 
     if "msg_id" not in df.columns:
-        msg_ids = [
-            _compute_message_id(index, row)
-            for index, row in enumerate(df.to_dict("records"))
-        ]
+        msg_ids = [_compute_message_id(row) for row in df.to_dict("records")]
         df.insert(0, "msg_id", msg_ids)
     else:
         df["msg_id"] = df["msg_id"].map(_stringify_value)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -415,5 +415,5 @@ def test_write_posts_for_period_saves_freeform_response(tmp_path, monkeypatch):
     assert "Annotation Memory Tool" in initial_message
 
     records = df.execute().to_dict("records")
-    expected_msg_id = writer._compute_message_id(0, records[0])
+    expected_msg_id = writer._compute_message_id(records[0])
     assert expected_msg_id in initial_message


### PR DESCRIPTION
## Summary
- add a SQLite-backed `AnnotationStore` that persists and retrieves writer annotations for each conversation message so the new tool has durable state
- update the writer prompt flow to emit stable `msg_id` values, surface prior annotations inline, and register the `annotate_conversation` tool (including the handler that stores new notes)
- document the tool for the model and extend the test suite to cover the persistence layer plus the annotated prompt rendering behaviour
- ensure `_compute_message_id` hashes only the message content so annotations remain stable even if row order changes

## Testing
- `pytest tests/test_writer.py -k msg_id` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68ffc3fb5cbc83258dcd6a8833d6e804