### PR TITLE
Sync slug metadata with duplicate filenames

### DIFF
--- a/src/egregora/orchestration/write_post.py
+++ b/src/egregora/orchestration/write_post.py
@@ -49,14 +49,30 @@ def write_post(
 
     validate_newsletter_privacy(content)
 
-    # Sanitize slug FIRST to ensure consistency between filename and front matter
-    safe_slug = slugify(metadata["slug"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    date_prefix = metadata["date"]
 
-    # Build front matter with sanitized slug
+    # Sanitize slug FIRST to ensure consistency between filename and front matter
+    base_slug = slugify(metadata["slug"])
+    slug_candidate = base_slug
+
+    # Ensure path stays within output_dir
+    filename = f"{date_prefix}-{slug_candidate}.md"
+    filepath = safe_path_join(output_dir, filename)
+
+    # Handle duplicates by appending suffix in lockstep with slug/front matter
+    suffix = 2
+    while filepath.exists():
+        slug_candidate = f"{base_slug}-{suffix}"
+        filename = f"{date_prefix}-{slug_candidate}.md"
+        filepath = safe_path_join(output_dir, filename)
+        suffix += 1
+
+    # Build front matter with the final slug candidate
     front_matter = {}
     front_matter["title"] = metadata["title"]
-    front_matter["date"] = metadata["date"]
-    front_matter["slug"] = safe_slug  # ✅ Use sanitized slug in front matter
+    front_matter["date"] = date_prefix
+    front_matter["slug"] = slug_candidate  # ✅ Use sanitized slug in front matter
 
     if "tags" in metadata:
         front_matter["tags"] = metadata["tags"]
@@ -70,21 +86,6 @@ def write_post(
     yaml_front = yaml.dump(front_matter, default_flow_style=False, allow_unicode=True)
 
     full_post = f"---\n{yaml_front}---\n\n{content}"
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"{metadata['date']}-{safe_slug}.md"
-
-    # Ensure path stays within output_dir
-    filepath = safe_path_join(output_dir, filename)
-
-    # Handle duplicates by appending suffix
-    if filepath.exists():
-        base_name = f"{metadata['date']}-{safe_slug}"
-        suffix = 2
-        while filepath.exists():
-            filename = f"{base_name}-{suffix}.md"
-            filepath = safe_path_join(output_dir, filename)
-            suffix += 1
 
     filepath.write_text(full_post, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- ensure write_post applies duplicate suffixes to the front matter slug alongside the filename
- restructure slug handling so the final slug is reflected in both filename and metadata before writing the post

## Testing
- pytest tests/test_path_safety.py *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_690533b7dbc883258bbbf89695c3b40e