### PR TITLE
Refactor prompt templates into ABC-backed classes

### DIFF
--- a/src/egregora/editor/agent.py
+++ b/src/egregora/editor/agent.py
@@ -23,7 +23,7 @@ from ibis.expr.types import Table
 from .document import DocumentSnapshot, Editor
 from ..utils import GeminiBatchClient, call_with_retries
 from ..config import ModelConfig
-from ..prompt_templates import render_editor_prompt
+from ..prompt_templates import EditorPromptTemplate
 from ..rag import query_similar_posts, VectorStore
 
 logger = logging.getLogger(__name__)
@@ -270,13 +270,13 @@ async def run_editor_session(  # noqa: PLR0912, PLR0913, PLR0915
 
     # Prepare initial prompt
     context = context or {}
-    prompt = render_editor_prompt(
+    prompt = EditorPromptTemplate(
         post_content=original_content,
         doc_id=str(post_path),
         version=snapshot.version,
         lines=snapshot.lines,
         context=context,
-    )
+    ).render()
 
     # Initialize conversation
     conversation_history = [genai_types.Content(role="user", parts=[genai_types.Part(text=prompt)])]

--- a/src/egregora/writer/core.py
+++ b/src/egregora/writer/core.py
@@ -39,7 +39,7 @@ from ..annotations import ANNOTATION_AUTHOR, Annotation, AnnotationStore
 from ..utils import GeminiBatchClient, call_with_retries_sync
 from ..config import ModelConfig, load_mkdocs_config
 from ..profiler import get_active_authors, read_profile, write_profile
-from ..prompt_templates import render_writer_prompt
+from ..prompt_templates import WriterPromptTemplate
 from ..rag import VectorStore, index_post, query_media, query_similar_posts
 from ..write_post import write_post
 
@@ -1118,7 +1118,7 @@ Use these features appropriately in your posts. You understand how each extensio
 """
 
     # Build prompt
-    prompt = render_writer_prompt(
+    prompt = WriterPromptTemplate(
         date=period_date,
         markdown_table=markdown_table,
         active_authors=", ".join(active_authors),
@@ -1128,7 +1128,7 @@ Use these features appropriately in your posts. You understand how each extensio
         rag_context=rag_context,
         freeform_memory=freeform_memory,
         enable_memes=meme_help_enabled,
-    )
+    ).render()
 
     # Setup conversation
     config = genai_types.GenerateContentConfig(


### PR DESCRIPTION
## Summary
- replace the collection of prompt-rendering helper functions with ABC-based dataclass templates so that each prompt exposes a consistent render interface and can accept alternate Jinja environments when needed
- update the writer, editor, and enricher modules to construct the new template objects, keeping existing prompt content while preparing the code for future reuse and extension

## Testing
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `ruff check src/egregora/prompt_templates.py src/egregora/enricher/core.py src/egregora/editor/agent.py src/egregora/writer/core.py` *(fails: existing import ordering and typing warnings in touched files)*

------
https://chatgpt.com/codex/tasks/task_e_6902dd5c6abc832580c81c661c2e4ebf