### PR TITLE
Remove JSON directory fallback from enrichment cache

### DIFF
--- a/src/egregora/cache.py
+++ b/src/egregora/cache.py
@@ -2,53 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-try:  # pragma: no cover - exercised indirectly via tests
-    import diskcache
-except ModuleNotFoundError:  # pragma: no cover - fallback exercised in tests
-    class _JSONBackedCache:
-        """Minimal substitute for :class:`diskcache.Cache` using plain files."""
-
-        def __init__(self, directory: str | Path):
-            self._directory = Path(directory)
-            self._directory.mkdir(parents=True, exist_ok=True)
-
-        def set(self, key: str, value: Any, expire: Any | None = None) -> None:  # noqa: D401
-            """Persist ``value`` as JSON; ``expire`` ignored for compatibility."""
-
-            path = self._directory / f"{key}.json"
-            path.write_text(json.dumps(value, ensure_ascii=False, indent=2), encoding="utf-8")
-
-        def get(self, key: str) -> Any | None:
-            path = self._directory / f"{key}.json"
-            if not path.exists():
-                return None
-
-            try:
-                return json.loads(path.read_text(encoding="utf-8"))
-            except json.JSONDecodeError:
-                path.unlink(missing_ok=True)
-                return None
-
-        def __delitem__(self, key: str) -> None:
-            path = self._directory / f"{key}.json"
-            if not path.exists():
-                raise KeyError(key)
-            path.unlink()
-
-        def close(self) -> None:  # pragma: no cover - nothing to release
-            return None
-
-    class _DiskcacheModule:
-        Cache = _JSONBackedCache
-
-    diskcache = _DiskcacheModule()  # type: ignore[assignment]
+import diskcache
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- simplify `EnrichmentCache` by removing the vendored JSONDirectoryCache fallback and importing `diskcache` directly
- align the implementation with the project requirements, which already list `diskcache` as a hard dependency, so only the native backend is needed

## Testing
- uv run pytest *(fails: existing Ruff violations in `tests/test_linting.py::test_repository_is_ruff_clean` and vector-store search failure in `tests/test_rag_store.py::test_search_filters_accept_temporal_inputs`)*

------
https://chatgpt.com/codex/tasks/task_e_69020bf2a6448325896bdce082f90340