### PR TITLE
Clarify Gemini key precedence across the CLI

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -404,7 +404,7 @@ egregora process --enable_enrichment=False
 
 #### --gemini_key
 
-Pass API key directly:
+Pass API key directly (takes precedence over the `GOOGLE_API_KEY` environment variable):
 
 ```bash
 egregora process --gemini_key=YOUR_KEY

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ egregora process <zip_file> [OPTIONS]
 | `--from-date` | str | None | Only process messages from this date onwards (YYYY-MM-DD) |
 | `--to-date` | str | None | Only process messages up to this date (YYYY-MM-DD) |
 | `--timezone` | str | None | Timezone for date parsing (e.g., 'America/New_York') |
-| `--gemini-key` | str | None | Google Gemini API key (or set GOOGLE_API_KEY env var) |
+| `--gemini-key` | str | None | Google Gemini API key (flag overrides GOOGLE_API_KEY env var) |
 | `--model` | str | None | Gemini model to use (or configure in mkdocs.yml) |
 | `--debug` | bool | `False` | Enable debug logging |
 
@@ -194,7 +194,7 @@ egregora rank [OPTIONS]
 | `--comparisons` | int | `1` | Number of comparisons to run |
 | `--strategy` | str | `fewest_games` | Selection strategy: 'fewest_games', 'random', etc. |
 | `--export-parquet` | bool | `False` | Export rankings to Parquet files |
-| `--gemini-key` | str | None | Google Gemini API key (or set GOOGLE_API_KEY env var) |
+| `--gemini-key` | str | None | Google Gemini API key (flag overrides GOOGLE_API_KEY env var) |
 | `--model` | str | None | Gemini model to use (or configure in mkdocs.yml) |
 | `--debug` | bool | `False` | Enable debug logging |
 
@@ -281,7 +281,7 @@ egregora edit <post_path> [OPTIONS]
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--rag-dir` | Path | `./rag` | RAG database directory for context |
-| `--gemini-key` | str | None | Google Gemini API key (or set GOOGLE_API_KEY env var) |
+| `--gemini-key` | str | None | Google Gemini API key (flag overrides GOOGLE_API_KEY env var) |
 | `--model` | str | None | Gemini model to use |
 | `--custom-instructions` | str | None | Custom editorial instructions |
 | `--debug` | bool | `False` | Enable debug logging |

--- a/src/egregora/cli.py
+++ b/src/egregora/cli.py
@@ -33,6 +33,12 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
+def _resolve_gemini_key(cli_override: str | None) -> str | None:
+    """Return the Gemini API key honoring CLI override precedence."""
+
+    return cli_override or os.getenv("GOOGLE_API_KEY")
+
+
 @app.command()
 def init(
     output_dir: Annotated[
@@ -154,7 +160,7 @@ def _validate_and_run_process(config: ProcessConfig):  # noqa: PLR0912, PLR0915
         console.print("[green]Initialized MkDocs scaffold. Continuing with processing.[/green]")
 
     # Get API key
-    api_key = config.gemini_key or os.getenv("GOOGLE_API_KEY")
+    api_key = _resolve_gemini_key(config.gemini_key)
     if not api_key:
         console.print("[red]Error: GOOGLE_API_KEY not set[/red]")
         console.print("Provide via --gemini-key or set GOOGLE_API_KEY environment variable")
@@ -210,7 +216,8 @@ def process(  # noqa: PLR0913
         str | None, typer.Option(help="Timezone for date parsing (e.g., 'America/New_York')")
     ] = None,
     gemini_key: Annotated[
-        str | None, typer.Option(help="Google Gemini API key (or set GOOGLE_API_KEY env var)")
+        str | None,
+        typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
     ] = None,
     model: Annotated[
         str | None, typer.Option(help="Gemini model to use (or configure in mkdocs.yml)")
@@ -299,7 +306,7 @@ def _run_ranking_session(config: RankingCliConfig, gemini_key: str | None):  # n
         console.print(f"[green]Initialized {newly_initialized} new posts with ELO 1500[/green]")
 
     # Get API key
-    api_key = os.getenv("GOOGLE_API_KEY", gemini_key)
+    api_key = _resolve_gemini_key(gemini_key)
     if not api_key:
         console.print("[red]Error: GOOGLE_API_KEY not set[/red]")
         console.print("Provide via --gemini-key or set GOOGLE_API_KEY environment variable")
@@ -386,7 +393,8 @@ def rank(  # noqa: PLR0913
         bool, typer.Option(help="Export rankings to Parquet after comparisons")
     ] = False,
     gemini_key: Annotated[
-        str | None, typer.Option(help="Google Gemini API key (or set GOOGLE_API_KEY env var)")
+        str | None,
+        typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
     ] = None,
     model: Annotated[
         str | None, typer.Option(help="Gemini model to use (or configure in mkdocs.yml)")
@@ -423,7 +431,8 @@ def edit(
         typer.Option(help="Gemini model to use (default: models/gemini-flash-latest)"),
     ] = None,
     gemini_key: Annotated[
-        str | None, typer.Option(help="Google Gemini API key (or set GOOGLE_API_KEY env var)")
+        str | None,
+        typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
     ] = None,
 ):
     """
@@ -458,7 +467,7 @@ def edit(
         console.print("[yellow]RAG directory not found. Editor will work without RAG.[/yellow]")
 
     # Get API key
-    api_key = os.getenv("GOOGLE_API_KEY", gemini_key)
+    api_key = _resolve_gemini_key(gemini_key)
     if not api_key:
         console.print("[red]Error: GOOGLE_API_KEY not set[/red]")
         console.print("Provide via --gemini-key or set GOOGLE_API_KEY environment variable")

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,121 @@
+import pytest
+import typer
+
+from src.egregora.cli import _resolve_gemini_key, _validate_and_run_process
+from src.egregora.config_types import ProcessConfig
+
+
+def test_resolve_gemini_key_prefers_cli_override(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+
+    result = _resolve_gemini_key("flag-key")
+
+    assert result == "flag-key"
+
+
+def test_resolve_gemini_key_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+
+    result = _resolve_gemini_key(None)
+
+    assert result == "env-key"
+
+
+def test_resolve_gemini_key_returns_none_without_sources(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    result = _resolve_gemini_key(None)
+
+    assert result is None
+
+
+def test_validate_process_uses_cli_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+
+    captured = {}
+
+    def fake_process_whatsapp_export(*args, **kwargs):
+        captured["api_key"] = kwargs["gemini_api_key"]
+        return {}
+
+    monkeypatch.setattr(
+        "src.egregora.cli.process_whatsapp_export", fake_process_whatsapp_export
+    )
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    monkeypatch.setattr(
+        "src.egregora.cli.find_mkdocs_file", lambda _path: site_dir / "mkdocs.yml"
+    )
+
+    zip_path = tmp_path / "chat.zip"
+    zip_path.write_text("dummy")
+
+    config = ProcessConfig(
+        zip_file=zip_path,
+        output_dir=site_dir,
+        gemini_key="flag-key",
+    )
+
+    _validate_and_run_process(config)
+
+    assert captured["api_key"] == "flag-key"
+
+
+def test_validate_process_uses_env_when_cli_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+
+    captured = {}
+
+    def fake_process_whatsapp_export(*args, **kwargs):
+        captured["api_key"] = kwargs["gemini_api_key"]
+        return {}
+
+    monkeypatch.setattr(
+        "src.egregora.cli.process_whatsapp_export", fake_process_whatsapp_export
+    )
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    monkeypatch.setattr(
+        "src.egregora.cli.find_mkdocs_file", lambda _path: site_dir / "mkdocs.yml"
+    )
+
+    zip_path = tmp_path / "chat.zip"
+    zip_path.write_text("dummy")
+
+    config = ProcessConfig(
+        zip_file=zip_path,
+        output_dir=site_dir,
+        gemini_key=None,
+    )
+
+    _validate_and_run_process(config)
+
+    assert captured["api_key"] == "env-key"
+
+
+def test_validate_process_exits_without_any_api_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    def fake_process_whatsapp_export(*args, **kwargs):
+        raise AssertionError("Should not be called when API key is missing")
+
+    monkeypatch.setattr(
+        "src.egregora.cli.process_whatsapp_export", fake_process_whatsapp_export
+    )
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    monkeypatch.setattr(
+        "src.egregora.cli.find_mkdocs_file", lambda _path: site_dir / "mkdocs.yml"
+    )
+
+    zip_path = tmp_path / "chat.zip"
+    zip_path.write_text("dummy")
+
+    config = ProcessConfig(
+        zip_file=zip_path,
+        output_dir=site_dir,
+        gemini_key=None,
+    )
+
+    with pytest.raises(typer.Exit):
+        _validate_and_run_process(config)


### PR DESCRIPTION
## Summary
- refactor the CLI to resolve the Gemini API key through a helper that prefers command-line overrides before checking the GOOGLE_API_KEY environment variable
- exercise the new resolution logic with targeted unit tests that cover flag, environment, and failure scenarios
- clarify the CLI option help text and documentation so they explicitly state the override precedence

## Testing
- pytest *(fails: missing optional dependencies such as ibis, typer, and jinja2 in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_690147e3f17883259f631ede50f81623