### PR TITLE
Handle Gemini EmbedContentResponse values in embedding client

### DIFF
--- a/src/egregora_v3/adapters/embeddings/gemini.py
+++ b/src/egregora_v3/adapters/embeddings/gemini.py
@@ -44,6 +44,22 @@ class GeminiEmbeddingClient:
             if embedding is None:
                 raise TypeError("Failed to extract embedding from Gemini response")
 
-            embeddings.append(embedding)
+            values = None
+            if hasattr(embedding, "values"):
+                values = getattr(embedding, "values")
+            elif isinstance(embedding, dict):
+                values = embedding.get("values")
+            elif isinstance(embedding, (list, tuple)):
+                values = embedding
+
+            if values is None:
+                raise TypeError("Gemini embedding does not contain numeric values")
+
+            try:
+                numeric_values = [float(v) for v in values]
+            except (TypeError, ValueError):
+                raise TypeError("Gemini embedding values are not numeric") from None
+
+            embeddings.append(numeric_values)
 
         return embeddings


### PR DESCRIPTION
## Summary
- unwrap Gemini EmbedContentResponse objects to extract their numeric values
- validate that returned embeddings contain numeric floats before returning them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69022f11286c83258435997058ec4fd2