### PR TITLE
Fix missing index metadata table creation

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -204,6 +204,22 @@ class VectorStore:
             """
         )
 
+    def _ensure_index_meta_table(self) -> None:
+        """Create the table used to persist ANN index metadata."""
+
+        self.conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {INDEX_META_TABLE} (
+                index_name TEXT PRIMARY KEY,
+                mode TEXT,
+                row_count BIGINT,
+                threshold BIGINT,
+                nlist INTEGER,
+                updated_at TIMESTAMPTZ
+            )
+            """
+        )
+
     def _get_stored_metadata(self) -> DatasetMetadata | None:
         """Fetch cached metadata for the backing Parquet file."""
 


### PR DESCRIPTION
## Summary
- restore the `_ensure_index_meta_table` helper so the vector store can initialize its index metadata table before use

## Testing
- pytest tests/test_rag_store.py *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_6901e65cc6648325b9dba5df21cb3033