### PR TITLE
Fix path traversal and RAG error handling risks (follow-up)

### DIFF
--- a/src/egregora/generation/writer/core.py
+++ b/src/egregora/generation/writer/core.py
@@ -1045,7 +1045,7 @@ def write_posts_for_period(  # noqa: PLR0913, PLR0915
                 rag_context = rag_result[0]
             case _:
                 # Modern Result type
-                if rag_result.is_success():
+                if rag_result.is_success:
                     context_obj = rag_result.unwrap()
                     rag_context = context_obj.text
                     logger.info("RAG context retrieved successfully")


### PR DESCRIPTION
## Summary
- Fix invocation of the `RagResult.is_success` property when handling RAG results to avoid runtime errors.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69052ffec3f48325b56b314b79b80427