### PR TITLE
Merge main ranking extra changes and align UTC handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- Hid the ranking agent behind the optional `ranking` extra so the CLI command and APIs only load when explicitly requested.
 
 ## [2.0.0] - 2024-05-20
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Architecture Highlights
 · DataFrames all the way: Powered by Ibis + DuckDB for performance
 · Functional pipeline: Simple, composable functions over complex agents
 · DuckDB storage: Fast vector operations for RAG and rankings
+· Optional extras: Install `egregora[ranking]` to enable the experimental ranking agent
 
 🤝 Community & Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Welcome to the Egregora documentation! This guide will help you turn your WhatsA
 
 - [Privacy & Anonymization](features/anonymization.md) - UUID5-based privacy-first approach
 - [User Commands](features/privacy-commands.md) - Control your data with `/egregora` commands
-- [Post Ranking](features/ranking.md) - ELO-based quality ranking system
+- [Post Ranking](features/ranking.md) - *(optional extra)* ELO-based quality ranking system
 - [Multi-Post Generation](features/multi-post.md) - Automatic thread detection and separation
 - [RAG Enrichment](features/rag.md) - Context-aware post enrichment
 

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -482,7 +482,7 @@ Editor quality depends on RAG index quality.
 
 - [RAG System](rag.md) - How RAG queries work
 - [Architecture](../guides/architecture.md) - Where the editor fits
-- [Post Ranking](ranking.md) - Quality assessment system
+- [Post Ranking](ranking.md) - Quality assessment system *(optional extra)*
 
 ## Code Reference
 

--- a/docs/features/ranking.md
+++ b/docs/features/ranking.md
@@ -2,6 +2,9 @@
 
 The Ranking Agent creates a dynamic ELO ranking system for blog posts using LLM-powered comparisons with profile impersonation.
 
+!!! note "Optional extra"
+    The ranking feature ships as an optional plug-in. Install Egregora with `pip install "egregora[ranking]"` to enable the `egregora rank` command and related APIs.
+
 ## Overview
 
 ### Three-Turn Conversation Protocol

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -418,5 +418,5 @@ Now that you understand the concepts:
 
 - [Try the Quickstart](quickstart.md) - Build your first blog
 - [Learn about Privacy](../features/anonymization.md) - Deep dive into anonymization
-- [Explore Features](../features/ranking.md) - Post ranking, RAG, etc.
+- [Explore Features](../features/ranking.md) - Post ranking *(optional extra)*, RAG, etc.
 - [Read the Architecture](../guides/architecture.md) - System design details

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -129,6 +129,8 @@ Use the ELO-based ranking system to identify your best content:
 egregora rank --site_dir . --comparisons 50
 ```
 
+> ℹ️ Install with `pip install "egregora[ranking]"` to expose the ranking command. Without the optional extra the command stays hidden.
+
 See [Post Ranking](../features/ranking.md) for details.
 
 ### Process More Dates

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -145,6 +145,9 @@ for result in results:
 
 ## Ranking System
 
+!!! note "Install the ranking extra"
+    Importing `egregora.ranking` requires installing the optional plug-in: `pip install "egregora[ranking]"`.
+
 ### RankingStore
 
 DuckDB-based ELO ranking store.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,6 +187,9 @@ egregora process whatsapp-export.zip \
 
 ### egregora rank
 
+!!! warning "Requires optional extra"
+    Install Egregora with `pip install "egregora[ranking]"` to expose this command. Without the extra, `egregora rank` remains hidden from `--help` output and calling it prints an installation hint.
+
 Run ELO-based ranking comparisons for blog posts.
 
 **Usage:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
     "pymdown-extensions>=10.0",
     "codespell>=2.3.0",
 ]
+ranking = []
 lint = [
     "pre-commit>=3.8",
     "ruff>=0.4.4",

--- a/src/egregora/cli.py
+++ b/src/egregora/cli.py
@@ -1,6 +1,7 @@
 """Typer-based CLI for Egregora v2."""
 
 import asyncio
+import importlib
 import logging
 import os
 import random
@@ -19,9 +20,6 @@ from .config_types import ProcessConfig, RankingCliConfig
 from .editor_agent import run_editor_session
 from .model_config import ModelConfig, load_site_config
 from .pipeline import process_whatsapp_export
-from .ranking.agent import run_comparison
-from .ranking.elo import get_posts_to_compare
-from .ranking.store import RankingStore
 from .site_config import find_mkdocs_file, resolve_site_paths
 from .site_scaffolding import ensure_mkdocs_project
 
@@ -311,157 +309,6 @@ def process(  # noqa: PLR0913
     _validate_and_run_process(config)
 
 
-def _run_ranking_session(config: RankingCliConfig, gemini_key: str | None):  # noqa: PLR0915
-    """Run the ranking session with the given configuration."""
-    if config.debug:
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format="%(message)s",
-            handlers=[RichHandler(console=console)],
-        )
-
-    site_path = config.site_dir.resolve()
-    if not site_path.exists():
-        console.print(f"[red]Site directory not found: {site_path}[/red]")
-        raise typer.Exit(1)
-
-    site_paths = resolve_site_paths(site_path)
-    posts_dir = site_paths.posts_dir
-    rankings_dir = site_paths.rankings_dir
-    profiles_dir = site_paths.profiles_dir
-
-    if not posts_dir.exists():
-        console.print(f"[red]Posts directory not found: {posts_dir}[/red]")
-        console.print("Run 'egregora process' first to generate posts")
-        raise typer.Exit(1)
-
-    # Initialize rankings
-    store = RankingStore(rankings_dir)
-    post_files = sorted(posts_dir.glob("**/*.md"))
-    post_ids = [p.stem for p in post_files]
-
-    if not post_ids:
-        console.print("[red]No posts found to rank[/red]")
-        raise typer.Exit(1)
-
-    newly_initialized = store.initialize_ratings(post_ids)
-    if newly_initialized > 0:
-        console.print(f"[green]Initialized {newly_initialized} new posts with ELO 1500[/green]")
-
-    # Get API key
-    api_key = _resolve_gemini_key(gemini_key)
-    if not api_key:
-        console.print("[red]Error: GOOGLE_API_KEY not set[/red]")
-        console.print("Provide via --gemini-key or set GOOGLE_API_KEY environment variable")
-        raise typer.Exit(1)
-
-    # Load model config
-    site_config = load_site_config(site_path)
-    model_config = ModelConfig(cli_model=config.model, site_config=site_config)
-    ranking_model = model_config.get_model("ranking")
-    logger.info("[blue]⚖️  Ranking model:[/] %s", ranking_model)
-
-    # Run comparisons
-    for i in range(config.comparisons):
-        console.print(
-            Panel(
-                f"[bold cyan]Comparison {i + 1} of {config.comparisons}[/bold cyan]",
-                border_style="cyan",
-            )
-        )
-
-        try:
-            post_a_id, post_b_id = get_posts_to_compare(rankings_dir, strategy=config.strategy)
-            console.print(f"[cyan]Comparing: {post_a_id} vs {post_b_id}[/cyan]")
-        except ValueError as e:
-            console.print(f"[red]{e}[/red]")
-            break
-
-        # Pick random profile
-        profile_files = list(profiles_dir.glob("*.md"))
-        if not profile_files:
-            console.print("[yellow]No profiles found, using default judge[/yellow]")
-            # Create a default profile
-            default_profile = profiles_dir / "judge.md"
-            default_profile.parent.mkdir(parents=True, exist_ok=True)
-            default_profile.write_text(
-                "---\nuuid: judge\nalias: Judge\n---\nA fair and balanced judge."
-            )
-            profile_files = [default_profile]
-
-        profile_path = random.choice(profile_files)
-
-        try:
-            run_comparison(
-                site_dir=site_path,
-                post_a_id=post_a_id,
-                post_b_id=post_b_id,
-                profile_path=profile_path,
-                api_key=api_key,
-                model=ranking_model,
-            )
-        except Exception as e:
-            console.print(f"[red]Comparison failed: {e}[/red]")
-            if config.debug:
-                raise
-            continue
-
-    # Export to Parquet if requested
-    if config.export_parquet:
-        store.export_to_parquet()
-        console.print(f"[green]Exported rankings to {rankings_dir}[/green]")
-
-    # Display stats
-    stats = store.stats()
-    console.print(
-        Panel(
-            f"[bold]Ranking Statistics:[/bold]\n"
-            f"• Total posts: {stats['total_posts']}\n"
-            f"• Total comparisons: {stats['total_comparisons']}\n"
-            f"• Avg games per post: {stats['avg_games_per_post']:.1f}\n"
-            f"• Highest ELO: {stats['highest_elo']:.0f}\n"
-            f"• Lowest ELO: {stats['lowest_elo']:.0f}",
-            title="📊 Rankings",
-            border_style="green",
-        )
-    )
-
-
-@app.command()
-def rank(  # noqa: PLR0913
-    site_dir: Annotated[Path, typer.Argument(help="Path to MkDocs site directory")],
-    comparisons: Annotated[int, typer.Option(help="Number of comparisons to run")] = 1,
-    strategy: Annotated[str, typer.Option(help="Post selection strategy")] = "fewest_games",
-    export_parquet: Annotated[
-        bool, typer.Option(help="Export rankings to Parquet after comparisons")
-    ] = False,
-    gemini_key: Annotated[
-        str | None,
-        typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
-    ] = None,
-    model: Annotated[
-        str | None, typer.Option(help="Gemini model to use (or configure in mkdocs.yml)")
-    ] = None,
-    debug: Annotated[bool, typer.Option(help="Enable debug logging")] = False,
-):
-    """
-    Run ELO-based ranking comparisons on posts using LLM judge.
-
-    Compares posts pairwise and updates ELO ratings. The LLM impersonates
-    a reader profile and provides detailed comments on each post.
-    """
-    config = RankingCliConfig(
-        site_dir=site_dir,
-        comparisons=comparisons,
-        strategy=strategy,
-        export_parquet=export_parquet,
-        model=model,
-        debug=debug,
-    )
-
-    _run_ranking_session(config, gemini_key)
-
-
 @app.command()
 def edit(
     post_path: Annotated[Path, typer.Argument(help="Path to the post markdown file")],
@@ -553,6 +400,192 @@ def edit(
     except Exception as e:
         console.print(f"[red]Editor session failed: {e}[/red]")
         raise typer.Exit(1) from e
+
+
+def _register_ranking_cli(app: typer.Typer) -> None:  # noqa: PLR0915
+    """Register ranking commands when the optional extra is installed."""
+
+    try:
+        ranking_agent = importlib.import_module("egregora.ranking.agent")
+        ranking_elo = importlib.import_module("egregora.ranking.elo")
+        ranking_store_module = importlib.import_module("egregora.ranking.store")
+        run_comparison = ranking_agent.run_comparison
+        get_posts_to_compare = ranking_elo.get_posts_to_compare
+        RankingStore = ranking_store_module.RankingStore
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on installation
+        missing = exc.name or "egregora.ranking"
+
+        @app.command(hidden=True)
+        def rank(  # noqa: PLR0913
+            site_dir: Annotated[Path, typer.Argument(help="Path to MkDocs site directory")],
+            comparisons: Annotated[
+                int, typer.Option(help="Number of comparisons to run")
+            ] = 1,
+            strategy: Annotated[
+                str, typer.Option(help="Post selection strategy")
+            ] = "fewest_games",
+            export_parquet: Annotated[
+                bool, typer.Option(help="Export rankings to Parquet after comparisons")
+            ] = False,
+            gemini_key: Annotated[
+                str | None,
+                typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
+            ] = None,
+            model: Annotated[
+                str | None,
+                typer.Option(help="Gemini model to use (or configure in mkdocs.yml)"),
+            ] = None,
+            debug: Annotated[bool, typer.Option(help="Enable debug logging")] = False,
+        ) -> None:
+            console.print(
+                "[red]Ranking commands require the optional extra: "
+                "pip install 'egregora[ranking]'[/red]"
+            )
+            console.print(f"[yellow]Missing dependency: {missing}[/yellow]")
+            raise typer.Exit(1)
+
+        logger.debug("Ranking extra unavailable: %s", missing)
+        return
+
+    def _run_ranking_session(  # noqa: PLR0915
+        config: RankingCliConfig, gemini_key: str | None
+    ) -> None:
+        site_path = config.site_dir.resolve()
+        if not site_path.exists():
+            console.print(f"[red]Site directory not found: {site_path}[/red]")
+            raise typer.Exit(1)
+
+        site_paths = resolve_site_paths(site_path)
+        posts_dir = site_paths.posts_dir
+        rankings_dir = site_paths.rankings_dir
+        profiles_dir = site_paths.profiles_dir
+
+        if not posts_dir.exists():
+            console.print(f"[red]Posts directory not found: {posts_dir}[/red]")
+            console.print("Run 'egregora process' first to generate posts")
+            raise typer.Exit(1)
+
+        store = RankingStore(rankings_dir)
+        post_files = sorted(posts_dir.glob("**/*.md"))
+        post_ids = [p.stem for p in post_files]
+
+        if not post_ids:
+            console.print("[red]No posts found to rank[/red]")
+            raise typer.Exit(1)
+
+        newly_initialized = store.initialize_ratings(post_ids)
+        if newly_initialized > 0:
+            console.print(f"[green]Initialized {newly_initialized} new posts with ELO 1500[/green]")
+
+        api_key = _resolve_gemini_key(gemini_key)
+        if not api_key:
+            console.print("[red]Error: GOOGLE_API_KEY not set[/red]")
+            console.print("Provide via --gemini-key or set GOOGLE_API_KEY environment variable")
+            raise typer.Exit(1)
+
+        site_config = load_site_config(site_path)
+        model_config = ModelConfig(cli_model=config.model, site_config=site_config)
+        ranking_model = model_config.get_model("ranking")
+        logger.info("[blue]⚖️  Ranking model:[/] %s", ranking_model)
+
+        for i in range(config.comparisons):
+            console.print(
+                Panel(
+                    f"[bold cyan]Comparison {i + 1} of {config.comparisons}[/bold cyan]",
+                    border_style="cyan",
+                )
+            )
+
+            try:
+                post_a_id, post_b_id = get_posts_to_compare(
+                    rankings_dir, strategy=config.strategy
+                )
+                console.print(f"[cyan]Comparing: {post_a_id} vs {post_b_id}[/cyan]")
+            except ValueError as e:
+                console.print(f"[red]{e}[/red]")
+                break
+
+            profile_files = list(profiles_dir.glob("*.md"))
+            if not profile_files:
+                console.print("[yellow]No profiles found, using default judge[/yellow]")
+                default_profile = profiles_dir / "judge.md"
+                default_profile.parent.mkdir(parents=True, exist_ok=True)
+                default_profile.write_text(
+                    "---\nuuid: judge\nalias: Judge\n---\nA fair and balanced judge."
+                )
+                profile_files = [default_profile]
+
+            profile_path = random.choice(profile_files)
+
+            try:
+                run_comparison(
+                    site_dir=site_path,
+                    post_a_id=post_a_id,
+                    post_b_id=post_b_id,
+                    profile_path=profile_path,
+                    api_key=api_key,
+                    model=ranking_model,
+                )
+            except Exception as e:
+                console.print(f"[red]Comparison failed: {e}[/red]")
+                if config.debug:
+                    raise
+                continue
+
+        if config.export_parquet:
+            store.export_to_parquet()
+            console.print(f"[green]Exported rankings to {rankings_dir}[/green]")
+
+        stats = store.stats()
+        console.print(
+            Panel(
+                f"[bold]Ranking Statistics:[/bold]\n"
+                f"• Total posts: {stats['total_posts']}\n"
+                f"• Total comparisons: {stats['total_comparisons']}\n"
+                f"• Avg games per post: {stats['avg_games_per_post']:.1f}\n"
+                f"• Highest ELO: {stats['highest_elo']:.0f}\n"
+                f"• Lowest ELO: {stats['lowest_elo']:.0f}",
+                title="📊 Rankings",
+                border_style="green",
+            )
+        )
+
+    @app.command()
+    def rank(  # noqa: PLR0913
+        site_dir: Annotated[Path, typer.Argument(help="Path to MkDocs site directory")],
+        comparisons: Annotated[
+            int, typer.Option(help="Number of comparisons to run")
+        ] = 1,
+        strategy: Annotated[
+            str, typer.Option(help="Post selection strategy")
+        ] = "fewest_games",
+        export_parquet: Annotated[
+            bool, typer.Option(help="Export rankings to Parquet after comparisons")
+        ] = False,
+        gemini_key: Annotated[
+            str | None,
+            typer.Option(help="Google Gemini API key (flag overrides GOOGLE_API_KEY env var)"),
+        ] = None,
+        model: Annotated[
+            str | None, typer.Option(help="Gemini model to use (or configure in mkdocs.yml)")
+        ] = None,
+        debug: Annotated[bool, typer.Option(help="Enable debug logging")] = False,
+    ) -> None:
+        """Run ELO-based ranking comparisons on posts using the ranking agent."""
+
+        config = RankingCliConfig(
+            site_dir=site_dir,
+            comparisons=comparisons,
+            strategy=strategy,
+            export_parquet=export_parquet,
+            model=model,
+            debug=debug,
+        )
+
+        _run_ranking_session(config, gemini_key)
+
+
+_register_ranking_cli(app)
 
 
 def main():

--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -1,10 +1,9 @@
 """Vector store using DuckDB VSS and Parquet."""
 
 import logging
-import math
 import uuid
 from dataclasses import dataclass
-from datetime import date, datetime, time, timezone
+from datetime import UTC, date, datetime, time
 from pathlib import Path
 from typing import Any
 
@@ -674,7 +673,7 @@ class VectorStore:
             return VectorStore._ensure_utc_datetime(value)
 
         if isinstance(value, date):
-            return datetime.combine(value, time.min, tzinfo=timezone.utc)
+            return datetime.combine(value, time.min, tzinfo=UTC)
 
         if isinstance(value, str):
             cleaned = value.strip()
@@ -688,7 +687,7 @@ class VectorStore:
                     parsed_date = date.fromisoformat(cleaned)
                 except ValueError as exc:  # pragma: no cover - defensive guard
                     raise ValueError(f"Invalid date_after value: {value!r}") from exc
-                return datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+                return datetime.combine(parsed_date, time.min, tzinfo=UTC)
 
             return VectorStore._ensure_utc_datetime(parsed_dt)
 
@@ -701,9 +700,9 @@ class VectorStore:
         """Coerce datetime objects to UTC-aware variants."""
 
         if value.tzinfo is None:
-            return value.replace(tzinfo=timezone.utc)
+            return value.replace(tzinfo=UTC)
 
-        return value.astimezone(timezone.utc)
+        return value.astimezone(UTC)
 
     def _ensure_arrow_table(self, arrow_object: Any) -> pa.Table:
         """Normalize DuckDB Arrow results to a ``pyarrow.Table`` instance."""

--- a/tests/test_rag_store.py
+++ b/tests/test_rag_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import duckdb
@@ -344,7 +344,7 @@ def test_search_filters_accept_temporal_inputs(tmp_path, monkeypatch):
                 document_id="media-jan",
                 media_uuid="media-jan",
                 media_type="image",
-                message_date=datetime(2024, 1, 1, 12, tzinfo=timezone.utc),
+                message_date=datetime(2024, 1, 1, 12, tzinfo=UTC),
                 tags=[],
                 authors=[],
             ),

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.4.4" },
     { name = "typer", extras = ["all"], specifier = ">=0.20.0" },
 ]
-provides-extras = ["test", "docs", "lint"]
+provides-extras = ["test", "docs", "ranking", "lint"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.14.0" }]


### PR DESCRIPTION
## Summary
- merge main's optional ranking extra gating into the branch and wire the CLI to hide ranking commands when the plug-in is missing
- update RAG datetime normalisation helpers to use the standard `UTC` alias and simplify their control flow
- adjust the RAG store tests to match the new timezone handling

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_690213d78bac832590f03a185346e241