### PR TITLE
Fix timezone normalization for enrichment union

### DIFF
--- a/src/egregora/augmentation/enrichment/core.py
+++ b/src/egregora/augmentation/enrichment/core.py
@@ -366,7 +366,9 @@ def enrich_table(
         return ts.astimezone(timezone.utc)
 
     messages_table_filtered = messages_table_filtered.mutate(
-        timestamp=ensure_timestamp_utc(messages_table_filtered.timestamp)
+        timestamp=ensure_timestamp_utc(messages_table_filtered.timestamp).cast(
+            schema["timestamp"]
+        )
     )
 
     combined = messages_table_filtered.union(enrichment_table, distinct=False)


### PR DESCRIPTION
## Summary
- normalize enrichment rows' timestamps to UTC before building the memtable
- convert existing message timestamps to UTC with a Python UDF instead of a raw cast to preserve offsets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905eb34fe5883259d739245b99434cd