### PR TITLE
Handle ImportError for Gemini fallback import

### DIFF
--- a/src/egregora_v3/adapters/embeddings/gemini.py
+++ b/src/egregora_v3/adapters/embeddings/gemini.py
@@ -2,7 +2,7 @@ from typing import List
 
 try:
     from google import genai  # type: ignore[import]
-except ModuleNotFoundError:  # pragma: no cover - depends on optional dependency
+except ImportError:  # pragma: no cover - depends on optional dependency
     import google.generativeai as genai  # type: ignore[import]
 
 class GeminiEmbeddingClient:


### PR DESCRIPTION
## Summary
- broaden the exception handling when importing the Gemini client to fall back to `google.generativeai`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690185873ec4832585b8f093e799565d