### PR TITLE
Ensure Retry-After jitter never shortens cooldown

### DIFF
--- a/src/egregora/utils/genai.py
+++ b/src/egregora/utils/genai.py
@@ -184,12 +184,14 @@ async def call_with_retries[RateLimitFn: Callable[..., Awaitable[Any]]](
             if recommended_delay is not None:
                 # Honor server's Retry-After, but also respect our minimum interval
                 base_delay_value = max(recommended_delay, _MIN_INTERVAL_SECONDS)
+                # Never shorten the server-specified delay; only extend it slightly.
+                jitter = base_delay_value * 0.2 * random.random()
+                delay = base_delay_value + jitter
             else:
                 base_delay_value = base_delay * (2 ** (attempt - 1))
-
-            # Add jitter to prevent thundering herd (±20% random variation)
-            jitter = base_delay_value * 0.2 * (2 * random.random() - 1)
-            delay = max(base_delay_value + jitter, _MIN_INTERVAL_SECONDS)
+                # Add jitter to prevent thundering herd (±20% random variation)
+                jitter = base_delay_value * 0.2 * (2 * random.random() - 1)
+                delay = max(base_delay_value + jitter, _MIN_INTERVAL_SECONDS)
 
             logger.info(
                 f"[yellow]⏳ Retry[/] {fn_name} — attempt {attempt}/{max_attempts}. "
@@ -223,12 +225,14 @@ def call_with_retries_sync(
             if recommended_delay is not None:
                 # Honor server's Retry-After, but also respect our minimum interval
                 base_delay_value = max(recommended_delay, _MIN_INTERVAL_SECONDS)
+                # Never shorten the server-specified delay; only extend it slightly.
+                jitter = base_delay_value * 0.2 * random.random()
+                delay = base_delay_value + jitter
             else:
                 base_delay_value = base_delay * (2 ** (attempt - 1))
-
-            # Add jitter to prevent thundering herd (±20% random variation)
-            jitter = base_delay_value * 0.2 * (2 * random.random() - 1)
-            delay = max(base_delay_value + jitter, _MIN_INTERVAL_SECONDS)
+                # Add jitter to prevent thundering herd (±20% random variation)
+                jitter = base_delay_value * 0.2 * (2 * random.random() - 1)
+                delay = max(base_delay_value + jitter, _MIN_INTERVAL_SECONDS)
 
             logger.info(
                 f"[yellow]⏳ Retry[/] {fn_name} — attempt {attempt}/{max_attempts}. "


### PR DESCRIPTION
## Summary
- ensure async retry helper never sleeps less than the Retry-After header by only adding positive jitter when the header is present
- mirror the same fix in the synchronous retry helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906b7e1bf14832587a4b3f047083475