### PR TITLE
refactor: render writer meme helper via template

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -211,6 +211,17 @@ extra:
       - Include participant UUIDs when quoting
 ```
 
+#### writer.enable_memes
+
+Show the meme-generation helper text in the writer system prompt (default: false).
+
+```yaml
+extra:
+  egregora:
+    writer:
+      enable_memes: true
+```
+
 #### enable_rag
 
 Enable RAG enrichment (default: true).

--- a/src/egregora/prompt_templates.py
+++ b/src/egregora/prompt_templates.py
@@ -27,6 +27,7 @@ def render_writer_prompt(  # noqa: PLR0913
     profiles_context: str = "",
     rag_context: str = "",
     freeform_memory: str = "",
+    enable_memes: bool = False,
 ) -> str:
     """
     Render the writer system prompt from Jinja template.
@@ -53,6 +54,7 @@ def render_writer_prompt(  # noqa: PLR0913
         profiles_context=profiles_context,
         rag_context=rag_context,
         freeform_memory=freeform_memory,
+        enable_memes=enable_memes,
     )
 
 

--- a/src/egregora/prompts/writer_system.jinja
+++ b/src/egregora/prompts/writer_system.jinja
@@ -5,24 +5,6 @@ You don't describe what "the group discussed" - you ARE the synthesis, engaging 
 
 Your audience: LessWrong-adjacent readers who value intellectual rigor, explicit reasoning, and elegant idea exploration.
 
-## Meme Generation Capability
-
-You can generate relevant memes using the memegen.link API to add humor and visual engagement to your posts.
-
-**Quick Usage:**
-- URL format: `https://api.memegen.link/images/{template}/{top_text}/{bottom_text}.png`
-- Use underscores for spaces: `hello_world` → "hello world"
-- Popular templates: `buzz` (X everywhere), `drake` (comparisons), `success` (wins), `fine` (fires), `fry` (uncertainty)
-- Example: `![Meme](https://api.memegen.link/images/buzz/ideas/ideas_everywhere.png)`
-
-**When to use memes:**
-- To illustrate a humorous point
-- To show relatable situations
-- To break up dense text with visual humor
-- When a meme captures the vibe better than words
-
-Keep memes relevant and don't overuse them. One well-placed meme can be more effective than paragraphs of explanation.
-
 {% if custom_instructions %}
 ## Custom Writing Instructions
 
@@ -147,7 +129,6 @@ For each post:
 - Ask questions (rhetorical or direct) to engage the reader's thinking
 - Show your reasoning process, including uncertainty and tension
 - Address potential objections: "You might be thinking... and you'd be right to wonder..."
-- Use memes when they add humor or illustrate a point better than words
 - Make connections explicit
 - Use profiles to understand communication style but write as unified consciousness
 - Reference related posts when genuinely relevant to your current thinking
@@ -177,6 +158,26 @@ Only write what's genuinely worth reading. Skip:
 Write when there's:
 - Substantive idea exploration
 - Novel perspectives or connections
+
+{% if enable_memes %}
+## Meme Generation Capability
+
+You can generate relevant memes using the memegen.link API to add humor and visual engagement to your posts.
+
+**Quick Usage:**
+- URL format: `https://api.memegen.link/images/{template}/{top_text}/{bottom_text}.png`
+- Use underscores for spaces: `hello_world` → "hello world"
+- Popular templates: `buzz` (X everywhere), `drake` (comparisons), `success` (wins), `fine` (fires), `fry` (uncertainty)
+- Example: `![Meme](https://api.memegen.link/images/buzz/ideas/ideas_everywhere.png)`
+
+**When to use memes:**
+- To illustrate a humorous point
+- To show relatable situations
+- To break up dense text with visual humor
+- When a meme captures the vibe better than words
+
+Keep memes relevant and don't overuse them. One well-placed meme can be more effective than paragraphs of explanation.
+{% endif %}
 - Useful insights or analysis
 - Meaningful uncertainty or debate
 

--- a/src/egregora/writer.py
+++ b/src/egregora/writer.py
@@ -253,6 +253,18 @@ logger = logging.getLogger(__name__)
 # Constants
 MAX_CONVERSATION_TURNS = 10
 
+def _memes_enabled(site_config: dict[str, Any]) -> bool:
+    """Return True when meme helper text should be appended to the prompt."""
+
+    if not isinstance(site_config, dict):
+        return False
+
+    writer_settings = site_config.get("writer")
+    if not isinstance(writer_settings, dict):
+        return False
+
+    return bool(writer_settings.get("enable_memes", False))
+
 
 class PostMetadata(BaseModel):
     """Metadata schema for write_post tool."""
@@ -1004,6 +1016,7 @@ def write_posts_for_period(  # noqa: PLR0913, PLR0915
     # Load site config and markdown extensions
     site_config = load_site_config(output_dir)
     custom_writer_prompt = site_config.get("writer_prompt", "")
+    meme_help_enabled = _memes_enabled(site_config)
     markdown_extensions_yaml = load_markdown_extensions(output_dir)
 
     markdown_features_section = ""
@@ -1029,6 +1042,7 @@ Use these features appropriately in your posts. You understand how each extensio
         profiles_context=profiles_context,
         rag_context=rag_context,
         freeform_memory=freeform_memory,
+        enable_memes=meme_help_enabled,
     )
 
     # Setup conversation


### PR DESCRIPTION
## Summary
- pass an `enable_memes` flag into the writer system prompt template so the meme helper is controlled with Jinja conditionals as requested, reducing ad-hoc Python concatenation
- inline the meme-generation guidance inside `writer_system.jinja` behind the flag to keep all prompt text colocated in the template and honor the feature toggle semantics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69020f27e164832597078c2995ed33ad