### PR TITLE
Ensure Google retry loop respects max attempts

### DIFF
--- a/src/egregora/genai_utils.py
+++ b/src/egregora/genai_utils.py
@@ -191,6 +191,8 @@ async def call_with_retries[**P, T](
         try:
             return await async_fn(*args, **kwargs)
         except _RETRYABLE_EXCEPTIONS as exc:
+            if attempt >= max_attempts:
+                raise
             handled_exc: Exception = exc
         except Exception as exc:  # noqa: BLE001
             if not _is_rate_limit_error(exc) or attempt >= max_attempts:
@@ -228,6 +230,8 @@ def call_with_retries_sync(
         try:
             return fn(*args, **kwargs)
         except _RETRYABLE_EXCEPTIONS as exc:
+            if attempt >= max_attempts:
+                raise
             handled_exc: Exception = exc
         except Exception as exc:  # noqa: BLE001
             if not _is_rate_limit_error(exc) or attempt >= max_attempts:


### PR DESCRIPTION
## Summary
- stop retry loops for Google API errors once the configured max attempts is reached
- keep raising the original exception on the final attempt for both async and sync helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902a735aed08325b26d7049adace817