### PR TITLE
Address settings precedence and missing fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tests/temp_output/
 # Generated metrics and logs
 metrics/
 *.csv
+!tests/v3/fixtures/*.csv
 # Added by Codex
 .egregora-cache/
 .egregora-cache-*/

--- a/src/egregora_v3/cli/app.py
+++ b/src/egregora_v3/cli/app.py
@@ -13,7 +13,6 @@ from egregora_v3.features.rag.build import build_embeddings
 from egregora_v3.features.rag.query import query_rag
 from egregora_v3.features.ranking.duel import run_duel
 from egregora_v3.features.ranking.export import export_rankings
-from egregora_v3.features.site.render import render_site
 from egregora_v3.features.importer import import_from_parquet
 
 app = typer.Typer(name="eg3", help="Egregora v3 - Emergent Group Reflection Engine")
@@ -108,9 +107,20 @@ def site_render():
     """
     Render the static site.
     """
+    try:
+        from egregora_v3.features.site.render import render_site  # type: ignore
+    except ModuleNotFoundError as exc:
+        console.print(
+            "[bold red]Site rendering is unavailable:[/] "
+            "missing 'egregora_v3.features.site.render'."
+        )
+        raise typer.Exit(code=1) from exc
+
     ctx = build_context()
-    render_site(ctx)
-    ctx.close()
+    try:
+        render_site(ctx)
+    finally:
+        ctx.close()
 
 @import_app.command("parquet")
 def import_parquet_cmd(in_path: Path = typer.Argument(..., help="Path to the v2 Parquet file.")):

--- a/src/egregora_v3/core/config.py
+++ b/src/egregora_v3/core/config.py
@@ -40,18 +40,37 @@ def load_settings(cli_overrides: Optional[dict] = None) -> Settings:
     if cli_overrides is None:
         cli_overrides = {}
 
-    # Load from TOML file first
     config_path = APP_DIR / "egregora.toml"
     toml_config = load_from_toml(config_path)
 
-    # Pydantic-settings will automatically load from environment variables.
-    # We can then merge the configs, giving precedence to CLI overrides.
+    # Load environment variables and defaults first.
+    # We will merge the TOML values afterward so environment overrides win.
+    base_settings = Settings()
+    settings_data = base_settings.model_dump()
 
-    # Start with TOML, then let Pydantic overwrite with ENV vars
-    settings = Settings(**toml_config)
+    model_config = getattr(Settings, "model_config", {}) or {}
+    env_prefix = model_config.get("env_prefix", "")
 
-    # Finally, apply CLI overrides
+    def env_var_candidates(field_name: str) -> list[str]:
+        """Return possible environment variable names for the given field."""
+        candidates = []
+        base = f"{env_prefix}{field_name}" if env_prefix else field_name
+        candidates.append(base)
+        candidates.append(base.upper())
+        candidates.append(base.lower())
+        return candidates
+
+    for key, value in toml_config.items():
+        if cli_overrides and key in cli_overrides:
+            continue
+
+        env_set = any(os.getenv(candidate) is not None for candidate in env_var_candidates(key))
+        if env_set:
+            continue
+
+        settings_data[key] = value
+
     if cli_overrides:
-        settings = Settings(**{**settings.dict(), **cli_overrides})
+        settings_data.update(cli_overrides)
 
-    return settings
+    return Settings(**settings_data)

--- a/tests/v3/fixtures/golden_author_data.csv
+++ b/tests/v3/fixtures/golden_author_data.csv
@@ -1,0 +1,4 @@
+Jules|b07ac1f4
+John Doe|957cf4d6
+Franklin|ca71a986
+Jane Doe|6ebd8acd


### PR DESCRIPTION
## Summary
- ensure environment variables override TOML defaults when loading settings
- guard the optional site rendering command behind a runtime import
- add the missing anonymization author fixture and whitelist it in gitignore

## Testing
- pytest tests/v3/test_anonymization_parity.py *(fails: ModuleNotFoundError: No module named 'ibis')*

------
https://chatgpt.com/codex/tasks/task_e_69017ca967988325a29b1a90f9068777