### PR TITLE
docs: align documentation with ibis table pipeline

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -147,14 +147,17 @@ Then create a Pull Request on GitHub.
 
 ```python
 # Good
-def parse_export(zip_path: Path) -> pl.DataFrame:
-    """Parse WhatsApp export into DataFrame.
+from ibis.expr.types import Table
+
+
+def parse_export(zip_path: Path) -> Table:
+    """Parse WhatsApp export into an Ibis table.
 
     Args:
         zip_path: Path to ZIP file
 
     Returns:
-        DataFrame with [timestamp, author, message, media]
+        Table with [timestamp, author, message, media, media_metadata]
     """
     ...
 
@@ -267,7 +270,7 @@ Update docs when adding features.
 ### Key Design Principles
 
 1. **Trust the LLM** - Let it make editorial decisions
-2. **DataFrames all the way** - Use Polars, avoid object conversions
+2. **Ibis tables all the way** - Stay in DuckDB, convert to pandas only at boundaries
 3. **Privacy first** - Anonymize before LLM sees data
 4. **Simple pipeline** - No complex agents or events
 5. **Functional style** - Pure functions where possible
@@ -326,15 +329,14 @@ logging.basicConfig(level=logging.DEBUG)
 
 Or use `--debug` flag in CLI.
 
-### Inspect DataFrames
+### Inspect Tables
 
 ```python
-import polars as pl
+import ibis
 
-df = parse_export(zip_path)
-print(df.head())
-print(df.schema)
-print(df.describe())
+table = parse_export(zip_path)
+print(table.schema())
+print(table.limit(5).execute())  # pandas DataFrame for quick inspection
 ```
 
 ### Profile Performance

--- a/docs/features/privacy-commands.md
+++ b/docs/features/privacy-commands.md
@@ -28,7 +28,7 @@ User: /egregora [sensitive financial discussion]
 User: /egregora Just testing, ignore this
 ```
 
-**These messages are removed from the DataFrame BEFORE any processing:**
+**These messages are removed from the Ibis table BEFORE any processing:**
 - Never reach LLM
 - Never in enrichment
 - Never in posts

--- a/docs/features/rag.md
+++ b/docs/features/rag.md
@@ -231,9 +231,10 @@ from egregora.rag import VectorStore
 
 store = VectorStore(Path("my-blog/rag"))
 
-# Get all embeddings as DataFrame
-df = store.get_all_embeddings()
-print(df)
+# Get all embeddings as an Ibis Table
+embeddings = store.get_all_embeddings()
+print(embeddings.schema())
+print(embeddings.limit(5).execute())  # pandas DataFrame preview
 
 # Search with raw embedding
 embedding = [0.1, 0.2, ...]  # 3072-dim vector

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -82,7 +82,7 @@ Each post includes:
 
 Egregora did the following:
 
-1. **Parsed** your WhatsApp export into a structured DataFrame
+1. **Parsed** your WhatsApp export into a structured Ibis table (DuckDB backend)
 2. **Anonymized** all names → UUID5 pseudonyms (privacy-first)
 3. **Grouped** messages by date (day/week/month)
 4. **Enriched** messages with URL/media context (optional)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,7 +151,7 @@ egregora process whatsapp-export.zip \
 
 **What it does:**
 
-1. **Parses** WhatsApp export into structured DataFrame
+1. **Parses** WhatsApp export into a structured Ibis table
 2. **Anonymizes** all names → UUID5 pseudonyms (privacy-first)
 3. **Groups** messages by period (day/week/month)
 4. **Enriches** messages with URL/media context (if enabled)


### PR DESCRIPTION
## Summary
- replace Polars-oriented descriptions in the getting started, architecture, anonymization, and API docs with the Ibis + DuckDB table workflow that the parser and anonymizer currently implement
- refresh code snippets across docs to show `ibis.memtable` creation, `Table` typing, and the explicit pandas `.execute()` boundaries while swapping remaining examples to Ibis or DuckDB SQL equivalents
- audit other documentation references to Polars, updating contributing, ranking, RAG, privacy, CLI, and quickstart pages so that the messaging stays consistent with today’s Ibis-based pipeline

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690147d1a54c83259f57ca9e88108fb0