### PR TITLE
Refactor writer pipeline to use Arrow tables

### DIFF
--- a/src/egregora/profiler.py
+++ b/src/egregora/profiler.py
@@ -87,7 +87,12 @@ def get_active_authors(df: Any) -> list[str]:
         arrow_table = df.select("author").distinct().to_pyarrow()
     except AttributeError:  # pragma: no cover - fallback for non-ibis tables
         result = df.select("author").distinct().execute()
-        if hasattr(result, "tolist"):
+        if hasattr(result, "columns"):
+            if "author" in result.columns:
+                authors = result["author"].tolist()
+            else:  # pragma: no cover - defensive path for misnamed columns
+                authors = result.iloc[:, 0].tolist()
+        elif hasattr(result, "tolist"):
             authors = list(result.tolist())
         else:  # pragma: no cover - defensive path
             authors = list(result)


### PR DESCRIPTION
## Sumário
- substitui as conversões para `pandas.DataFrame` no writer por fluxos baseados em `pyarrow.Table`, mantendo os dados em Arrow até o momento de gerar o markdown
- adapta as rotinas de formatação de conversas para aceitar entradas genéricas (Arrow, listas de mapeamentos) e gerar as colunas em memória sem depender de pandas
- atualiza o cálculo dos autores ativos e as fixtures de teste para trabalharem com tabelas Arrow
- corrige o fallback de detecção de autores ativos para preservar a extração a partir de DataFrames quando Arrow não está disponível

## Motivação
- reduzir o acoplamento com pandas no caminho crítico de geração de posts, conforme a iniciativa de minimizar o uso dessa dependência e privilegiar Arrow/Ibis
- permitir tornar pandas opcional no futuro, mantendo compatibilidade com cenários em que a biblioteca não esteja instalada

## Testes
- não executado nesta etapa; alteração restrita ao fallback do profiler

------
https://chatgpt.com/codex/tasks/task_e_690223be66c88325bfb150f7e1ceefca

------
https://chatgpt.com/codex/tasks/task_e_690229665e2c8325967f3fe713c4540c