### PR TITLE
Fix: accept retrieval kwargs in whatsapp pipeline stub

### DIFF
--- a/tests/test_whatsapp_real_scenario.py
+++ b/tests/test_whatsapp_real_scenario.py
@@ -100,6 +100,10 @@ def _install_pipeline_stubs(monkeypatch, captured_dates: list[str]):
         model_config,
         enable_rag=True,
         embedding_output_dimensionality=3072,
+        *,
+        retrieval_mode="exact",
+        retrieval_nprobe=None,
+        retrieval_overfetch=None,
     ):
         captured_dates.append(period_key)
         output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- allow the whatsapp pipeline test stub to accept the retrieval kwargs passed by the pipeline

## Testing
- `uv run pytest tests/test_whatsapp_real_scenario.py::test_pipeline_generates_expected_posts` *(fails: duckdb missing so the module-level skip guard aborts collection)*

------
https://chatgpt.com/codex/tasks/task_e_69016ef49f1c8325a45c97047bea8348