### PR TITLE
Clarify _compute_message_id API by removing legacy row index shim

### DIFF
--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -111,36 +111,27 @@ def _escape_table_cell(value: Any) -> str:
     return text.replace("\n", "<br>")
 
 
-def _compute_message_id(
-    row_or_index: Mapping[str, Any] | int, row: Mapping[str, Any] | None = None
-) -> str:
+def _compute_message_id(row: Mapping[str, Any]) -> str:
     """Derive a deterministic identifier for a conversation row.
 
-    The helper historically accepted ``(row_index, row)`` positional arguments.
-    For backward compatibility we still support that shape while allowing the
-    modern ``(row)`` form. Any provided ``row_index`` is ignored to ensure the
-    identifier stays stable even if row ordering changes.
+    Only the mapping-based call signature is supported. Legacy helpers passed
+    both ``(row_index, row)`` positional arguments, but that form is no longer
+    accepted because the index value is ignored during hash computation.
     """
 
-    if isinstance(row_or_index, Mapping) and row is None:
-        resolved_row = row_or_index
-    elif isinstance(row_or_index, int) and row is not None:
-        resolved_row = row
-    else:
-        raise TypeError(
-            "_compute_message_id now expects either (row) or (row_index, row)."
-        )
+    if not isinstance(row, Mapping):
+        raise TypeError("_compute_message_id expects a mapping representing the row")
 
     parts: list[str] = []
     for key in ("msg_id", "timestamp", "author", "message", "content", "text"):
-        value = resolved_row.get(key)
+        value = row.get(key)
         normalized = _stringify_value(value)
         if normalized:
             parts.append(normalized)
 
     if not parts:
         fallback_pairs = []
-        for key, value in sorted(resolved_row.items()):
+        for key, value in sorted(row.items()):
             if key in {"row_index", "similarity"}:
                 continue
             normalized = _stringify_value(value)
@@ -150,7 +141,7 @@ def _compute_message_id(
             parts.extend(fallback_pairs)
         else:
             parts.append(
-                json.dumps(resolved_row, sort_keys=True, default=_stringify_value)
+                json.dumps(row, sort_keys=True, default=_stringify_value)
             )
 
     raw = "||".join(parts)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -419,5 +419,5 @@ def test_write_posts_for_period_saves_freeform_response(tmp_path, monkeypatch):
     assert "Annotation Memory Tool" in initial_message
 
     records = df.execute().to_dict("records")
-    expected_msg_id = writer._compute_message_id(0, records[0])
+    expected_msg_id = writer._compute_message_id(records[0])
     assert expected_msg_id in initial_message


### PR DESCRIPTION
## Summary
- remove the `(row_index, row)` compatibility shim from `_compute_message_id` and document the supported mapping-only signature
- update the writer freeform test helper to exercise the new API shape

## Testing
- pytest tests/test_writer.py::test_write_posts_for_period_freeform *(fails: ModuleNotFoundError: No module named 'jinja2')*


------
https://chatgpt.com/codex/tasks/task_e_6900c9168cd08325a744d7758406dbb0