### PR TITLE
Ensure deterministic pagination for enrichment batch processing

### DIFF
--- a/src/egregora/augmentation/enrichment/media.py
+++ b/src/egregora/augmentation/enrichment/media.py
@@ -11,6 +11,7 @@ import ibis
 from ibis.expr.types import Table
 
 from ...config import MEDIA_DIR_NAME
+from .batch import _get_stable_ordering
 
 # WhatsApp attachment markers (special Unicode)
 ATTACHMENT_MARKERS = (
@@ -249,8 +250,11 @@ def extract_and_replace_media(
     batch_size = 1000
     count = messages_table.count().execute()
 
+    ordering = _get_stable_ordering(messages_table)
+    ordered_table = messages_table.order_by(ordering) if ordering else messages_table
+
     for offset in range(0, count, batch_size):
-        batch = messages_table.limit(batch_size, offset=offset).execute()
+        batch = ordered_table.limit(batch_size, offset=offset).execute()
         batch_records = batch.to_dict("records")
         for row in batch_records:
             message = row.get("message", "")


### PR DESCRIPTION
## Summary
- add a helper to derive a deterministic ordering for Ibis tables when paginating
- reuse the stable ordering in batch conversion and media extraction to avoid skipped rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69057b2f06d88325a17cee0f092fb269