### PR TITLE
Fix CLI posts path and pipeline test stubs

### DIFF
--- a/src/egregora/orchestration/cli.py
+++ b/src/egregora/orchestration/cli.py
@@ -1004,7 +1004,8 @@ def gather_context(  # noqa: PLR0913
 
             # Load freeform memory
             console.print("[yellow]Loading freeform memory...[/yellow]")
-            freeform_memory = _load_freeform_memory(site_paths.posts_dir)
+            posts_output_dir = site_paths.posts_dir / ".posts"
+            freeform_memory = _load_freeform_memory(posts_output_dir)
 
             # RAG context (if enabled)
             rag_similar_posts: list[dict[str, Any]] = []
@@ -1168,12 +1169,13 @@ def write_posts(  # noqa: PLR0913
             console.print(f"[yellow]Invoking LLM writer for period {period_key}...[/yellow]")
 
             # Write posts (this uses the existing write_posts_for_period function)
+            posts_output_dir = site_paths.posts_dir / ".posts"
             result = write_posts_for_period(
                 enriched_table,
                 period_key,
                 client,
                 embedding_batch_client,
-                site_paths.posts_dir,
+                posts_output_dir,
                 site_paths.profiles_dir,
                 site_paths.rag_dir,
                 model_config,
@@ -1191,7 +1193,7 @@ def write_posts(  # noqa: PLR0913
             console.print(f"[green]✅ Updated {profiles_count} profiles[/green]")
 
             if posts_count > 0:
-                console.print(f"[cyan]Posts saved to:[/cyan] {site_paths.posts_dir}")
+                console.print(f"[cyan]Posts saved to:[/cyan] {posts_output_dir}")
                 for post_path in result.get("posts", [])[:5]:  # Show first 5
                     console.print(f"  • {Path(post_path).name}")
                 if posts_count > 5:

--- a/tests/test_whatsapp_real_scenario.py
+++ b/tests/test_whatsapp_real_scenario.py
@@ -95,7 +95,7 @@ class DummyGenaiClient:
 def _install_pipeline_stubs(monkeypatch, captured_dates: list[str]):
     monkeypatch.setattr("egregora.orchestration.pipeline.genai.Client", DummyGenaiClient)
     monkeypatch.setattr(
-        "egregora.orchestration.pipeline.GeminiBatchClient",
+        "egregora.orchestration.pipeline.GeminiDispatcher",
         lambda client, model, **kwargs: DummyBatchClient(model),
     )
 


### PR DESCRIPTION
## Summary
- ensure the CLI uses the hidden `.posts` directory when loading freeform memory and writing posts so stage execution matches the pipeline
- update the WhatsApp scenario test harness to stub the new `GeminiDispatcher` export

## Testing
- pytest tests/test_whatsapp_real_scenario.py *(fails: google.genai.types.FunctionCall missing in google-genai package)*

------
https://chatgpt.com/codex/tasks/task_e_69053570f5d8832594775624342154e8