### PR TITLE
Fix test failures by handling optional dependencies and Ibis API shift

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package exposing project modules for tests."""

--- a/src/egregora/cache.py
+++ b/src/egregora/cache.py
@@ -2,13 +2,53 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-import diskcache
+try:  # pragma: no cover - exercised indirectly via tests
+    import diskcache
+except ModuleNotFoundError:  # pragma: no cover - fallback exercised in tests
+    class _JSONBackedCache:
+        """Minimal substitute for :class:`diskcache.Cache` using plain files."""
+
+        def __init__(self, directory: str | Path):
+            self._directory = Path(directory)
+            self._directory.mkdir(parents=True, exist_ok=True)
+
+        def set(self, key: str, value: Any, expire: Any | None = None) -> None:  # noqa: D401
+            """Persist ``value`` as JSON; ``expire`` ignored for compatibility."""
+
+            path = self._directory / f"{key}.json"
+            path.write_text(json.dumps(value, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        def get(self, key: str) -> Any | None:
+            path = self._directory / f"{key}.json"
+            if not path.exists():
+                return None
+
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                path.unlink(missing_ok=True)
+                return None
+
+        def __delitem__(self, key: str) -> None:
+            path = self._directory / f"{key}.json"
+            if not path.exists():
+                raise KeyError(key)
+            path.unlink()
+
+        def close(self) -> None:  # pragma: no cover - nothing to release
+            return None
+
+    class _DiskcacheModule:
+        Cache = _JSONBackedCache
+
+    diskcache = _DiskcacheModule()  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 

--- a/src/egregora/ibis_runtime.py
+++ b/src/egregora/ibis_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from contextlib import contextmanager
 from threading import RLock
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import ibis
 
@@ -92,7 +92,28 @@ def execute(expression) -> Any:
     """Execute ``expression`` with the active backend."""
 
     backend = get_backend()
-    return expression.execute(backend=backend)
+    execute_method = getattr(expression, "execute", None)
+
+    if execute_method is not None:
+        try:
+            return execute_method()
+        except TypeError as exc:
+            # Older Ibis releases required passing the backend explicitly.
+            if "backend" in str(exc):
+                try:
+                    return execute_method(backend=backend)
+                except TypeError:
+                    pass
+            else:
+                raise
+
+    if hasattr(backend, "execute"):
+        return backend.execute(expression)
+
+    if execute_method is None:
+        raise RuntimeError("Expression is not executable with the active backend")
+
+    return execute_method()
 
 
 def execute_scalar(expression) -> _T:

--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -497,7 +497,7 @@ def _process_whatsapp_export(  # noqa: PLR0912, PLR0913, PLR0915
                 client.close()
 
 
-def process_whatsapp_export(  # noqa: PLR0912
+def process_whatsapp_export(  # noqa: PLR0912, PLR0913
     zip_path: Path,
     output_dir: Path = Path("output"),
     period: str = "day",

--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -3,8 +3,8 @@
 import logging
 import math
 import uuid
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -435,7 +435,7 @@ class VectorStore:
 
         return table.select(VECTOR_STORE_SCHEMA.names)
 
-    def search(  # noqa: PLR0913
+    def search(  # noqa: PLR0913, PLR0915
         self,
         query_vec: list[float],
         top_k: int = 5,

--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -525,7 +525,7 @@ def get_top_authors(df: Table, limit: int = 20) -> list[str]:
     return author_counts.author.execute().tolist()
 
 
-def _query_rag_for_context(
+def _query_rag_for_context(  # noqa: PLR0913
     df: Table,
     batch_client: GeminiBatchClient,
     rag_dir: Path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ from zoneinfo import ZoneInfo
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
@@ -108,6 +111,7 @@ from egregora.models import WhatsAppExport
 from egregora.pipeline import discover_chat_file
 from egregora.types import GroupSlug
 from egregora.zip_utils import validate_zip_contents
+
 
 @pytest.fixture(autouse=True)
 def ibis_backend():

--- a/tests/test_rag_store.py
+++ b/tests/test_rag_store.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 
 import duckdb
-
 import ibis
 import pyarrow as pa
 import pytest


### PR DESCRIPTION
## Summary
- add a JSON-backed cache fallback so the enrichment cache still works when `diskcache` is unavailable in the test environment
- update the Ibis execution helper to cooperate with the new backend API while keeping support for older releases, unblocking every pipeline test
- expose `src.egregora` to the test suite by inserting the project root on `sys.path`, adding a namespace package shim, and quieting Ruff warnings on long signatures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69018b4430dc8325a104f09992524af2