### PR TITLE
Fix google.genai stub fallback in tests

### DIFF
--- a/tests/test_gemini_batch.py
+++ b/tests/test_gemini_batch.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 try:  # pragma: no cover - exercised implicitly when dependency is present
     from google import genai as genai_module  # type: ignore
     from google.genai import types as genai_types_module  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - simple stub fallback
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - simple stub fallback
     google_module = sys.modules.get("google")
     if google_module is None:
         google_module = types.ModuleType("google")


### PR DESCRIPTION
## Summary
- catch ImportError in addition to ModuleNotFoundError when importing google.genai stubs so the fallback activates when other google packages are installed

## Testing
- not run (duckdb dependency missing)


------
https://chatgpt.com/codex/tasks/task_e_69021657e3f48325b26b78a6270077d0