### PR TITLE
Fix Gemini dispatcher individual embedding response handling

### DIFF
--- a/src/egregora/utils/gemini_dispatcher.py
+++ b/src/egregora/utils/gemini_dispatcher.py
@@ -104,13 +104,11 @@ class GeminiEmbeddingDispatcher(BaseDispatcher[EmbeddingBatchRequest, EmbeddingB
             )
 
             # Extract embedding from response object
-            if response.embeddings and len(response.embeddings) > 0:
-                embedding = response.embeddings[0].values
-                return EmbeddingBatchResult(
-                    tag=request.tag, embedding=list(embedding) if embedding else None
-                )
-            else:
-                return EmbeddingBatchResult(tag=request.tag, embedding=None)
+            embedding = getattr(response, "embedding", None)
+            values = getattr(embedding, "values", None)
+            if values:
+                return EmbeddingBatchResult(tag=request.tag, embedding=list(values))
+            return EmbeddingBatchResult(tag=request.tag, embedding=None)
 
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Summary
- correct the individual embedding path to read embeddings from the `embedding.values` field exposed by the Gemini SDK
- return `None` gracefully when the SDK omits embedding values instead of raising and falling back to error handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904ce351c888325815ef9ed5e14efca