### PR TITLE
fix: align async media enrichment upload arguments

### DIFF
--- a/src/egregora/enricher.py
+++ b/src/egregora/enricher.py
@@ -174,8 +174,7 @@ async def enrich_media(
 
     uploaded_file = await call_with_retries(
         upload_fn,
-        path=str(file_path),
-        display_name=file_path.name,
+        file=str(file_path),
     )
 
     parts = [genai_types.Part(text=prompt)]
@@ -187,7 +186,6 @@ async def enrich_media(
                 file_data=genai_types.FileData(
                     file_uri=upload_uri,
                     mime_type=mime_type,
-                    display_name=file_path.name,
                 )
             )
         )


### PR DESCRIPTION
## Summary
- update the async `enrich_media` helper to pass the new `file=` argument when uploading media
- drop the deprecated `display_name` field when constructing `FileData` parts to match the google-genai client

## Testing
- uv run --with pytest pytest tests/test_enricher.py

------
https://chatgpt.com/codex/tasks/task_e_69025d35034083259724356982e047ce