### PR TITLE
Guard pydantic import in models module

### DIFF
--- a/src/egregora/models.py
+++ b/src/egregora/models.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+try:
+    from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    msg = "`pydantic` is required for egregora's configuration models."
+    raise RuntimeError(msg) from exc
 
 from .types import GroupSlug
 
@@ -28,7 +32,7 @@ class WhatsAppExport:
 class MergeConfig(BaseModel):
     """Configuration for merging multiple groups into a virtual group."""
 
-    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", validate_assignment=True)
 
     name: str  # "RC Americas"
     source_groups: list[GroupSlug] = Field(


### PR DESCRIPTION
## Summary
- add a runtime guard around the `pydantic` import in `models.py`, surfacing a clear error when the optional dependency is absent so the module follows the repository’s optional dependency convention
- annotate `MergeConfig.model_config` as a `ClassVar[ConfigDict]` to eliminate the implicit `Any` and keep the model configuration type-safe during validation

## Testing
- `mypy src/egregora/models.py` *(fails: environment lacks third-party stubs for ibis, yaml, google, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6902ab405fe083258b28c0f9757bf721