### PR TITLE
Move DuckDB schema to shared SQL file

### DIFF
--- a/docs/features/ranking.md
+++ b/docs/features/ranking.md
@@ -58,7 +58,24 @@ Rankings are stored in a **DuckDB database** for fast updates and efficient quer
 
 ### Primary Storage: `rankings.duckdb`
 
-DuckDB database with two tables:
+DuckDB database with four tables:
+
+**`elo_profiles` table:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `profile_id` | VARCHAR | Judge profile UUID (PRIMARY KEY) |
+| `first_seen` | TIMESTAMP | When the judge first appeared |
+
+**`elo_profile_stats` table:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `profile_id` | VARCHAR | FK to `elo_profiles.profile_id` |
+| `alias` | VARCHAR | Preferred display name (nullable) |
+| `bio` | VARCHAR | Short bio excerpt (nullable) |
+| `comparisons` | INTEGER | Total comparisons performed |
+| `last_seen` | TIMESTAMP | Most recent comparison timestamp |
 
 **`elo_ratings` table:**
 
@@ -84,6 +101,11 @@ DuckDB database with two tables:
 | `comment_b` | VARCHAR | Feedback on post B (max 250 chars) |
 | `stars_b` | INTEGER | Star rating for B (1-5) |
 
+Foreign keys enforce referential integrity:
+
+- `elo_history.profile_id` → `elo_profiles.profile_id`
+- `elo_history.post_a` and `elo_history.post_b` → `elo_ratings.post_id`
+
 **Why DuckDB?**
 - **Fast updates**: No read-modify-write of entire file (10-50x faster than Parquet)
 - **ACID transactions**: Safe concurrent access
@@ -100,6 +122,8 @@ egregora rank --site_dir ./blog --comparisons 10 --export_parquet
 ```
 
 Creates:
+- `rankings/elo_profiles.parquet`
+- `rankings/elo_profile_stats.parquet`
 - `rankings/elo_ratings.parquet`
 - `rankings/elo_history.parquet`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -256,6 +256,8 @@ egregora rank --site-dir=./my-blog --debug
 
 **Output:**
 - `rankings/rankings.duckdb` - DuckDB database with ELO ratings and history
+- `rankings/elo_profiles.parquet` - Parquet export (if --export-parquet)
+- `rankings/elo_profile_stats.parquet` - Parquet export (if --export-parquet)
 - `rankings/elo_ratings.parquet` - Parquet export (if --export-parquet)
 - `rankings/elo_history.parquet` - Parquet export (if --export-parquet)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ packages = ["src/egregora"]
 
 [tool.hatchling.build.targets.wheel.force-include]
 "src/egregora/templates" = "egregora/templates"
+"src/egregora/schema.sql" = "egregora/schema.sql"
 
 [tool.uv]
 managed = true

--- a/src/egregora/annotations.py
+++ b/src/egregora/annotations.py
@@ -11,7 +11,8 @@ from typing import Any
 import duckdb
 import ibis
 
-from .privacy import PrivacyViolationError, validate_newsletter_privacy
+from egregora.duckdb_ddl import apply_schema
+from egregora.privacy import PrivacyViolationError, validate_newsletter_privacy
 
 ANNOTATION_AUTHOR = "egregora"
 ANNOTATIONS_TABLE = "annotations"
@@ -45,24 +46,7 @@ class AnnotationStore:
         return self._backend.con
 
     def _initialize(self) -> None:
-        self._backend.raw_sql(
-            f"""
-            CREATE TABLE IF NOT EXISTS {ANNOTATIONS_TABLE} (
-                id BIGINT PRIMARY KEY,
-                msg_id TEXT NOT NULL,
-                author TEXT NOT NULL,
-                commentary TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL,
-                parent_annotation_id BIGINT
-            )
-            """
-        )
-        self._backend.raw_sql(
-            f"""
-            CREATE INDEX IF NOT EXISTS idx_annotations_msg_id_created
-            ON {ANNOTATIONS_TABLE} (msg_id, created_at)
-            """
-        )
+        apply_schema(self._connection)
 
     def _fetch_records(
         self, query: str, params: Sequence[object] | None = None

--- a/src/egregora/duckdb_ddl.py
+++ b/src/egregora/duckdb_ddl.py
@@ -1,0 +1,111 @@
+"""Utilities for managing DuckDB schema and raw SQL helpers."""
+
+from __future__ import annotations
+
+from importlib import resources
+from textwrap import dedent
+from typing import Iterable, Protocol
+
+
+class SupportsRawSQL(Protocol):
+    """Protocol for objects exposing a ``raw_sql`` method."""
+
+    def raw_sql(self, query: str) -> object: ...
+
+
+class SupportsExecute(Protocol):
+    """Protocol for objects exposing an ``execute`` method."""
+
+    def execute(self, query: str) -> object: ...
+
+
+def quote_identifier(name: str) -> str:
+    """Return ``name`` quoted for safe inclusion in DuckDB SQL."""
+
+    if not name:
+        raise ValueError("Identifier must not be empty")
+    return '"' + name.replace('"', '""') + '"'
+
+
+def string_literal(value: str) -> str:
+    """Return ``value`` quoted as a SQL string literal."""
+
+    return "'" + value.replace("'", "''") + "'"
+
+
+def load_schema_sql() -> str:
+    """Load the central schema SQL file bundled with the package."""
+
+    return resources.files("egregora").joinpath("schema.sql").read_text()
+
+
+def apply_schema(connection: SupportsExecute) -> None:
+    """Execute the bundled schema SQL against ``connection``."""
+
+    sql = load_schema_sql()
+    statements = [statement.strip() for statement in sql.split(";") if statement.strip()]
+    for statement in statements:
+        connection.execute(statement)
+
+
+def create_index_if_not_exists(
+    backend: SupportsRawSQL,
+    *,
+    index_name: str,
+    table_name: str,
+    columns: Iterable[str],
+) -> None:
+    """Create an index if missing using the DuckDB backend."""
+
+    column_sql = ", ".join(quote_identifier(column) for column in columns)
+    backend.raw_sql(
+        dedent(
+            f"""
+            CREATE INDEX IF NOT EXISTS {quote_identifier(index_name)}
+            ON {quote_identifier(table_name)} ({column_sql})
+            """
+        )
+    )
+
+
+def drop_index_if_exists(backend: SupportsRawSQL, *, index_name: str) -> None:
+    """Drop an index if it exists."""
+
+    backend.raw_sql(
+        dedent(
+            f"""
+            DROP INDEX IF EXISTS {quote_identifier(index_name)}
+            """
+        )
+    )
+
+
+def drop_table_if_exists(backend: SupportsRawSQL, *, table_name: str) -> None:
+    """Drop a table if it exists."""
+
+    backend.raw_sql(
+        dedent(
+            f"""
+            DROP TABLE IF EXISTS {quote_identifier(table_name)}
+            """
+        )
+    )
+
+
+def create_vss_index(
+    backend: SupportsRawSQL,
+    *,
+    index_name: str,
+    table_name: str,
+) -> None:
+    """Create a DuckDB VSS index for the ``embedding`` column."""
+
+    backend.raw_sql(
+        dedent(
+            f"""
+            CREATE INDEX {quote_identifier(index_name)}
+            ON {quote_identifier(table_name)} (embedding)
+            USING vss(metric='cosine', storage_type='ivfflat')
+            """
+        )
+    )

--- a/src/egregora/ranking/agent.py
+++ b/src/egregora/ranking/agent.py
@@ -182,12 +182,17 @@ def save_comparison(  # noqa: PLR0913
     stars_a: int,
     comment_b: str,
     stars_b: int,
+    *,
+    profile_alias: str | None = None,
+    profile_bio: str | None = None,
 ) -> None:
     """Save comparison result to DuckDB."""
     comparison_data = {
         "comparison_id": str(uuid.uuid4()),
         "timestamp": datetime.now(UTC),
         "profile_id": profile_id,
+        "profile_alias": profile_alias,
+        "profile_bio": profile_bio,
         "post_a": post_a,
         "post_b": post_b,
         "winner": winner,
@@ -440,6 +445,8 @@ def run_comparison(  # noqa: PLR0913
         stars_a=stars_a,
         comment_b=comment_b,
         stars_b=stars_b,
+        profile_alias=profile.get("alias"),
+        profile_bio=profile.get("bio"),
     )
 
     # Update ELO ratings

--- a/src/egregora/schema.sql
+++ b/src/egregora/schema.sql
@@ -1,0 +1,106 @@
+-- Centralized DuckDB schema for egregora persistence layers.
+-- Contains table and index definitions shared across stores.
+
+-- Writer annotations captured via the CLI.
+CREATE TABLE IF NOT EXISTS annotations (
+    id BIGINT PRIMARY KEY,
+    msg_id TEXT NOT NULL,
+    author TEXT NOT NULL,
+    commentary TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    parent_annotation_id BIGINT,
+    CONSTRAINT fk_annotations_parent
+        FOREIGN KEY (parent_annotation_id)
+        REFERENCES annotations (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_annotations_msg_id_created
+    ON annotations (msg_id, created_at);
+
+-- Metadata cached for materialised Parquet datasets powering the vector store.
+CREATE TABLE IF NOT EXISTS rag_chunks_metadata (
+    path TEXT PRIMARY KEY,
+    mtime_ns BIGINT,
+    size BIGINT,
+    row_count BIGINT
+);
+
+-- Persistent settings for approximate nearest neighbour indices.
+CREATE TABLE IF NOT EXISTS index_meta (
+    index_name TEXT PRIMARY KEY,
+    mode TEXT,
+    row_count BIGINT,
+    threshold BIGINT,
+    nlist INTEGER,
+    updated_at TIMESTAMPTZ
+);
+
+-- Ranking store judge registry.
+CREATE TABLE IF NOT EXISTS elo_profiles (
+    profile_id VARCHAR PRIMARY KEY,
+    first_seen TIMESTAMP NOT NULL
+);
+
+-- Aggregated judge statistics tied to the registry.
+CREATE TABLE IF NOT EXISTS elo_profile_stats (
+    profile_id VARCHAR PRIMARY KEY,
+    alias VARCHAR,
+    bio VARCHAR,
+    comparisons INTEGER NOT NULL DEFAULT 0 CHECK (comparisons >= 0),
+    last_seen TIMESTAMP NOT NULL,
+    CONSTRAINT fk_elo_profile_stats_profile
+        FOREIGN KEY (profile_id)
+        REFERENCES elo_profiles (profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_profile_stats_last_seen
+    ON elo_profile_stats (last_seen);
+
+CREATE INDEX IF NOT EXISTS idx_profile_stats_comparisons
+    ON elo_profile_stats (comparisons);
+
+-- ELO ratings for ranked posts.
+CREATE TABLE IF NOT EXISTS elo_ratings (
+    post_id VARCHAR PRIMARY KEY,
+    elo_global DOUBLE NOT NULL DEFAULT 1500,
+    games_played INTEGER NOT NULL DEFAULT 0,
+    last_updated TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ratings_games
+    ON elo_ratings (games_played);
+
+CREATE INDEX IF NOT EXISTS idx_ratings_elo
+    ON elo_ratings (elo_global);
+
+-- Comparison history between posts with judge provenance.
+CREATE TABLE IF NOT EXISTS elo_history (
+    comparison_id VARCHAR PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    profile_id VARCHAR NOT NULL,
+    post_a VARCHAR NOT NULL,
+    post_b VARCHAR NOT NULL,
+    winner VARCHAR NOT NULL CHECK (winner IN ('A', 'B')),
+    comment_a VARCHAR NOT NULL,
+    stars_a INTEGER NOT NULL CHECK (stars_a BETWEEN 1 AND 5),
+    comment_b VARCHAR NOT NULL,
+    stars_b INTEGER NOT NULL CHECK (stars_b BETWEEN 1 AND 5),
+    CONSTRAINT fk_elo_history_profile
+        FOREIGN KEY (profile_id)
+        REFERENCES elo_profiles (profile_id),
+    CONSTRAINT fk_elo_history_post_a
+        FOREIGN KEY (post_a)
+        REFERENCES elo_ratings (post_id),
+    CONSTRAINT fk_elo_history_post_b
+        FOREIGN KEY (post_b)
+        REFERENCES elo_ratings (post_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_history_post_a
+    ON elo_history (post_a);
+
+CREATE INDEX IF NOT EXISTS idx_history_post_b
+    ON elo_history (post_b);
+
+CREATE INDEX IF NOT EXISTS idx_history_timestamp
+    ON elo_history (timestamp);

--- a/src/egregora/zip_utils.py
+++ b/src/egregora/zip_utils.py
@@ -1,0 +1,5 @@
+"""Compatibility layer exposing ZIP helper utilities."""
+
+from egregora.utils.zip import validate_zip_contents
+
+__all__ = ["validate_zip_contents"]

--- a/tests/test_ranking_store.py
+++ b/tests/test_ranking_store.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from egregora.ranking.store import RankingStore
+
+
+@pytest.fixture()
+def ranking_store(tmp_path: Path) -> RankingStore:
+    store = RankingStore(tmp_path)
+    yield store
+    store.conn.close()
+
+
+def _comparison_payload(**overrides: object) -> dict[str, object]:
+    now = datetime.now(UTC)
+    payload: dict[str, object] = {
+        "comparison_id": "cmp-1",
+        "timestamp": now,
+        "profile_id": "judge-123",
+        "profile_alias": "Curious Critic",
+        "profile_bio": "Keeps score on long-form pieces.",
+        "post_a": "post-a",
+        "post_b": "post-b",
+        "winner": "A",
+        "comment_a": "Great structure.",
+        "stars_a": 5,
+        "comment_b": "Needs more references.",
+        "stars_b": 3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_profile_metadata_upsert_and_history_insert(ranking_store: RankingStore) -> None:
+    ranking_store.initialize_ratings(["post-a", "post-b"])
+
+    ranking_store.save_comparison(_comparison_payload())
+
+    profile_row = ranking_store.conn.execute(
+        """
+        SELECT
+            p.profile_id,
+            s.alias,
+            s.bio,
+            s.comparisons,
+            p.first_seen,
+            s.last_seen
+        FROM elo_profiles AS p
+        JOIN elo_profile_stats AS s ON p.profile_id = s.profile_id
+        """
+    ).fetchone()
+
+    assert profile_row is not None
+    assert profile_row[0] == "judge-123"
+    assert profile_row[1] == "Curious Critic"
+    assert profile_row[2] == "Keeps score on long-form pieces."
+    assert profile_row[3] == 1
+
+    first_seen = profile_row[4]
+    last_seen = profile_row[5]
+    assert first_seen == last_seen
+
+    ranking_store.save_comparison(
+        _comparison_payload(
+            comparison_id="cmp-2",
+            profile_alias="Critical Curator",
+            stars_a=4,
+            stars_b=2,
+            winner="B",
+        )
+    )
+
+    updated_profile = ranking_store.conn.execute(
+        """
+        SELECT s.alias, s.comparisons, p.first_seen, s.last_seen
+        FROM elo_profiles AS p
+        JOIN elo_profile_stats AS s ON p.profile_id = s.profile_id
+        WHERE p.profile_id = ?
+        """,
+        ["judge-123"],
+    ).fetchone()
+
+    assert updated_profile is not None
+    assert updated_profile[0] == "Critical Curator"
+    assert updated_profile[1] == 2
+    assert updated_profile[2] == first_seen  # first_seen is stable
+    assert updated_profile[3] != first_seen  # last_seen updated
+
+    history_rows = ranking_store.conn.execute(
+        "SELECT COUNT(*) FROM elo_history WHERE profile_id = ?",
+        ["judge-123"],
+    ).fetchone()
+    assert history_rows == (2,)
+
+
+def test_history_enforces_profile_foreign_key(ranking_store: RankingStore) -> None:
+    ranking_store.initialize_ratings(["post-a", "post-b"])
+
+    with pytest.raises(duckdb.ConstraintException):
+        ranking_store.conn.execute(
+            """
+            INSERT INTO elo_history (
+                comparison_id,
+                timestamp,
+                profile_id,
+                post_a,
+                post_b,
+                winner,
+                comment_a,
+                stars_a,
+                comment_b,
+                stars_b
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                "cmp-missing-profile",
+                datetime.now(UTC),
+                "does-not-exist",
+                "post-a",
+                "post-b",
+                "A",
+                "missing profile",
+                5,
+                "still missing",
+                4,
+            ],
+        )


### PR DESCRIPTION
## Summary
- add a packaged `schema.sql` that declares every DuckDB table and index so the stores load a single source of truth for their schemas
- refactor the annotation, vector, and ranking stores to execute the shared SQL during initialization while keeping all runtime mutations inside ibis
- adjust packaging and helper utilities now that table-specific `ensure_*` functions are obsolete, retaining the raw SQL helpers used by the vector store

## Testing
- uv run --extra test pytest tests/test_rag_store.py tests/test_annotations.py tests/test_cli_ranking.py tests/test_ranking_store.py

------
https://chatgpt.com/codex/tasks/task_e_6902deacff148325ad2c993d9f41fbf3