### PR TITLE
Update RAG docs for Parquet-based vector store

### DIFF
--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -322,7 +322,7 @@ The Editor Agent uses the same RAG system as the main pipeline:
 ```python
 from egregora.rag import VectorStore
 
-store = VectorStore(Path("./rag"))
+store = VectorStore(Path("./rag/chunks.parquet"))
 
 # Editor Agent will query this store
 ```
@@ -447,7 +447,7 @@ Editor quality depends on RAG index quality.
 **Problem:** `query_rag` returns empty results
 
 **Solution:**
-1. Check RAG index exists: `ls -la rag/vectors.duckdb`
+1. Check RAG index exists: `ls -la rag/chunks.parquet`
 2. Ensure posts are indexed
 3. Try broader queries
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -276,8 +276,8 @@ my-blog/
 │   ├── a1b2c3d4.md
 │   └── e5f6g7h8.md
 ├── media/             # Uploaded media
-├── rag/               # RAG database
-│   └── vectors.duckdb
+├── rag/               # RAG embeddings (Parquet)
+│   └── chunks.parquet
 └── rankings/          # ELO rankings
     └── rankings.duckdb
 ```

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -293,18 +293,18 @@ rm my-blog/rankings/rankings.duckdb
 
 ## RAG Issues
 
-### No RAG Database Found
+### No RAG Index Found
 
 **Problem:**
 ```
-FileNotFoundError: rag/vectors.duckdb not found
+FileNotFoundError: rag/chunks.parquet not found
 ```
 
 **Cause:** RAG indexing hasn't run yet
 
 **Solution:**
 ```bash
-# Enable enrichment to build RAG index
+# Enable enrichment to build the Parquet embedding file
 egregora process \
   --zip_file=export.zip \
   --enable_enrichment=True

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -87,7 +87,7 @@ DuckDB-based vector store for RAG.
 from pathlib import Path
 from egregora.rag import VectorStore
 
-store = VectorStore(Path("./rag"))
+store = VectorStore(Path("./rag/chunks.parquet"))
 
 # Get all embeddings
 df = store.get_all_embeddings()
@@ -106,7 +106,7 @@ from google import genai
 from egregora.rag import VectorStore, index_post
 
 client = genai.Client(api_key="YOUR_KEY")
-store = VectorStore(Path("./rag"))
+store = VectorStore(Path("./rag/chunks.parquet"))
 
 # Index a post
 num_chunks = await index_post(
@@ -254,7 +254,7 @@ async def main():
 
     # 2. Query RAG for similar content
     client = genai.Client(api_key="YOUR_KEY")
-    store = VectorStore(Path("./my-blog/rag"))
+    store = VectorStore(Path("./my-blog/rag/chunks.parquet"))
 
     results = await query_similar_posts(
         query="AI alignment discussions",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -162,7 +162,7 @@ egregora process whatsapp-export.zip \
 **Output:**
 - `posts/` - Generated blog posts in markdown
 - `profiles/` - Author profiles in markdown
-- `rag/` - RAG vector database (if enrichment enabled)
+- `rag/` - RAG embeddings stored in `chunks.parquet` (if enrichment enabled)
 - `enriched/` - Debug CSV files (if debug mode)
 
 **Environment Variables:**

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -63,8 +63,8 @@ my-blog/
 ├── profiles/               # Author profiles
 │   ├── a1b2c3d4.md
 │   └── e5f6g7h8.md
-├── rag/                    # RAG database
-│   └── vectors.duckdb
+├── rag/                    # RAG embeddings (Parquet)
+│   └── chunks.parquet
 └── docs/                   # Site pages
     └── index.md
 ```


### PR DESCRIPTION
## Summary
- document that embeddings are stored in `{output}/rag/chunks.parquet` and accessed through DuckDB, matching the current VectorStore implementation
- update RAG troubleshooting, architecture, and quickstart guides to reference the Parquet file rather than a DuckDB database file
- refresh API and editor snippets plus DuckDB CLI examples so readers load the Parquet file correctly before running similarity searches

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690147d9508c8325bce7511f1f8d1e4b