### PR TITLE
Fix UTC import for retriever timestamps

### DIFF
--- a/src/egregora/rag/retriever.py
+++ b/src/egregora/rag/retriever.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import ibis
@@ -226,7 +226,7 @@ def _parse_media_enrichment(enrichment_path: Path) -> dict | None:
             time_str = time_match.group(1).strip()
             try:
                 parsed = datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
-                metadata["message_date"] = parsed.replace(tzinfo=datetime.UTC)
+                metadata["message_date"] = parsed.replace(tzinfo=UTC)
             except ValueError:
                 logger.warning(f"Failed to parse date/time: {date_str} {time_str}")
                 metadata["message_date"] = None
@@ -423,8 +423,8 @@ def _coerce_message_datetime(value: object) -> datetime | None:  # noqa: PLR0911
 
     if isinstance(value, datetime):
         if value.tzinfo is None:
-            return value.replace(tzinfo=datetime.UTC)
-        return value.astimezone(datetime.UTC)
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
 
     if isinstance(value, str):
         text = value.strip()
@@ -441,8 +441,8 @@ def _coerce_message_datetime(value: object) -> datetime | None:  # noqa: PLR0911
             return None
 
         if parsed.tzinfo is None:
-            return parsed.replace(tzinfo=datetime.UTC)
-        return parsed.astimezone(datetime.UTC)
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
 
     logger.warning("Unsupported message datetime type: %s", type(value))
     return None


### PR DESCRIPTION
## Summary
- import the UTC sentinel from the datetime module so retriever utilities can reference it
- update message timestamp normalization helpers to use the imported UTC constant when coercing datetimes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690212f8e26083259fa88904ba5947db