### PR TITLE
Allow blank WhatsApp messages and cover with test

### DIFF
--- a/src/egregora/parser.py
+++ b/src/egregora/parser.py
@@ -270,7 +270,7 @@ _LINE_PATTERN = re.compile(
     r"(?:\s*(?P<ampm>[APap][Mm]))?"
     r"\s*[—\-]\s*"
     r"(?P<author>[^:]+?):\s*"
-    r"(?P<message>.+)"
+    r"(?P<message>.*)"
     r")$"
 )
 

--- a/tests/test_whatsapp_real_scenario.py
+++ b/tests/test_whatsapp_real_scenario.py
@@ -165,6 +165,16 @@ def test_parser_preserves_all_messages(whatsapp_fixture: WhatsAppFixture):
     assert participant_rows.count().execute() == 10
 
 
+def test_parser_retains_blank_message_payloads(whatsapp_fixture: WhatsAppFixture):
+    export = create_export_from_fixture(whatsapp_fixture)
+    table = parse_export(export, timezone=whatsapp_fixture.timezone)
+
+    messages = table.execute().to_dict("records")
+    blank_payloads = [row for row in messages if row.get("message") == ""]
+
+    assert blank_payloads, "Expected at least one conversation row with an empty message payload"
+
+
 def test_parser_extracts_media_references(whatsapp_fixture: WhatsAppFixture):
     export = create_export_from_fixture(whatsapp_fixture)
     table = parse_export(export, timezone=whatsapp_fixture.timezone)


### PR DESCRIPTION
## Summary
- widen the WhatsApp line matcher so chat rows ending after the colon still produce a message entry
- add a regression test that asserts the parser returns at least one blank payload from the real fixture

## Testing
- PYTHONPATH=src pytest tests/test_whatsapp_real_scenario.py::test_parser_retains_blank_message_payloads -q *(fails: ModuleNotFoundError: No module named 'egregora.cache' in local test environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902e89ab65883258656a0f156b97d32