### PR TITLE
Restore async enrich_media helper for alpha callers

### DIFF
--- a/src/egregora/enricher.py
+++ b/src/egregora/enricher.py
@@ -22,10 +22,12 @@ from google.genai import types as genai_types
 from ibis.expr.types import Table
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from .cache import EnrichmentCache, make_enrichment_cache_key
+from .config_types import EnrichmentConfig
 from .gemini_batch import BatchPromptRequest, GeminiBatchClient
+from .genai_utils import call_with_retries
 from .model_config import ModelConfig
 from .prompt_templates import (
     render_media_enrichment_detailed_prompt,
@@ -103,6 +105,120 @@ class MediaEnrichmentJob:
     cached: bool = False
     upload_uri: str | None = None
     mime_type: str | None = None
+
+
+async def enrich_media(
+    *,
+    file_path: Path,
+    original_message: str,
+    sender_uuid: str,
+    timestamp: Any,
+    config: EnrichmentConfig,
+    media_type: str | None = None,
+    upload_fn: Callable[..., Awaitable[Any]] | None = None,
+    generate_content_fn: Callable[..., Awaitable[Any]] | None = None,
+) -> str | None:
+    """Enrich a single media file using the legacy async Gemini interface.
+
+    ``enrich_dataframe`` is the preferred batch API, but we keep this helper so
+    alpha users that still import :func:`enrich_media` are not broken while the
+    migration completes.  The implementation mirrors the previous behaviour:
+    upload the media, request a markdown description, persist it under
+    ``media/enrichments`` and delete the original file when the model flags
+    potential PII.
+    """
+
+    docs_dir = config.output_dir
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    detected_media_type = media_type or detect_media_type(file_path)
+    if not detected_media_type:
+        logger.warning("Unsupported media type for enrichment: %s", file_path.name)
+        return None
+
+    enrichment_dir = docs_dir / MEDIA_DIR_NAME / "enrichments"
+    enrichment_dir.mkdir(parents=True, exist_ok=True)
+    enrichment_id = uuid.uuid5(uuid.NAMESPACE_DNS, str(file_path.resolve()))
+    enrichment_path = enrichment_dir / f"{enrichment_id}.md"
+
+    ts = _ensure_datetime(timestamp)
+    try:
+        media_path = str(file_path.relative_to(docs_dir))
+    except ValueError:
+        subfolder = get_media_subfolder(file_path.suffix)
+        media_path = str(Path(MEDIA_DIR_NAME) / subfolder / file_path.name)
+
+    prompt = render_media_enrichment_detailed_prompt(
+        media_type=detected_media_type,
+        media_filename=file_path.name,
+        media_path=media_path,
+        original_message=original_message,
+        sender_uuid=sender_uuid,
+        date=ts.strftime("%Y-%m-%d"),
+        time=ts.strftime("%H:%M"),
+    )
+
+    if upload_fn is None or generate_content_fn is None:
+        client = getattr(config, "client", None)
+        aio_client = getattr(client, "aio", None) if client is not None else None
+        files_client = getattr(aio_client, "files", None) if aio_client else None
+        models_client = getattr(aio_client, "models", None) if aio_client else None
+
+        upload_fn = upload_fn or getattr(files_client, "upload", None)
+        generate_content_fn = generate_content_fn or getattr(models_client, "generate_content", None)
+
+    if upload_fn is None or generate_content_fn is None:
+        raise RuntimeError(
+            "Gemini async client missing: provide EnrichmentConfig.client or override upload_fn/generate_content_fn."
+        )
+
+    uploaded_file = await call_with_retries(
+        upload_fn,
+        path=str(file_path),
+        display_name=file_path.name,
+    )
+
+    parts = [genai_types.Part(text=prompt)]
+    upload_uri = getattr(uploaded_file, "uri", None)
+    if upload_uri:
+        mime_type = getattr(uploaded_file, "mime_type", "application/octet-stream")
+        parts.append(
+            genai_types.Part(
+                file_data=genai_types.FileData(
+                    file_uri=upload_uri,
+                    mime_type=mime_type,
+                    display_name=file_path.name,
+                )
+            )
+        )
+
+    response = await call_with_retries(
+        generate_content_fn,
+        contents=[genai_types.Content(role="user", parts=parts)],
+        model=config.model,
+        config=genai_types.GenerateContentConfig(temperature=0.3),
+    )
+
+    markdown_content = (getattr(response, "text", None) or "").strip()
+    if not markdown_content:
+        logger.warning("No enrichment generated for media: %s", file_path.name)
+        return None
+
+    if "PII_DETECTED" in markdown_content:
+        logger.warning(
+            "PII detected in media: %s. Media will be deleted after redaction.",
+            file_path.name,
+        )
+        markdown_content = markdown_content.replace("PII_DETECTED", "").strip()
+        try:
+            file_path.unlink(missing_ok=True)
+            logger.info("Deleted media file containing PII: %s", file_path)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to delete %s: %s", file_path, exc)
+
+    enrichment_path.write_text(markdown_content, encoding="utf-8")
+    logger.info("Saved media enrichment for %s at %s", file_path.name, enrichment_path)
+    return str(enrichment_path)
 
 
 def _ensure_datetime(value):

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -76,9 +76,8 @@ async def test_enrich_media_with_pii_detection():
         test_media.write_bytes(b"fake image data")
 
         # Mock configuration
-        mock_client = Mock()
         mock_config = EnrichmentConfig(
-            client=mock_client,
+            client=Mock(),
             output_dir=output_dir,
             model="test-model",
         )
@@ -110,6 +109,9 @@ This image shows a person holding an identification document in an indoor settin
         mock_uploaded_file.uri = "test://file"
         mock_uploaded_file.mime_type = "image/jpeg"
 
+        upload_fn = AsyncMock()
+        generate_fn = AsyncMock()
+
         with patch("egregora.enricher.call_with_retries", new_callable=AsyncMock) as mock_retry:
             # First call is for file upload, second is for generate_content
             mock_retry.side_effect = [mock_uploaded_file, mock_response]
@@ -121,6 +123,8 @@ This image shows a person holding an identification document in an indoor settin
                 sender_uuid="test123",
                 timestamp=MagicMock(strftime=lambda x: "2024-01-01" if "Y" in x else "12:00"),
                 config=mock_config,
+                upload_fn=upload_fn,
+                generate_content_fn=generate_fn,
             )
 
             # Assertions
@@ -147,9 +151,8 @@ async def test_enrich_media_without_pii():
         test_media.write_bytes(b"fake image data")
 
         # Mock configuration
-        mock_client = Mock()
         mock_config = EnrichmentConfig(
-            client=mock_client,
+            client=Mock(),
             output_dir=output_dir,
             model="test-model",
         )
@@ -178,6 +181,9 @@ The composition features a wide vista with layers of mountain ranges receding in
         mock_uploaded_file.uri = "test://file"
         mock_uploaded_file.mime_type = "image/jpeg"
 
+        upload_fn = AsyncMock()
+        generate_fn = AsyncMock()
+
         with patch("egregora.enricher.call_with_retries", new_callable=AsyncMock) as mock_retry:
             mock_retry.side_effect = [mock_uploaded_file, mock_response]
 
@@ -188,6 +194,8 @@ The composition features a wide vista with layers of mountain ranges receding in
                 sender_uuid="test123",
                 timestamp=MagicMock(strftime=lambda x: "2024-01-01" if "Y" in x else "12:00"),
                 config=mock_config,
+                upload_fn=upload_fn,
+                generate_content_fn=generate_fn,
             )
 
             # Assertions


### PR DESCRIPTION
## Summary
- restore an async `enrich_media` wrapper that mirrors the previous Gemini workflow while documenting that batch enrichment remains the preferred path
- allow callers (and tests) to inject upload and generate functions so we can keep clean dependencies during the alpha migration
- refresh the enricher tests to exercise the compatibility shim with the new injectable hooks

## Testing
- pytest tests/test_enricher.py *(fails: ModuleNotFoundError: No module named 'ibis' in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e1dd96d48325b75c53177e6f4e31