### PR TITLE
Fix builtin decorator reference

### DIFF
--- a/src/egregora/schema.py
+++ b/src/egregora/schema.py
@@ -24,7 +24,7 @@ MESSAGE_SCHEMA: dict[str, dt.DataType] = {
 }
 
 
-@utable.scalar.builtin(
+@udf.scalar.builtin(
     name="timezone",
     signature=((dt.string, dt.Timestamp(timezone=None)), dt.Timestamp(timezone="UTC")),
 )


### PR DESCRIPTION
## Summary
- restore the `_builtin_timezone` decorator to `udf.scalar.builtin` so the module imports correctly

## Testing
- not run (import-only fix)


------
https://chatgpt.com/codex/tasks/task_e_6902daf53a708325b454c9a4273ff5be