### PR TITLE
Ensure deterministic pagination for batch and media enrichment

### DIFF
--- a/src/egregora/augmentation/enrichment/batch.py
+++ b/src/egregora/augmentation/enrichment/batch.py
@@ -142,7 +142,9 @@ def _iter_table_record_batches(
             ((row_number >= start) & (row_number < upper))
             if start
             else (row_number < upper)
-        ).drop("_batch_row_number")
+        ).order_by(row_number)
+        # Drop helper column only after enforcing deterministic ordering
+        batch_expr = batch_expr.drop("_batch_row_number")
         dataframe = batch_expr.execute()
         batch_records = _frame_to_records(dataframe)
         if not batch_records:


### PR DESCRIPTION
## Summary
- ensure numbered batch slices are ordered by their assigned row numbers before execution, restoring deterministic pagination

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69061d7140b08325aa318317c4775e70