### PR TITLE
Add frontmatter stub and tighten chunker type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 check_untyped_defs = true
 disallow_untyped_defs = false
+mypy_path = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/egregora/rag/chunker.py
+++ b/src/egregora/rag/chunker.py
@@ -42,10 +42,10 @@ def chunk_markdown(
         List of text chunks
     """
     # Split into paragraphs
-    paragraphs = content.split("\n\n")
+    paragraphs: list[str] = content.split("\n\n")
 
-    chunks = []
-    current_chunk = []
+    chunks: list[str] = []
+    current_chunk: list[str] = []
     current_tokens = 0
 
     for paragraph in paragraphs:
@@ -62,7 +62,7 @@ def chunk_markdown(
             chunks.append(chunk_text)
 
             # Start new chunk with overlap (keep last few paragraphs)
-            overlap_paras = []
+            overlap_paras: list[str] = []
             overlap_tokens_count = 0
 
             for prev_para in reversed(current_chunk):
@@ -151,7 +151,7 @@ def chunk_document(
     text_chunks = chunk_markdown(content, max_tokens=max_tokens)
 
     # Build chunk objects
-    chunks = []
+    chunks: list[dict[str, Any]] = []
     for i, chunk_text in enumerate(text_chunks):
         chunks.append(
             {

--- a/src/frontmatter/__init__.pyi
+++ b/src/frontmatter/__init__.pyi
@@ -1,0 +1,7 @@
+from typing import Any, Mapping, Protocol, TextIO
+
+class Post(Protocol):
+    metadata: Mapping[str, Any]
+    content: str
+
+def load(fp: TextIO) -> Post: ...


### PR DESCRIPTION
## Summary
- add a local typing stub for `python-frontmatter` so mypy can resolve the import used by the chunker
- annotate the mutable accumulators inside `egregora.rag.chunker` to make their intended types explicit
- point mypy at the `src/` tree so the new stub package is discoverable during type checking

## Testing
- `mypy src/egregora/rag/chunker.py` *(fails: existing repository-wide missing third-party stubs and legacy typing issues outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_6902ab52946c83259b5429113524fe12