### PR TITLE
Refine DuckDB identity handling and drop PyArrow helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,15 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: forbid-pandas-imports
+        name: "Forbid pandas imports"
+        entry: tools/check_forbidden_imports.py pandas
+        language: system
+        pass_filenames: false
+      - id: forbid-pyarrow-imports
+        name: "Forbid pyarrow imports"
+        entry: tools/check_forbidden_imports.py pyarrow
+        language: system
+        pass_filenames: false

--- a/src/egregora/knowledge/annotations.py
+++ b/src/egregora/knowledge/annotations.py
@@ -46,14 +46,10 @@ class AnnotationStore:
         return self._backend.con
 
     def _initialize(self) -> None:
-        sequence_name = f"{ANNOTATIONS_TABLE}_id_seq"
-        self._connection.execute(
-            f"CREATE SEQUENCE IF NOT EXISTS {sequence_name} START 1"
-        )
         self._connection.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {ANNOTATIONS_TABLE} (
-                id INTEGER PRIMARY KEY DEFAULT nextval('{sequence_name}'),
+                id BIGINT PRIMARY KEY,
                 parent_id VARCHAR NOT NULL,
                 parent_type VARCHAR NOT NULL,
                 author VARCHAR,
@@ -62,64 +58,24 @@ class AnnotationStore:
             )
             """
         )
+        try:
+            self._connection.execute(
+                f"ALTER TABLE {ANNOTATIONS_TABLE} ALTER COLUMN id DROP DEFAULT"
+            )
+        except duckdb.Error:
+            # Default may already be absent or incompatible with DROP DEFAULT
+            pass
         database_schema.ensure_identity_column(
             self._connection, ANNOTATIONS_TABLE, "id", generated="ALWAYS"
         )
         # Add primary key using raw connection
         database_schema.add_primary_key(self._connection, ANNOTATIONS_TABLE, "id")
-        column_default_row = self._connection.execute(
-            """
-            SELECT column_default
-            FROM information_schema.columns
-            WHERE lower(table_name) = lower(?) AND lower(column_name) = 'id'
-            LIMIT 1
-            """,
-            [ANNOTATIONS_TABLE],
-        ).fetchone()
-        if not column_default_row or column_default_row[0] != f"nextval('{sequence_name}')":
-            self._connection.execute(
-                f"ALTER TABLE {ANNOTATIONS_TABLE} ALTER COLUMN id SET DEFAULT nextval('{sequence_name}')"
-            )
         self._backend.raw_sql(
             f"""
             CREATE INDEX IF NOT EXISTS idx_annotations_parent_created
             ON {ANNOTATIONS_TABLE} (parent_id, parent_type, created_at)
             """
         )
-
-        max_id_row = self._connection.execute(
-            f"SELECT MAX(id) FROM {ANNOTATIONS_TABLE}"
-        ).fetchone()
-        if max_id_row and max_id_row[0] is not None:
-            max_id = int(max_id_row[0])
-            sequence_state = self._connection.execute(
-                """
-                SELECT start_value, increment_by, last_value
-                FROM duckdb_sequences()
-                WHERE schema_name = current_schema() AND sequence_name = ?
-                LIMIT 1
-                """,
-                [sequence_name],
-            ).fetchone()
-            if sequence_state is None:
-                raise RuntimeError(
-                    f"Could not find sequence metadata for {sequence_name}"
-                )
-
-            start_value, increment_by, last_value = sequence_state
-            current_next = (
-                int(start_value)
-                if last_value is None
-                else int(last_value) + int(increment_by)
-            )
-            desired_next = max(current_next, max_id + 1)
-            steps_needed = desired_next - current_next
-            if steps_needed > 0:
-                cursor = self._connection.execute(
-                    "SELECT nextval(?) FROM range(?)",
-                    [sequence_name, steps_needed],
-                )
-                cursor.fetchall()
 
     def _fetch_records(
         self, query: str, params: Sequence[object] | None = None

--- a/src/egregora/knowledge/rag/store.py
+++ b/src/egregora/knowledge/rag/store.py
@@ -10,9 +10,8 @@ from typing import Any
 import duckdb
 import ibis
 import ibis.expr.datatypes as dt
-import pyarrow as pa
-import pyarrow.parquet as pq
 from ibis.expr.types import Table
+import uuid
 
 from ...core import database_schema
 
@@ -222,8 +221,19 @@ class VectorStore:
             return "BIGINT"
         if dtype.is_int32():
             return "INTEGER"
+        if dtype.is_float64():
+            return "DOUBLE"
+        if dtype.is_boolean():
+            return "BOOLEAN"
         if dtype.is_timestamp():
-            return "TIMESTAMP"
+            return "TIMESTAMP WITH TIME ZONE" if getattr(dtype, "timezone", None) else "TIMESTAMP"
+        if dtype.is_date():
+            return "DATE"
+        if dtype.is_array():
+            inner = VectorStore._duckdb_type_from_ibis(dtype.value_type)
+            if inner is None:
+                return None
+            return f"{inner}[]"
 
         return None
 
@@ -275,11 +285,15 @@ class VectorStore:
         """Inspect the Parquet file for structural metadata."""
 
         stats = self.parquet_path.stat()
-        metadata = pq.read_metadata(self.parquet_path)
+        row = self.conn.execute(
+            "SELECT COUNT(*) FROM read_parquet(?)",
+            [str(self.parquet_path)],
+        ).fetchone()
+        row_count = int(row[0]) if row and row[0] is not None else 0
         return DatasetMetadata(
             mtime_ns=int(stats.st_mtime_ns),
             size=int(stats.st_size),
-            row_count=int(metadata.num_rows),
+            row_count=row_count,
         )
 
     def _duckdb_table_exists(self, table_name: str) -> bool:
@@ -481,9 +495,17 @@ class VectorStore:
             chunk_count = chunks_table.count().execute()
             logger.info(f"Creating new vector store with {chunk_count} chunks")
 
-        # Write to Parquet
+        # Write to Parquet using DuckDB COPY to avoid Arrow round-trips
         self.parquet_path.parent.mkdir(parents=True, exist_ok=True)
-        combined_table.execute().to_parquet(self.parquet_path)
+        view_name = f"_egregora_chunks_{uuid.uuid4().hex}"
+        self._client.create_view(view_name, combined_table, overwrite=True)
+        try:
+            self.conn.execute(
+                f"COPY (SELECT * FROM {view_name}) TO ? (FORMAT PARQUET)",
+                [str(self.parquet_path)],
+            )
+        finally:
+            self._client.drop_view(view_name, force=True)
 
         self._table_synced = False
         self._ensure_dataset_loaded(force=True)
@@ -776,90 +798,63 @@ class VectorStore:
     def _execute_search_query(self, query: str, params: list[Any], min_similarity: float) -> Table:
         """Execute the provided search query and normalize the results."""
 
-        result_arrow = self.conn.execute(query, params).arrow()
-        result_table = self._ensure_arrow_table(result_arrow)
-        if result_table.num_rows == 0:
+        cursor = self.conn.execute(query, params)
+        columns = [description[0] for description in cursor.description or []]
+        rows = cursor.fetchall()
+        if not rows:
             return self._empty_table(SEARCH_RESULT_SCHEMA)
 
-        prepared_table = self._prepare_search_results(result_table)
-        table = self._table_from_arrow(prepared_table, SEARCH_RESULT_SCHEMA)
+        raw_records = [dict(zip(columns, row, strict=False)) for row in rows]
+        prepared_records = self._prepare_search_results(raw_records)
+        table = self._table_from_rows(prepared_records, SEARCH_RESULT_SCHEMA)
 
         row_count = table.count().execute()
         logger.info("Found %d similar chunks (min_similarity=%s)", row_count, min_similarity)
 
         return table
 
-    def _prepare_search_results(self, result_table: pa.Table) -> pa.Table:
-        """Normalize DuckDB arrow results to match the search schema."""
+    def _prepare_search_results(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Normalize DuckDB result rows to match the search schema."""
 
-        data = result_table.to_pydict()
-        row_count = result_table.num_rows
+        if not records:
+            return []
 
+        normalized: list[dict[str, Any]] = []
         valid_columns = set(SEARCH_RESULT_SCHEMA.names) | {"similarity"}
-        for key in list(data.keys()):
-            if key not in valid_columns:
-                data.pop(key)
 
-        if "document_type" in data:
-            data["document_type"] = [value or "post" for value in data["document_type"]]
-        else:
-            data["document_type"] = ["post"] * row_count
+        for index, record in enumerate(records):
+            filtered = {key: value for key, value in record.items() if key in valid_columns}
 
-        chunk_ids = data.get("chunk_id", [""] * row_count)
-        post_slugs = data.get("post_slug", [None] * row_count)
-        if "document_id" in data:
-            document_ids = []
-            for index, existing in enumerate(data["document_id"]):
-                slug = post_slugs[index] if index < len(post_slugs) else None
-                chunk_id = chunk_ids[index] if index < len(chunk_ids) else ""
-                document_ids.append(existing or slug or chunk_id)
-            data["document_id"] = document_ids
-        else:
-            document_ids = []
-            for index in range(row_count):
-                slug = post_slugs[index] if index < len(post_slugs) else None
-                chunk_id = chunk_ids[index] if index < len(chunk_ids) else ""
-                document_ids.append(slug or chunk_id)
-            data["document_id"] = document_ids
+            filtered.setdefault("document_type", "post")
 
-        array_columns = ("tags", "authors")
-        for column_name in array_columns:
-            if column_name not in data:
-                data[column_name] = [[] for _ in range(row_count)]
-            else:
-                data[column_name] = [value or [] for value in data[column_name]]
+            chunk_id = filtered.get("chunk_id") or ""
+            post_slug = filtered.get("post_slug")
+            document_id = filtered.get("document_id") or post_slug or chunk_id
+            filtered["document_id"] = document_id
 
-        optional_defaults: dict[str, list[Any]] = {}
-        for column_name in (
-            "post_slug",
-            "post_title",
-            "post_date",
-            "media_uuid",
-            "media_type",
-            "media_path",
-            "original_filename",
-            "message_date",
-            "author_uuid",
-            "category",
-        ):
-            if column_name not in data:
-                optional_defaults[column_name] = [None] * row_count
+            for column_name in ("tags", "authors"):
+                value = filtered.get(column_name)
+                filtered[column_name] = list(value or [])
 
-        if optional_defaults:
-            data.update(optional_defaults)
+            for column_name in (
+                "post_slug",
+                "post_title",
+                "post_date",
+                "media_uuid",
+                "media_type",
+                "media_path",
+                "original_filename",
+                "message_date",
+                "author_uuid",
+                "category",
+            ):
+                filtered.setdefault(column_name, None)
 
-        if "chunk_index" not in data:
-            data["chunk_index"] = list(range(row_count))
+            filtered.setdefault("chunk_index", index)
 
-        schema = SEARCH_RESULT_SCHEMA.to_pyarrow()
-        arrays = []
-        for field in schema:
-            values = data.get(field.name)
-            if values is None:
-                values = [None] * row_count
-            arrays.append(pa.array(values, type=field.type))
+            normalized.append(filtered)
 
-        return pa.Table.from_arrays(arrays, schema=schema)
+        return normalized
 
     @staticmethod
     def _normalize_date_filter(value: date | datetime | str) -> datetime:
@@ -898,55 +893,33 @@ class VectorStore:
 
         return value.astimezone(UTC)
 
-    def _ensure_arrow_table(self, arrow_object: Any) -> pa.Table:
-        """Normalize DuckDB Arrow results to a ``pyarrow.Table`` instance."""
+    def _table_from_rows(self, records: list[dict[str, Any]], schema: ibis.Schema) -> Table:
+        """Create a DuckDB-backed table from an in-memory sequence of records."""
 
-        if isinstance(arrow_object, pa.Table):
-            return arrow_object
+        if not records:
+            return self._empty_table(schema)
 
-        if isinstance(arrow_object, pa.RecordBatchReader):
-            return arrow_object.read_all()
-
-        for attr in ("read_all", "to_table", "to_arrow_table"):
-            method = getattr(arrow_object, attr, None)
-            if not callable(method):
-                continue
-
-            result = method()
-            if isinstance(result, pa.RecordBatchReader):
-                return result.read_all()
-            if isinstance(result, pa.Table):
-                return result
-
-        to_pydict = getattr(arrow_object, "to_pydict", None)
-        if callable(to_pydict):
-            data = to_pydict()
-            if isinstance(data, dict):
-                return pa.Table.from_pydict(data)
-
-        raise TypeError(f"Unsupported Arrow object type: {type(arrow_object)!r}")
-
-    def _table_from_arrow(
-        self, arrow_table: pa.Table | pa.RecordBatchReader, schema: ibis.Schema
-    ) -> Table:
-        """Register an Arrow table with DuckDB and return an Ibis table."""
-
-        arrow_table = self._ensure_arrow_table(arrow_table)
-
-        table_name = f"_vector_store_{uuid.uuid4().hex}"
-        self.conn.register(table_name, arrow_table)
-        table = self._client.table(table_name)
-
-        casts = {}
+        temp_name = f"_vector_store_{uuid.uuid4().hex}"
+        column_defs = []
         for column_name, dtype in schema.items():
-            column = table[column_name]
-            if column.type() != dtype:
-                casts[column_name] = column.cast(dtype)
+            column_type = self._duckdb_type_from_ibis(dtype)
+            if column_type is None:
+                raise TypeError(f"Unsupported dtype {dtype!r} for column {column_name}")
+            column_defs.append(f"{column_name} {column_type}")
 
-        if casts:
-            table = table.mutate(**casts)
+        columns_sql = ", ".join(column_defs)
+        self.conn.execute(f"CREATE TEMP TABLE {temp_name} ({columns_sql})")
 
-        return table.select(schema.names)
+        column_names = list(schema.names)
+        placeholders = ", ".join("?" for _ in column_names)
+        values = [tuple(record.get(name) for name in column_names) for record in records]
+        if values:
+            self.conn.executemany(
+                f"INSERT INTO {temp_name} ({', '.join(column_names)}) VALUES ({placeholders})",
+                values,
+            )
+
+        return self._client.table(temp_name)
 
     def _ensure_local_table(self, table: Table) -> Table:
         """Materialize a table on the store backend when necessary."""
@@ -960,35 +933,16 @@ class VectorStore:
             return table
 
         source_schema = table.schema()
-        op = table.op() if hasattr(table, "op") else None
-        pandas_proxy = getattr(op, "data", None) if op is not None else None
-
-        if pandas_proxy is not None and hasattr(pandas_proxy, "to_frame"):
-            dataframe = pandas_proxy.to_frame()
-            missing_columns = [
-                column for column in source_schema.names if column not in dataframe.columns
-            ]
-            for column in missing_columns:
-                dataframe[column] = None
-            dataframe = dataframe.reindex(columns=source_schema.names)
-        else:
-            dataframe = table.execute()
-
-        arrow_table = pa.Table.from_pandas(
-            dataframe,
-            schema=source_schema.to_pyarrow(),
-            preserve_index=False,
-            safe=False,
-        )
-        return self._table_from_arrow(arrow_table, source_schema)
+        dataframe = table.execute()
+        records = dataframe.to_dict("records") if hasattr(dataframe, "to_dict") else [
+            dict(zip(source_schema.names, row, strict=False)) for row in dataframe
+        ]
+        return self._table_from_rows(records, source_schema)
 
     def _empty_table(self, schema: ibis.Schema) -> Table:
         """Create an empty table with the given schema using the local backend."""
 
-        arrow_schema = schema.to_pyarrow()
-        arrays = [pa.array([], type=field.type) for field in arrow_schema]
-        empty_arrow = pa.Table.from_arrays(arrays, schema=arrow_schema)
-        return self._table_from_arrow(empty_arrow, schema)
+        return ibis.memtable([], schema=schema)
 
     def close(self) -> None:
         """Close the DuckDB connection if owned by this store."""

--- a/tests/test_annotations_store.py
+++ b/tests/test_annotations_store.py
@@ -35,3 +35,17 @@ def test_concurrent_annotation_inserts_produce_unique_sequential_ids(tmp_path):
     assert len(ids) == 10
     assert len(set(ids)) == len(ids)
     assert sorted(ids) == list(range(1, len(ids) + 1))
+
+
+def test_annotation_store_identity_survives_restart(tmp_path):
+    db_path = tmp_path / "annotations.duckdb"
+    store = AnnotationStore(db_path)
+
+    first = store.save_annotation("message-1", "message", "First comment")
+    second = store.save_annotation("message-2", "message", "Second comment")
+
+    store = AnnotationStore(db_path)
+    third = store.save_annotation("message-3", "message", "Third comment")
+
+    assert second.id == first.id + 1
+    assert third.id == second.id + 1

--- a/tests/test_duckdb_sql_integrations.py
+++ b/tests/test_duckdb_sql_integrations.py
@@ -71,6 +71,22 @@ def test_ranking_store_bulk_initialize_and_update(tmp_path: Path):
     assert rating_b == {"elo_global": 1400.0, "games_played": 1}
 
 
+def test_ranking_store_initialize_handles_empty_batches(tmp_path: Path):
+    store = RankingStore(tmp_path / "rankings")
+
+    assert store.initialize_ratings([]) == 0
+
+    temp_tables = store.conn.execute(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE lower(table_name) = lower('__elo_init_posts')
+        """
+    ).fetchall()
+
+    assert temp_tables == []
+
+
 def test_annotation_store_uses_identity_column(tmp_path: Path):
     store = AnnotationStore(tmp_path / "annotations.duckdb")
 

--- a/tools/check_forbidden_imports.py
+++ b/tools/check_forbidden_imports.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail pre-commit if forbidden imports are introduced outside allowlist."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ALLOWLIST_PATH = Path("tools/forbidden_import_allowlist.txt")
+
+
+def load_allowlist() -> set[str]:
+    if not ALLOWLIST_PATH.exists():
+        return set()
+    return {
+        line.strip()
+        for line in ALLOWLIST_PATH.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def check_module(module: str, allowlist: set[str]) -> list[str]:
+    pattern = rf"(^|\\s)import\\s+{module}\\b|(^|\\s)from\\s+{module}\\b"
+    result = subprocess.run(
+        [
+            "git",
+            "grep",
+            "-nE",
+            pattern,
+            "--",
+            ".",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    offending: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        path, *_ = line.split(":", 2)
+        if path.startswith("tests/") or path.startswith("tests_unit/"):
+            continue
+        if path in allowlist:
+            continue
+        offending.append(line)
+    return offending
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: check_forbidden_imports.py <module> [<module> ...]", file=sys.stderr)
+        return 2
+
+    allowlist = load_allowlist()
+    failures: list[str] = []
+    for module in argv[1:]:
+        failures.extend(check_module(module, allowlist))
+
+    if failures:
+        print("Forbidden imports detected. Review the following lines:\n", file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        if allowlist:
+            print(
+                "\nIf these imports are intentional, add the file path to",
+                ALLOWLIST_PATH,
+                file=sys.stderr,
+            )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/forbidden_import_allowlist.txt
+++ b/tools/forbidden_import_allowlist.txt
@@ -1,0 +1,2 @@
+# Files temporarily allowed to import pandas/pyarrow until refactored
+src/egregora/generation/writer/formatting.py


### PR DESCRIPTION
## Summary
- centralize DuckDB identity fallback in `ensure_identity_column` and simplify the annotations store initialization
- replace pyarrow-based insert paths in enrichment, ranking, and vector store modules with DuckDB-native operations and strengthen type handling
- add pre-commit guards against pandas/pyarrow imports and extend the test suite for identity sequencing, ranking init edge cases, and rag metadata expectations

## Testing
- pytest tests/test_annotations_store.py tests/test_duckdb_sql_integrations.py tests/test_rag_store.py

------
https://chatgpt.com/codex/tasks/task_e_6909022895dc8325bde58cfa66640c04