### PR TITLE
Cache embedding dimensionality during model config initialization

### DIFF
--- a/src/egregora/pipeline.py
+++ b/src/egregora/pipeline.py
@@ -270,9 +270,7 @@ def _process_whatsapp_export(  # noqa: PLR0912, PLR0913, PLR0915
         vision_batch_client = GeminiBatchClient(client, model_config.get_model("enricher_vision"))
         embedding_model_name = model_config.get_model("embedding")
         embedding_batch_client = GeminiBatchClient(client, embedding_model_name)
-        embedding_dimensionality = model_config.get_embedding_output_dimensionality(
-            embedding_model_name
-        )
+        embedding_dimensionality = model_config.embedding_output_dimensionality
         cache_dir = Path(".egregora-cache") / site_paths.site_root.name
         enrichment_cache = EnrichmentCache(cache_dir)
         checkpoint_store = CheckpointStore(site_paths.site_root / ".egregora" / "checkpoints")


### PR DESCRIPTION
## Summary
- resolve the embedding output dimensionality once when a ModelConfig is created and cache it on the instance
- keep the existing public accessor but serve the cached value while logging when mismatched model names are supplied
- update the pipeline to rely on the cached dimensionality so the embedding configuration is evaluated a single time

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_69020f65838c8325b165ee89f598e397