### PR TITLE
Fix legacy annotations migration follow-up

### DIFF
--- a/src/egregora/knowledge/annotations.py
+++ b/src/egregora/knowledge/annotations.py
@@ -141,6 +141,7 @@ class AnnotationStore:
                 f"ALTER TABLE {ANNOTATIONS_TABLE} DROP COLUMN parent_annotation_id"
             )
         if has_msg_id:
+            self._connection.execute("DROP INDEX IF EXISTS idx_annotations_msg_id_created")
             self._connection.execute(f"ALTER TABLE {ANNOTATIONS_TABLE} DROP COLUMN msg_id")
 
         invalidate_metadata = getattr(self._backend, "invalidate_metadata", None)


### PR DESCRIPTION
## Summary
- add a migration step that backfills `parent_id`/`parent_type` for legacy DuckDB annotation tables and drops the old columns
- add a regression test that covers loading an annotations database created before the schema change
- drop the legacy `idx_annotations_msg_id_created` index before removing `msg_id` so the migration succeeds against existing databases

## Testing
- `pytest tests/test_annotations_store.py::test_annotations_store_migrates_legacy_schema` *(fails: missing duckdb dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906292faf608325adc67fa9136616da