### PR TITLE
Document TENET-BREAK violation flag usage

### DIFF
--- a/.egregora-tenets.yml
+++ b/.egregora-tenets.yml
@@ -1,0 +1,5 @@
+tenets:
+  no-compat: "No backwards compatibility layers or shims."
+  clean: "Code must be simple, readable, and minimal."
+  no-defensive: "Do not guard against impossible states; rely on types/tests."
+  propagate-errors: "Do not swallow errors; let them bubble to boundaries."

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -25,6 +25,122 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install -e '.[docs,lint,test]'
 ```
 
+## TENET-BREAK — Philosophy Violation Flag
+
+Love it. Here’s a single, loud flag tailored for Egregora.
+
+**TENET-BREAK — Philosophy Violation Flag**
+
+Use exactly one tag to mark intentional violations of Egregora’s core principles. It’s a red flare for future cleanup and review.
+
+### When to Use
+
+Only when an external constraint (vendor, deadline, migration window) forces you to go against a tenet such as:
+
+- `no-compat` — No backwards compatibility shims.
+- `clean` — Clean code; clarity over cleverness; no “quick-and-dirty.”
+- `no-defensive` — Don’t code defensively for “impossible states”; trust types + tests.
+- `propagate-errors` — Let errors bubble; don’t swallow or silently recover.
+
+> If you’re not breaking a principle, don’t use TENET-BREAK. Prefer HACK, WORKAROUND, REFACTOR, etc., for normal debt.
+
+### Required Format
+
+```
+TENET-BREAK(scope)[owner][priority][due:YYYY-MM-DD]: tenet=<code>; why=<constraint>; exit=<condition>  (#refs)
+```
+
+- **scope:** `parser|ingestion|pipeline|rag|embeddings|ranking|ui|api|storage|infra|i18n|compliance`
+- **owner:** `@handle` or team
+- **priority:** `P0|P1|P2` (default P1)
+- **due:** real date to remove/undo the breach
+- **tenet:** one of `no-compat|clean|no-defensive|propagate-errors`
+- **why:** short factual reason (vendor, rollout, law, bug upstream…)
+- **exit:** what must happen so we remove it (partner migrated, lib fixed, feature flag off…)
+- **#refs:** link to the issue/PR/spec
+
+### Examples
+
+```python
+# TENET-BREAK(api)[@franklin][P0][due:2025-12-01]:
+# tenet=no-compat; why=partner still on v1 payloads; exit=partner migrates (#742)
+def parse_legacy_payload(...):
+    ...
+```
+
+```ts
+// TENET-BREAK(ui)[@platform][P1][due:2025-11-30]:
+// tenet=clean; why=rushed demo; exit=replace with DataGrid v2 (#885)
+renderLegacyTable(data)
+```
+
+```go
+// TENET-BREAK(rag)[@core][P1][due:2025-12-15]:
+// tenet=no-defensive; why=uncertain third-party input; exit=type-safe adapter merged (#903)
+if q == "" { q = "fallback" } // temporary guard
+```
+
+```sql
+-- TENET-BREAK(storage)[@data][P1][due:2025-11-20]:
+-- tenet=propagate-errors; why=DuckDB UDF lacks error bubbling; exit=upgrade 1.1 (#777)
+-- Swallowing NULLs here to keep job alive
+```
+
+### Guardrails (Team Discipline)
+
+- Must include owner, due, tenet, why, exit, and a #refs link.
+- Default P0 if the breach touches security, privacy, or correctness paths.
+- One TENET-BREAK per site (don’t scatter the same rationale everywhere—link to one canonical comment).
+- Remove on time: turning a breach into “normal” code is not allowed; either fix or escalate.
+
+### Optional Repo Config (Codify the Tenets)
+
+```yaml
+.egregora-tenets.yml
+
+tenets:
+  no-compat: "No backwards compatibility layers or shims."
+  clean: "Code must be simple, readable, and minimal."
+  no-defensive: "Do not guard against impossible states; rely on types/tests."
+  propagate-errors: "Do not swallow errors; let them bubble to boundaries."
+```
+
+### Cheap CI Lint (Drop-in)
+
+```bash
+# required fields present
+rg -n 'TENET-BREAK' | rg -v 'tenet=(no-compat|clean|no-defensive|propagate-errors); .*exit=.*due:\d{4}-\d{2}-\d{2}.*#' \
+  && echo "TENET-BREAK checks passed" || (echo "TENET-BREAK missing required fields"; exit 1)
+```
+
+```python
+# Block overdue entries (example, due before today)
+python - <<'PY'
+import re, sys, datetime, pathlib
+today = datetime.date.today()
+bad = []
+for path in pathlib.Path(".").rglob("*"):
+    if path.is_file() and path.suffix not in {".png", ".jpg", ".jpeg", ".pdf", ".bin"}:
+        for idx, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            if "TENET-BREAK" in line:
+                match = re.search(r"due:(\d{4})-(\d{2})-(\d{2})", line)
+                if match and datetime.date(*map(int, match.groups())) < today:
+                    bad.append(f"{path}:{idx}: overdue TENET-BREAK -> {line.strip()}")
+if bad:
+    print("\n".join(bad))
+    sys.exit(1)
+PY
+```
+
+### Decision Checklist (Before Adding One)
+
+1. Is this truly a principle breach (not just debt)?
+2. Is there a ticket and a real exit?
+3. Did you put the breach in the narrowest scope?
+4. Did you set a due date you will actually meet?
+
+## Testing
+
 > **Tip:** The RAG retriever depends on DuckDB's `vss` extension. The development install above
 > pulls in `duckdb` by default, but the first `pytest` or `egregora process` run still needs to
 > download the extension. Ensure your machine has network access or install it manually with


### PR DESCRIPTION
## Summary
- document the TENET-BREAK philosophy violation flag in the development guide, including usage rules, required format, guardrails, and automation helpers
- add the optional `.egregora-tenets.yml` configuration file that codifies the four core tenets referenced by TENET-BREAK comments

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_69025d2f75408325a9364dd514d5e6a6