### PR TITLE
Add pandas dependency for writer module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mdformat>=0.7.22",
     "jinja2>=3.1.0",
     "fire>=0.7.1",
+    "pandas>=2.0",
     "pyarrow>=21.0.0",
     "typer[all]>=0.20.0",
 ]


### PR DESCRIPTION
## Summary
- add pandas to the core dependencies now required by the writer module

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ffc6dacc1883259ecb685a7ce60f63