### PR TITLE
Add DuckDB Arrow fallbacks for ranking and rag stores

### DIFF
--- a/src/egregora/rag/store.py
+++ b/src/egregora/rag/store.py
@@ -714,17 +714,22 @@ class VectorStore:
         if isinstance(arrow_object, pa.RecordBatchReader):
             return arrow_object.read_all()
 
-        read_all = getattr(arrow_object, "read_all", None)
-        if callable(read_all):
-            result = read_all()
+        for attr in ("read_all", "to_table", "to_arrow_table"):
+            method = getattr(arrow_object, attr, None)
+            if not callable(method):
+                continue
+
+            result = method()
+            if isinstance(result, pa.RecordBatchReader):
+                return result.read_all()
             if isinstance(result, pa.Table):
                 return result
 
-        to_table = getattr(arrow_object, "to_table", None)
-        if callable(to_table):
-            result = to_table()
-            if isinstance(result, pa.Table):
-                return result
+        to_pydict = getattr(arrow_object, "to_pydict", None)
+        if callable(to_pydict):
+            data = to_pydict()
+            if isinstance(data, dict):
+                return pa.Table.from_pydict(data)
 
         raise TypeError(f"Unsupported Arrow object type: {type(arrow_object)!r}")
 


### PR DESCRIPTION
## Summary
- extend the ranking store Arrow conversion helper to accept DuckDB objects exposing `to_arrow_table` or `to_pydict`
- update the vector store Arrow normalization to recognize `to_arrow_table` and `to_pydict` fallbacks

## Testing
- `uv run --with duckdb pytest` *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_6902165a9e848325956f80aa475585d9