### PR TITLE
Remove duckdb.functional shim and normalize Arrow outputs

### DIFF
--- a/src/egregora/__init__.py
+++ b/src/egregora/__init__.py
@@ -1,12 +1,5 @@
 """Egregora v2: Ultra-simple WhatsApp to blog pipeline."""
 
-from types import SimpleNamespace
-
-import duckdb
-
-if not hasattr(duckdb, "functional"):
-    duckdb.functional = SimpleNamespace(ARROW="arrow", NATIVE="native")
-
 from .pipeline import process_whatsapp_export
 
 __version__ = "2.0.0"


### PR DESCRIPTION
## Summary
- drop the global duckdb.functional shim from the package import path
- normalize DuckDB Arrow query results in the RAG vector store so newer duckdb releases still return tables
- make the ranking store robust to RecordBatchReader responses before creating Ibis memtables

## Testing
- python -m pytest tests/test_rag_store.py

------
https://chatgpt.com/codex/tasks/task_e_69020f0521d8832598ea88a756cec675