### PR TITLE
Document private _compute_message_id signature change

### DIFF
--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -117,7 +117,8 @@ def _compute_message_id(row: Any) -> str:
     :class:`dict` as well as :class:`pandas.Series` produced by
     ``DataFrame.iterrows()``). Legacy helpers passed both ``(row_index, row)``
     positional arguments, but that form is no longer accepted because the index
-    value is ignored during hash computation.
+    value is ignored during hash computation. The function is private to this
+    module, so no downstream backwards compatibility considerations apply.
     """
 
     if not (hasattr(row, "get") and hasattr(row, "items")):


### PR DESCRIPTION
## Summary
- clarify that the updated `_compute_message_id` helper remains private and does not require backward compatibility for the dropped `row_index` argument

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900df8951548325b9f5f306ecdf7a75