### PR TITLE
refactor: Phase 1 - Fix auto-fixable Ruff rules (PTH, UP, F, RUF, S50…

### DIFF
--- a/src/egregora/adapters/slack.py
+++ b/src/egregora/adapters/slack.py
@@ -134,7 +134,7 @@ class SlackAdapter(SourceAdapter):
 
         if input_path.is_file() and input_path.suffix == ".json":
             try:
-                with open(input_path) as f:
+                with input_path.open() as f:
                     data = json.load(f)
                     has_data = bool(data)
             except (OSError, json.JSONDecodeError):

--- a/src/egregora/agents/banner/generator.py
+++ b/src/egregora/agents/banner/generator.py
@@ -149,7 +149,7 @@ class BannerGenerator:
                     banner_filename = f"banner-{request.slug}{file_extension}"
                     banner_path = request.output_dir / banner_filename
 
-                    with open(banner_path, "wb") as f:
+                    with banner_path.open("wb") as f:
                         f.write(data_buffer)
 
                     logger.info(f"Banner saved to: {banner_path}")

--- a/src/egregora/agents/ranking/ranking_agent.py
+++ b/src/egregora/agents/ranking/ranking_agent.py
@@ -141,6 +141,7 @@ def load_profile(profile_path: Path) -> dict[str, Any]:
 
 def load_comments_for_post(post_id: str, store: RankingStore) -> str | None:
     """Load all existing comments for a post from DuckDB.
+
     Format as markdown for agent context.
     """
     comments_table = store.get_comments_for_post(post_id)

--- a/src/egregora/agents/resolver.py
+++ b/src/egregora/agents/resolver.py
@@ -35,6 +35,7 @@ def resolve_agent_name(post_path: Path, docs_path: Path) -> str:
 
 def merge_variables(agent_config: AgentConfig, post_path: Path) -> dict[str, Any]:
     """Merges variables from the post's front-matter into the agent's variables,
+
     respecting the allowlist.
     """
     post = frontmatter.load(post_path)
@@ -63,8 +64,9 @@ class AgentResolver:
     def resolve(
         self, post_path: Path, agent_override: str | None = None
     ) -> tuple[AgentConfig, str, dict[str, Any]]:
-        """Resolves the agent for a given post and returns the agent config, prompt template,
-        and the final merged variables.
+        """Resolves the agent for a given post and returns the agent config, prompt template.
+
+        And the final merged variables.
         """
         agent_name = agent_override or resolve_agent_name(post_path, self.docs_path)
         agent_config, prompt_template = load_agent(agent_name, self.egregora_path)

--- a/src/egregora/agents/tools/rag/chunker.py
+++ b/src/egregora/agents/tools/rag/chunker.py
@@ -93,7 +93,7 @@ def parse_post(post_path: Path) -> tuple[dict[str, Any], str]:
         (metadata_dict, content_string)
 
     """
-    with open(post_path, encoding="utf-8") as f:
+    with post_path.open(encoding="utf-8") as f:
         post = frontmatter.load(f)
 
     metadata = dict(post.metadata)

--- a/src/egregora/cli.py
+++ b/src/egregora/cli.py
@@ -388,6 +388,7 @@ def edit(
     ] = False,
 ) -> None:
     """Interactive LLM-powered editor with RAG and meta-LLM capabilities.
+
     The editor can:
     - Read and edit posts line-by-line
     - Search similar posts via RAG

--- a/src/egregora/config/site.py
+++ b/src/egregora/config/site.py
@@ -99,7 +99,7 @@ def load_mkdocs_config(
         return {}, None
 
     try:
-        config = yaml.load(mkdocs_path.read_text(encoding="utf-8"), Loader=_ConfigLoader) or {}
+        config = yaml.load(mkdocs_path.read_text(encoding="utf-8"), Loader=_ConfigLoader) or {}  # noqa: S506  # _ConfigLoader extends SafeLoader
     except yaml.YAMLError as exc:
         logger.warning("Failed to parse mkdocs.yml at %s: %s", mkdocs_path, exc)
         config = {}

--- a/src/egregora/enrichment/core.py
+++ b/src/egregora/enrichment/core.py
@@ -74,11 +74,11 @@ def _atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> Non
             f.write(content)
 
         # Atomic rename (replaces destination if it exists)
-        os.replace(temp_path, path)
+        Path(temp_path).replace(path)
     except OSError as e:
         # Clean up temp file on error
         try:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
         except (FileNotFoundError, PermissionError):
             # Temp file already gone or can't delete - not critical
             pass

--- a/src/egregora/init/scaffolding.py
+++ b/src/egregora/init/scaffolding.py
@@ -44,7 +44,7 @@ def ensure_mkdocs_project(site_root: Path) -> tuple[Path, bool]:
 def _read_existing_mkdocs(mkdocs_path: Path, site_root: Path) -> Path:
     """Return the docs directory defined by an existing mkdocs.yml."""
     try:
-        payload = yaml.load(mkdocs_path.read_text(encoding="utf-8"), Loader=_ConfigLoader) or {}
+        payload = yaml.load(mkdocs_path.read_text(encoding="utf-8"), Loader=_ConfigLoader) or {}  # noqa: S506  # _ConfigLoader extends SafeLoader
     except yaml.YAMLError:
         payload = {}
 

--- a/src/egregora/models.py
+++ b/src/egregora/models.py
@@ -57,6 +57,7 @@ class MergeConfig(BaseModel):
 @dataclass(slots=True)
 class GroupSource:
     """Source for generating posts.
+
     Can be real (single group) or virtual (merge of multiple groups).
     """
 

--- a/src/egregora/pipeline/__init__.py
+++ b/src/egregora/pipeline/__init__.py
@@ -88,7 +88,6 @@ def __getattr__(name):
     if name in ("group_by_period", "period_has_posts"):
         # Import the module-level pipeline.py file (not this package)
         import sys
-        from importlib import import_module
 
         # Get the parent module to access pipeline.py sibling
         parent = sys.modules["egregora"]

--- a/src/egregora/pipeline/adapters.py
+++ b/src/egregora/pipeline/adapters.py
@@ -262,7 +262,7 @@ class SourceAdapter(ABC):
         """
         # Compute SHA-256 hash of file content
         sha256 = hashlib.sha256()
-        with open(file_path, "rb") as f:
+        with file_path.open("rb") as f:
             # Read in chunks to handle large files efficiently
             for chunk in iter(lambda: f.read(8192), b""):
                 sha256.update(chunk)

--- a/src/egregora/pipeline/orchestrator.py
+++ b/src/egregora/pipeline/orchestrator.py
@@ -247,7 +247,7 @@ class CoreOrchestrator:
             metadata = self.source_adapter.get_metadata(config.input_path)
             context.metadata.update(metadata)
             if metadata:
-                logger.info(f"[cyan]ℹ️  Metadata:[/] {metadata}")
+                logger.info(f"[cyan]INFO Metadata:[/] {metadata}")
         except Exception as e:
             logger.debug(f"Could not extract metadata: {e}")
 

--- a/src/egregora/utils/batch.py
+++ b/src/egregora/utils/batch.py
@@ -306,7 +306,7 @@ class GeminiBatchClient:
             sleep_with_progress_sync(poll_interval, f"Waiting for {job_name}")
 
 
-def chunk_requests[_T](items: Sequence[_T], *, size: int) -> Iterable[Sequence[_T]]:
+def chunk_requests[T](items: Sequence[T], *, size: int) -> Iterable[Sequence[T]]:
     """Yield fixed-size batches from ``items``."""
     if size <= 0:
         msg = "Batch size must be positive"


### PR DESCRIPTION
…6, D205)

Complete Phase 1 of category-by-category Ruff enforcement plan. Fixed all auto-fixable and easily manually-fixable rules.

Category 1A - Code Cleanup (9 fixes):
- PTH123 (4): Replace open() with Path.open()
- PTH105 (1): Replace os.replace() with Path.replace()
- PTH108 (1): Replace os.unlink() with Path.unlink()
- UP049 (1): Rename type parameter _T to T (PEP 695)
- F401 (1): Remove unused import
- RUF001 (1): Fix ambiguous unicode (ℹ️ → INFO)

Category 1B - Security (2 fixes):
- S506 (2): Add noqa comments for false positive (_ConfigLoader extends SafeLoader, so yaml.load is safe)

Category 1C - Documentation (5 fixes):
- D205 (5): Add blank line after docstring summary

Changes:
- src/egregora/adapters/slack.py: Path.open()
- src/egregora/agents/banner/generator.py: Path.open()
- src/egregora/agents/tools/rag/chunker.py: Path.open()
- src/egregora/enrichment/core.py: Path.replace(), Path.unlink()
- src/egregora/pipeline/__init__.py: Remove unused import
- src/egregora/pipeline/adapters.py: Path.open()
- src/egregora/pipeline/orchestrator.py: Fix unicode
- src/egregora/utils/batch.py: Fix type parameter name
- src/egregora/config/site.py: Add noqa for S506
- src/egregora/init/scaffolding.py: Add noqa for S506
- Multiple files: Add blank lines in docstrings

All unit tests passing (77/77).
Ready for Phase 2: Manual fixes (logging, unused args, exceptions, types).