### PR TITLE
Ensure annotation sequence resumes after existing records

### DIFF
--- a/src/egregora/knowledge/annotations.py
+++ b/src/egregora/knowledge/annotations.py
@@ -87,10 +87,35 @@ class AnnotationStore:
             f"SELECT MAX(id) FROM {ANNOTATIONS_TABLE}"
         ).fetchone()
         if max_id_row and max_id_row[0] is not None:
-            next_value = int(max_id_row[0]) + 1
-            self._connection.execute(
-                f"ALTER SEQUENCE {sequence_name} RESTART WITH {next_value}"
+            max_id = int(max_id_row[0])
+            sequence_state = self._connection.execute(
+                """
+                SELECT start_value, increment_by, last_value
+                FROM duckdb_sequences()
+                WHERE schema_name = current_schema() AND sequence_name = ?
+                LIMIT 1
+                """,
+                [sequence_name],
+            ).fetchone()
+            if sequence_state is None:
+                raise RuntimeError(
+                    f"Could not find sequence metadata for {sequence_name}"
+                )
+
+            start_value, increment_by, last_value = sequence_state
+            current_next = (
+                int(start_value)
+                if last_value is None
+                else int(last_value) + int(increment_by)
             )
+            desired_next = max(current_next, max_id + 1)
+            steps_needed = desired_next - current_next
+            if steps_needed > 0:
+                cursor = self._connection.execute(
+                    "SELECT nextval(?) FROM range(?)",
+                    [sequence_name, steps_needed],
+                )
+                cursor.fetchall()
 
     def _fetch_records(
         self, query: str, params: Sequence[object] | None = None


### PR DESCRIPTION
## Summary
- ensure the DuckDB annotation ID sequence is advanced to the current maximum when initializing the store

## Testing
- pytest tests/test_annotations_store.py *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_6908a976ca088325baaf0c0bfafcb4fb