### PR TITLE
Fix GitHub Actions workflow for PR

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -112,23 +112,23 @@ jobs:
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             # Extract everything after @gemini safely using Python
             python3 << 'PYTHON_EOF'
-import os
-import re
-import sys
+            import os
+            import re
+            import sys
 
-comment_body = os.environ.get('COMMENT_BODY', '')
-# Extract text after @gemini
-match = re.search(r'@gemini\s*(.*)', comment_body, re.DOTALL)
-user_comment = match.group(1).strip() if match else ''
+            comment_body = os.environ.get('COMMENT_BODY', '')
+            # Extract text after @gemini
+            match = re.search(r'@gemini\s*(.*)', comment_body, re.DOTALL)
+            user_comment = match.group(1).strip() if match else ''
 
-# Write to GITHUB_OUTPUT safely
-with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-    f.write('user_comment<<EOF\n')
-    f.write(user_comment + '\n')
-    f.write('EOF\n')
-    f.write(f'pr_number={os.environ["ISSUE_NUMBER"]}\n')
-    f.write('trigger_mode=comment\n')
-PYTHON_EOF
+            # Write to GITHUB_OUTPUT safely
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                f.write('user_comment<<EOF\n')
+                f.write(user_comment + '\n')
+                f.write('EOF\n')
+                f.write(f'pr_number={os.environ["ISSUE_NUMBER"]}\n')
+                f.write('trigger_mode=comment\n')
+            PYTHON_EOF
 
             # Get PR head SHA from API
             PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
The workflow had a YAML syntax error on line 115 where the Python heredoc code had no indentation, breaking the YAML block scalar syntax. This caused GitHub Actions to fail parsing the workflow file silently, preventing it from triggering on any PRs.

Fixed by:
- Adding proper indentation (12 spaces) to all Python heredoc content
- Ensuring the heredoc delimiter is also indented
- Maintaining consistent YAML block scalar formatting

This fixes the issue where PR #603 and other PRs weren't triggering the automated Gemini code review workflow.