### PR TITLE
Fix P0 and P1 issues from PR review

### DIFF
--- a/src/egregora/orchestration/cli.py
+++ b/src/egregora/orchestration/cli.py
@@ -18,8 +18,7 @@ from rich.markup import escape
 from rich.panel import Panel
 
 from ..augmentation.enrichment import enrich_table, extract_and_replace_media
-from ..augmentation.profiler import get_active_authors
-from ..augmentation.profiler import _update_profile_metadata
+from ..augmentation.profiler import _update_profile_metadata, get_active_authors
 from ..augmentation.profiler import read_profile as read_author_profile
 from ..config import (
     ModelConfig,
@@ -87,9 +86,7 @@ def _make_json_safe(value: Any, *, strict: bool = False) -> Any:
 
     # Unknown type - log warning and convert to string (or raise in strict mode)
     if strict:
-        raise TypeError(
-            f"Cannot serialize type {type(value).__name__} to JSON. " f"Value: {value!r}"
-        )
+        raise TypeError(f"Cannot serialize type {type(value).__name__} to JSON. Value: {value!r}")
 
     logger.warning(
         "Converting non-serializable type %s to string for JSON export: %r",
@@ -1218,7 +1215,8 @@ def main():
 
 def _parse_avatar_from_profile(profile_content: str) -> str | None:
     """Extract avatar path from profile markdown."""
-    match = re.search(r"## Avatar\s*\nImage: (.+)", profile_content)
+    # Match markdown image format: ![Avatar](<path> "Avatar")
+    match = re.search(r"## Avatar\s*\n!\[Avatar\]\(([^\s)]+)", profile_content)
     return match.group(1) if match else None
 
 

--- a/src/egregora/orchestration/pipeline.py
+++ b/src/egregora/orchestration/pipeline.py
@@ -106,7 +106,7 @@ def group_by_period(table: Table, period: str = "day") -> dict[str, Table]:
         iso_year = ibis.cases(
             ((week_num >= 52) & (table.timestamp.month() == 1), table.timestamp.year() - 1),  # noqa: PLR2004
             ((week_num == 1) & (table.timestamp.month() == 12), table.timestamp.year() + 1),  # noqa: PLR2004
-            else_=table.timestamp.year()
+            else_=table.timestamp.year(),
         )
 
         year_str = iso_year.cast("string")
@@ -259,7 +259,7 @@ def _process_whatsapp_export(  # noqa: PLR0912, PLR0913, PLR0915
 
         # Globally extract all media attachments from the ZIP export.
         # This replaces attachment placeholders with markdown links.
-        messages_table, _ = extract_and_replace_media(
+        messages_table, media_mapping = extract_and_replace_media(
             messages_table,
             zip_path,
             site_paths.docs_dir,


### PR DESCRIPTION
P0 (Critical): Fix NameError - capture media_mapping instead of discarding it
- In pipeline.py, changed `messages_table, _ = extract_and_replace_media(...)` to `messages_table, media_mapping = extract_and_replace_media(...)`
- This fixes the undefined `media_mapping` variable error when processing commands

P1 (Major): Fix avatar format mismatch
- Updated `_parse_avatar_from_profile()` to match markdown image syntax
- Changed regex from `## Avatar\s*\nImage: (.+)` to `## Avatar\s*\n!\[Avatar\]\(([^\s)]+)`
- Now correctly parses avatars written as `![Avatar](<path> "Avatar")`

Addresses review: https://github.com/franklinbaldo/egregora/pull/557#pullrequestreview-3413490962