### PR TITLE
fix: Fix unterminated here-document in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -111,24 +111,24 @@ jobs:
         run: |
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             # Extract everything after @gemini safely using Python
-            python3 << 'PYTHON_EOF'
-            import os
-            import re
-            import sys
+            python3 <<'PYTHON_EOF'
+import os
+import re
+import sys
 
-            comment_body = os.environ.get('COMMENT_BODY', '')
-            # Extract text after @gemini
-            match = re.search(r'@gemini\s*(.*)', comment_body, re.DOTALL)
-            user_comment = match.group(1).strip() if match else ''
+comment_body = os.environ.get('COMMENT_BODY', '')
+# Extract text after @gemini
+match = re.search(r'@gemini\s*(.*)', comment_body, re.DOTALL)
+user_comment = match.group(1).strip() if match else ''
 
-            # Write to GITHUB_OUTPUT safely
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                f.write('user_comment<<EOF\n')
-                f.write(user_comment + '\n')
-                f.write('EOF\n')
-                f.write(f'pr_number={os.environ["ISSUE_NUMBER"]}\n')
-                f.write('trigger_mode=comment\n')
-            PYTHON_EOF
+# Write to GITHUB_OUTPUT safely
+with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+    f.write('user_comment<<EOF\n')
+    f.write(user_comment + '\n')
+    f.write('EOF\n')
+    f.write(f'pr_number={os.environ["ISSUE_NUMBER"]}\n')
+    f.write('trigger_mode=comment\n')
+PYTHON_EOF
 
             # Get PR head SHA from API
             PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
The PYTHON_EOF delimiter was indented, causing bash to not recognize it as the closing delimiter for the here-document. Bash requires the closing delimiter to be at column 0 (no leading whitespace).

Changes:
- Move PYTHON_EOF closing delimiter to column 0
- Move Python code inside here-doc to column 0
- This fixes the "syntax error: unexpected end of file" error

The GEMINI_API_KEY validation logic was already correct and didn't require changes.