### PR TITLE
Review ruff format order in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -21,11 +21,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 


### PR DESCRIPTION
- Run ruff check --fix before ruff format (fixes may need formatting)
- Remove unnecessary dependency installation step
- Use uvx ruff instead of uv run ruff for better efficiency