### PR TITLE
Address review feedback for hidden posts directory handling

### DIFF
--- a/src/egregora/knowledge/ranking/agent.py
+++ b/src/egregora/knowledge/ranking/agent.py
@@ -173,10 +173,17 @@ def load_comments_for_post(post_id: str, store: RankingStore) -> str | None:
 def _find_post_path(posts_dir: Path, post_id: str) -> Path:
     """Locate a post file within the MkDocs posts directory."""
 
-    candidates = []
-    hidden_posts_dir = posts_dir / ".posts"
+    candidates: list[Path] = []
 
-    for directory in (hidden_posts_dir, posts_dir):
+    search_dirs: list[Path] = []
+    if posts_dir.name == ".posts":
+        search_dirs.append(posts_dir)
+        search_dirs.append(posts_dir.parent)
+    else:
+        search_dirs.append(posts_dir / ".posts")
+        search_dirs.append(posts_dir)
+
+    for directory in search_dirs:
         if not directory.exists():
             continue
 
@@ -193,7 +200,7 @@ def _find_post_path(posts_dir: Path, post_id: str) -> Path:
                 raise ValueError(f"Multiple posts found for {post_id}: {matches_str}")
             return matches[0]
 
-    searched = ", ".join(str(candidate.parent) for candidate in candidates)
+    searched = ", ".join(str(candidate.parent) for candidate in candidates if candidate.parent)
     raise ValueError(f"Post not found for id '{post_id}'. Looked in: {searched}")
 
 

--- a/src/egregora/knowledge/ranking/elo.py
+++ b/src/egregora/knowledge/ranking/elo.py
@@ -62,8 +62,23 @@ def initialize_ratings(posts_dir: Path, rankings_dir: Path) -> RankingStore:
     Returns:
         RankingStore instance
     """
-    # Find all markdown posts
-    post_files = list(posts_dir.glob("*.md"))
+    # Find all markdown posts, preferring the hidden .posts directory when present
+    search_dirs = []
+    hidden_posts_dir = posts_dir / ".posts"
+    if hidden_posts_dir.exists():
+        search_dirs.append(hidden_posts_dir)
+    search_dirs.append(posts_dir)
+
+    seen: set[Path] = set()
+    post_files: list[Path] = []
+    for directory in search_dirs:
+        if not directory.exists():
+            continue
+
+        for path in directory.glob("**/*.md"):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                post_files.append(path)
 
     if not post_files:
         raise ValueError(f"No posts found in {posts_dir}")

--- a/src/egregora/orchestration/cli.py
+++ b/src/egregora/orchestration/cli.py
@@ -498,7 +498,10 @@ def _register_ranking_cli(app: typer.Typer) -> None:  # noqa: PLR0915
             raise typer.Exit(1)
 
         site_paths = resolve_site_paths(site_path)
-        posts_dir = site_paths.posts_dir
+        posts_root = site_paths.posts_dir
+        posts_dir = posts_root / ".posts"
+        if not posts_dir.exists():
+            posts_dir = posts_root
         rankings_dir = site_paths.rankings_dir
         profiles_dir = site_paths.profiles_dir
 

--- a/src/egregora/orchestration/pipeline.py
+++ b/src/egregora/orchestration/pipeline.py
@@ -19,6 +19,7 @@ from ..core.types import GroupSlug
 from ..generation.writer import write_posts_for_period
 from ..ingestion.parser import extract_commands, filter_egregora_messages, parse_export
 from ..knowledge.rag import VectorStore, index_all_media
+from ..utils.batch import GeminiBatchClient  # noqa: F401  # Backwards compatibility for tests
 from ..utils.cache import EnrichmentCache
 from ..utils.checkpoints import CheckpointStore
 from ..utils.gemini_dispatcher import GeminiDispatcher


### PR DESCRIPTION
## Summary
- update the ranking CLI to look in the `.posts` subdirectory when available
- allow the ranking utilities to discover posts inside `.posts`
- re-export `GeminiBatchClient` from the pipeline module for backward compatibility

## Testing
- pytest tests/test_whatsapp_real_scenario.py *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_69055c940e08832597eddeeaffdb1f04