### PR TITLE
Refactor: Align with propagate-errors tenet (retry HTTP 429 responses)

### DIFF
--- a/src/egregora/genai_utils.py
+++ b/src/egregora/genai_utils.py
@@ -33,6 +33,7 @@ _RETRYABLE_EXCEPTIONS = (
     google_api_exceptions.ServiceUnavailable,
     google_api_exceptions.InternalServerError,
     google_api_exceptions.DeadlineExceeded,
+    google_api_exceptions.TooManyRequests,
 )
 
 


### PR DESCRIPTION
This commit addresses violations of the `propagate-errors` tenet by replacing broad `except Exception` blocks with more specific exception handling across the codebase. This makes the code more robust, easier to debug, and ensures that unexpected errors cause a fast failure.

Key changes:
- `genai_utils.py`: Replaced generic exception handling with specific `google-api-core` exceptions for retries. Added `google-api-core` as a dependency.
- `writer.py`: Narrowed exception handling in `_process_tool_calls` to only catch `ValueError`, allowing unexpected errors to propagate.
- `parser.py`: Refactored date/time parsing to raise `ValueError` on failure instead of returning `None`, making parsing stricter.
- `pipeline.py`: Removed error swallowing for RAG indexing to allow errors to propagate up to the caller.
- `profiler.py`: Refined exception handling in the `process_commands` loop to catch `KeyError` and `OSError`, allowing other errors to surface.
- `cli.py`: Improved the top-level exception handler in the CLI to catch a more specific set of exceptions, providing better error messages to the user.
- `tests/test_gemini_batch.py`: Updated a test to raise `google.api_core.exceptions.ResourceExhausted` to align with the refactored retry logic.
- `genai_utils.py`: Ensure HTTP 429 responses (TooManyRequests) remain eligible for retries to preserve rate-limit handling.

---
*PR created automatically by Jules for task [17759530284557946403](https://jules.google.com/task/17759530284557946403)*

------
https://chatgpt.com/codex/tasks/task_e_690295a5e9a883259051cf6789105502