### PR TITLE
Fix offline tests and lint configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,9 +153,6 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-# pytest-vcr configuration
-vcr_record_mode = "once"  # Record once, then replay
-vcr_cassette_dir = "tests/cassettes"
 
 [dependency-groups]
 dev = [

--- a/src/egregora/orchestration/cli.py
+++ b/src/egregora/orchestration/cli.py
@@ -69,13 +69,13 @@ def _make_json_safe(value: Any, *, strict: bool = False) -> Any:
     Raises:
         TypeError: If strict=True and value is not JSON-serializable
     """
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if value is None or isinstance(value, str | int | float | bool):
         return value
-    if isinstance(value, (datetime, date)):
+    if isinstance(value, datetime | date):
         return value.isoformat()
     if isinstance(value, dict):
         return {key: _make_json_safe(val, strict=strict) for key, val in value.items()}
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, list | tuple | set):
         return [_make_json_safe(item, strict=strict) for item in value]
     if hasattr(value, "item"):
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import sys
 import types
 import zipfile
@@ -79,6 +80,7 @@ def _install_google_stubs() -> None:
     for attr in (
         "Schema",
         "FunctionDeclaration",
+        "FunctionCall",
         "Tool",
         "FunctionResponse",
         "Part",
@@ -243,7 +245,6 @@ def vcr_config():
     This configuration filters out sensitive data like API keys from cassettes
     and properly handles binary file uploads (images, etc.).
     """
-    import base64
 
     def _serialize_request_body(request):
         """Serialize request body, encoding binary data as base64."""
@@ -286,6 +287,10 @@ def vcr_config():
     return {
         # Record mode: 'once' means record the first time, then replay
         "record_mode": "once",
+        # Directory containing pre-recorded cassettes
+        "cassette_library_dir": str(Path(__file__).parent / "cassettes"),
+        # Ensure httpx.Client is patched for playback
+        "custom_patches": ("httpx",),
         # Filter API keys from recordings
         "filter_headers": [
             ("x-goog-api-key", "DUMMY_API_KEY"),

--- a/tests/test_init_template_structure.py
+++ b/tests/test_init_template_structure.py
@@ -6,7 +6,6 @@ matches the templates defined in src/egregora/publication/site/templates/.
 
 from pathlib import Path
 
-import pytest
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from egregora.config.site import resolve_site_paths
@@ -60,14 +59,8 @@ def test_init_creates_all_template_files(tmp_path: Path):
         )
 
     # Verify blog index (not from template, but created by scaffolding)
-    blog_index = tmp_path / "docs" / "posts" / "index.md"
-    # Note: blog_index is actually at posts.parent/index.md which is docs/posts/../index.md = docs/index.md
-    # But there's also a simple blog index created. Let's check the actual behavior:
-    # Looking at line 130-133 in scaffolding.py:
-    # blog_index_path = posts_dir.parent / "index.md"  # posts_dir is blog_dir/posts/, parent is blog_dir
-    # So it's docs/posts/index.md (if blog_dir is "posts")
-    # Actually no - posts_dir.parent would be docs/ if posts_dir is docs/posts/
-    # This is created but not from a template, so it's OK
+    blog_index = tmp_path / "docs" / "index.md"
+    assert blog_index.exists(), "Blog index should be created in docs/index.md"
 
 
 def test_all_templates_are_used(tmp_path: Path):

--- a/tests/test_writer_pydantic_agent.py
+++ b/tests/test_writer_pydantic_agent.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import pytest
 from pydantic_ai.models.test import TestModel
+from tests.mock_batch_client import create_mock_batch_client
 
 from egregora.generation.writer.pydantic_agent import write_posts_with_pydantic_agent
-from tests.mock_batch_client import create_mock_batch_client
 
 
 @pytest.fixture()

--- a/tests/utils/raw_gemini_client.py
+++ b/tests/utils/raw_gemini_client.py
@@ -9,8 +9,9 @@ This is ONLY for testing - production code should use the official genai SDK.
 
 from __future__ import annotations
 
-import httpx
 from typing import Any
+
+import httpx
 
 
 class RawGeminiClient:


### PR DESCRIPTION
## Summary
- update CLI JSON serialization helper to use modern union syntax accepted by ruff
- extend google.genai stubs and pytest VCR settings so tests import cleanly
- replace the VCR-dependent pipeline test with deterministic Gemini mocks and tidy related imports/config

## Testing
- pytest -q
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_690803cb7dd88325b62d22c49c8c5d47