### PR TITLE
Permitir que _compute_message_id aceite linhas do pandas

### DIFF
--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Mapping
 from datetime import timezone
 from functools import lru_cache
 from pathlib import Path
@@ -111,16 +110,20 @@ def _escape_table_cell(value: Any) -> str:
     return text.replace("\n", "<br>")
 
 
-def _compute_message_id(row: Mapping[str, Any]) -> str:
+def _compute_message_id(row: Any) -> str:
     """Derive a deterministic identifier for a conversation row.
 
-    Only the mapping-based call signature is supported. Legacy helpers passed
-    both ``(row_index, row)`` positional arguments, but that form is no longer
-    accepted because the index value is ignored during hash computation.
+    The helper accepts any object exposing ``get`` and ``items`` (for example,
+    :class:`dict` as well as :class:`pandas.Series` produced by
+    ``DataFrame.iterrows()``). Legacy helpers passed both ``(row_index, row)``
+    positional arguments, but that form is no longer accepted because the index
+    value is ignored during hash computation.
     """
 
-    if not isinstance(row, Mapping):
-        raise TypeError("_compute_message_id expects a mapping representing the row")
+    if not (hasattr(row, "get") and hasattr(row, "items")):
+        raise TypeError(
+            "_compute_message_id expects an object with mapping-style access"
+        )
 
     parts: list[str] = []
     for key in ("msg_id", "timestamp", "author", "message", "content", "text"):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -181,6 +181,7 @@ def _call_with_retries_sync(sync_fn, *args, **kwargs):
 genai_utils_stub = ModuleType("egregora.genai_utils")
 genai_utils_stub.call_with_retries = _call_with_retries_sync
 genai_utils_stub.call_with_retries_sync = _call_with_retries_sync
+genai_utils_stub.sleep_with_progress_sync = lambda *args, **kwargs: None
 sys.modules["egregora.genai_utils"] = genai_utils_stub
 
 
@@ -329,6 +330,23 @@ def test_write_freeform_markdown_creates_file(tmp_path):
         "date: 2024-05-01\n"
         "---\n\n"
         "This is a freeform response.\n"
+    )
+
+
+def test_compute_message_id_accepts_pandas_series():
+    import pandas as pd
+
+    mapping_row = {
+        "msg_id": "abc123",
+        "timestamp": "2024-05-01T10:00:00Z",
+        "author": "alice",
+        "message": "Hello there",
+    }
+
+    series_row = pd.Series(mapping_row)
+
+    assert writer._compute_message_id(series_row) == writer._compute_message_id(
+        mapping_row
     )
 
 


### PR DESCRIPTION
## Summary
- remover a verificação rígida por `Mapping` em `_compute_message_id` e aceitar qualquer objeto que exponha `get`/`items`, restaurando o uso com linhas do pandas sem lançar exceção
- atualizar a documentação inline para explicar a interface esperada pelo utilitário
- adicionar um teste que valida a geração de hash para `pandas.Series` e ajustar o stub de `genai_utils` usado nos testes

## Testing
- pytest tests/test_writer.py -k pandas_series

------
https://chatgpt.com/codex/tasks/task_e_6900cff61b748325b107901994480744