### PR TITLE
Restore default backend registration for memtable callers

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -8,7 +8,6 @@ from typing import Any
 import duckdb
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.common.exceptions import NoBackendError
 import pyarrow as pa
 from ibis.expr.types import Table
 
@@ -103,10 +102,34 @@ class VectorStore:
     def _ensure_default_backend(self) -> None:
         """Ensure a global backend exists for memtable-based callers."""
 
-        try:
-            ibis.get_backend()
-        except NoBackendError:
-            ibis.set_backend(self._client)
+        backend: Any | None = None
+        get_backend = getattr(ibis, "get_backend", None)
+
+        if callable(get_backend):
+            try:
+                backend = get_backend()
+            except Exception:  # pragma: no cover - defensive for older Ibis releases
+                backend = None
+
+        if backend is not None:
+            return
+
+        options_backend: Any | None = None
+        if hasattr(ibis, "options"):
+            options_backend = getattr(ibis.options, "default_backend", None)
+            if options_backend is not None:
+                return
+
+        set_backend = getattr(ibis, "set_backend", None)
+        if callable(set_backend):
+            try:
+                set_backend(self._client)
+                return
+            except Exception:  # pragma: no cover - fallback to option assignment
+                pass
+
+        if hasattr(ibis, "options") and getattr(ibis.options, "default_backend", None) is None:
+            ibis.options.default_backend = self._client
 
     def add(self, chunks_df: Table):
         """


### PR DESCRIPTION
## Summary
- ensure the vector store registers its DuckDB backend with Ibis when no default backend is configured so memtable helpers keep working

## Testing
- PYTHONPATH=src pytest tests/test_rag_store.py *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_6901514d4b48832593e8c969d700a7a0