### PR TITLE
Fix google.genai stub fallback in tests

### DIFF
--- a/tests/test_gemini_batch.py
+++ b/tests/test_gemini_batch.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 try:  # pragma: no cover - exercised implicitly when dependency is present
     from google import genai as genai_module  # type: ignore
     from google.genai import types as genai_types_module  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - simple stub fallback
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - simple stub fallback
     google_module = sys.modules.get("google")
     if google_module is None:
         google_module = types.ModuleType("google")


### PR DESCRIPTION
## Summary
- guard the google genai stub installation on the specific module import so tests work when other google packages are installed

## Testing
- uv run pytest tests/test_gemini_batch.py *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_690212f25c6883259a08322fae94f322