### PR TITLE
Fix DummyClient models stub in writer test

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -366,6 +366,8 @@ def test_write_posts_for_period_saves_freeform_response(tmp_path, monkeypatch):
     class DummyClient:
         def __init__(self, response_obj):
             self.aio = DummyAio(response_obj)
+            # Ensure synchronous code paths can access the same models stub.
+            self.models = self.aio.models
 
     captured_request: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- expose a synchronous `models` attribute on the DummyClient test double so the writer test exercises the sync path

## Testing
- uv run --with pytest --with pytest-asyncio pytest tests/test_writer.py::test_write_posts_for_period_saves_freeform_response *(fails: ImportError: cannot import name 'sleep_with_progress_sync' from 'egregora.genai_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6900b793633c83258467c953f6ce69a8