### PR TITLE
Guard VectorStore backend setup against missing Ibis helpers

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -114,9 +114,11 @@ class VectorStore:
         if backend is not None:
             return
 
-        default_backend = getattr(getattr(ibis, "options", object()), "default_backend", None)
-        if default_backend is not None:
-            return
+        options_backend: Any | None = None
+        if hasattr(ibis, "options"):
+            options_backend = getattr(ibis.options, "default_backend", None)
+            if options_backend is not None:
+                return
 
         set_backend = getattr(ibis, "set_backend", None)
         if callable(set_backend):
@@ -126,7 +128,7 @@ class VectorStore:
             except Exception:  # pragma: no cover - fallback to option assignment
                 pass
 
-        if hasattr(ibis, "options"):
+        if hasattr(ibis, "options") and getattr(ibis.options, "default_backend", None) is None:
             ibis.options.default_backend = self._client
 
     def add(self, chunks_df: Table):


### PR DESCRIPTION
## Summary
- remove the import of a nonexistent ibis NoBackendError symbol
- defensively check for available backend helpers before registering the DuckDB client and fall back to the options API

## Testing
- PYTHONPATH=src pytest tests/test_rag_store.py

------
https://chatgpt.com/codex/tasks/task_e_690153bf923083258f81d217728f9e0a