### PR TITLE
Document Python 3.12 runtime requirement across contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ black --check src/
 ```
 
 ### Key Project Configurations
-- Python 3.11+ required
+- Python 3.12+ required
 - Linting: ruff, black
 - Type checking: mypy
 - Line length: 100 characters

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@ black --check src/
 ```
 
 ### Key Project Configurations
-- Python 3.11+ required
+- Python 3.12+ required
 - Linting: ruff, black
 - Type checking: mypy
 - Line length: 100 characters


### PR DESCRIPTION
## Summary
- atualizei os guias do repositório para deixar explícito que a base de execução é Python 3.12+
- alinhei as instruções das agentes (Claude e Gemini) com o requisito já refletido no pyproject
- removi referências antigas a 3.11 que estavam causando dúvidas na revisão do Codex

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_6905798fa4fc8325a77e878d6004481f