### PR TITLE
Address review feedback: ensure vector store registers backend

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -114,6 +114,12 @@ class VectorStore:
         if backend is not None:
             return
 
+        options_backend: Any | None = None
+        if hasattr(ibis, "options"):
+            options_backend = getattr(ibis.options, "default_backend", None)
+            if options_backend is not None:
+                return
+
         set_backend = getattr(ibis, "set_backend", None)
         if callable(set_backend):
             try:
@@ -122,7 +128,7 @@ class VectorStore:
             except Exception:  # pragma: no cover - fallback to option assignment
                 pass
 
-        if hasattr(ibis, "options"):
+        if hasattr(ibis, "options") and getattr(ibis.options, "default_backend", None) is None:
             ibis.options.default_backend = self._client
 
     def add(self, chunks_df: Table):


### PR DESCRIPTION
## Summary
- ensure `_ensure_default_backend` registers the DuckDB client whenever no backend is active
- keep the options fallback for Ibis releases without `set_backend`

## Testing
- PYTHONPATH=src pytest tests/test_rag_store.py *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_69015569407c8325ae3c93cab560ad55