### PR TITLE
Fix conflicts for collapse-ibis-backend-abstraction

### DIFF
--- a/src/egregora/parser.py
+++ b/src/egregora/parser.py
@@ -174,15 +174,14 @@ def filter_egregora_messages(df: Table) -> tuple[Table, int]:
     Returns:
         (filtered_df, num_removed)
     """
-    if int(df.count().execute()) == 0:
+    total_messages = int(df.count().execute())
+    if total_messages == 0:
         return df, 0
-
-    original_count = int(df.count().execute())
 
     # Filter out messages starting with /egregora (case-insensitive)
     filtered_df = df.filter(~df.message.lower().startswith("/egregora"))
 
-    removed_count = original_count - int(filtered_df.count().execute())
+    removed_count = total_messages - int(filtered_df.count().execute())
 
     if removed_count > 0:
         logger.info(f"Removed {removed_count} /egregora messages from DataFrame")


### PR DESCRIPTION
## Summary
- avoid recomputing the total message count in `filter_egregora_messages`, caching the `df.count().execute()` result before filtering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69021087560c832590b086f38f4765d7