### PR TITLE
Practice handling GitHub links and discussions

### DIFF
--- a/.claude/skills/github-api/README.md
+++ b/.claude/skills/github-api/README.md
@@ -48,11 +48,30 @@ https://gist.github.com/user/123
 
 ## Key Features
 
-1. **No HTML Scraping** - Direct access to plain text content
-2. **No Authentication** - Works with public repos (raw content has no rate limits)
-3. **Multiple Formats** - Choose diff, patch, raw, or feed formats
-4. **Whitespace Control** - Add `?w=1` to ignore whitespace changes
-5. **Line Numbers** - Use `#L10-L20` for specific line ranges
+1. **Plain Text First** - Direct access without HTML scraping (when possible)
+2. **Smart Fallback** - Falls back to HTML for errors or review comments
+3. **No Authentication** - Works with public repos (raw content has no rate limits)
+4. **Multiple Formats** - Choose diff, patch, raw, or feed formats
+5. **Whitespace Control** - Add `?w=1` to ignore whitespace changes
+6. **Line Numbers** - Use `#L10-L20` for specific line ranges
+
+## Important Notes
+
+**When to use HTML instead of plain text:**
+- URL has fragment identifier (`#discussion_r123`, `#issuecomment-456`)
+- .diff/.patch returns 403 Forbidden error
+- Need review comments or discussion threads
+- Want PR description and metadata
+
+**Fragment identifiers require HTML:**
+```bash
+# Has fragment → Must use HTML
+https://github.com/owner/repo/pull/123#discussion_r2506786717  ✅ HTML
+https://github.com/owner/repo/pull/123.diff  ❌ Won't show comment
+
+# No fragment → Try plain text first
+https://github.com/owner/repo/pull/123  → Try .diff first
+```
 
 ## URL Patterns
 
@@ -69,11 +88,13 @@ https://gist.github.com/user/123
 ## Workflow
 
 When a user shares a GitHub URL:
-1. **Identify** the URL type
-2. **Transform** to plain text format
-3. **Fetch** using WebFetch tool
-4. **Analyze** the content
-5. **Respond** with insights
+1. **Check** for fragment identifiers (`#discussion_...`) → Use HTML if present
+2. **Identify** the URL type (PR, commit, file, etc.)
+3. **Transform** to plain text format (.diff, .patch, raw)
+4. **Fetch** using WebFetch tool
+5. **Handle errors** - If 403: Fall back to HTML
+6. **Analyze** the content
+7. **Respond** with insights
 
 ## Documentation
 

--- a/.claude/skills/github-api/examples.md
+++ b/.claude/skills/github-api/examples.md
@@ -2,23 +2,60 @@
 
 Practical examples of using GitHub's plain text URL transformations.
 
-## Example 1: Code Review
+## Example 1: Code Review (Simple PR)
 
 **User Request:**
 > "Can you review this PR? https://github.com/franklinbaldo/egregora/pull/600"
 
 **Claude Workflow:**
 
-1. **Identify**: This is a pull request URL
-2. **Transform**: Add `.diff` suffix
-3. **Fetch**: `https://github.com/franklinbaldo/egregora/pull/600.diff`
-4. **Analyze**: Review the unified diff
-5. **Respond**: Provide code review feedback
+1. **Check**: No fragment identifier → Try plain text
+2. **Identify**: This is a pull request URL
+3. **Transform**: Add `.diff` suffix
+4. **Fetch**: `https://github.com/franklinbaldo/egregora/pull/600.diff`
+5. **Handle errors**: If 403 → Fall back to HTML
+6. **Analyze**: Review the unified diff
+7. **Respond**: Provide code review feedback
 
 **Why `.diff` instead of `.patch`?**
 - `.diff` is lighter weight (just the changes)
 - `.patch` includes commit metadata (author, message, date)
 - For code review, just the diff is usually sufficient
+
+## Example 1b: PR Review Comment
+
+**User Request:**
+> "Check this review comment: https://github.com/franklinbaldo/egregora/pull/628#discussion_r2506786717"
+
+**Claude Workflow:**
+
+1. **Check**: Fragment identifier detected (`#discussion_r2506786717`) → Use HTML
+2. **Fetch**: `https://github.com/franklinbaldo/egregora/pull/628` (HTML page)
+3. **Analyze**: Extract PR info, code changes, and specific review comment
+4. **Respond**: Provide context about the comment and related code
+
+**Why HTML instead of `.diff`?**
+- Review comments are only visible in the HTML page
+- `.diff` format shows code changes but not discussion threads
+- Fragment identifiers (`#discussion_...`) require HTML rendering
+
+**Example response:**
+```
+PR #628: "Simplify avatar to accept only URL format"
+
+The review comment (discussion_r2506786717) is a P1 priority issue from Codex:
+
+Issue: The new `update_profile_avatar()` signature only accepts `avatar_url`
+and timestamp, but existing callers still pass the old parameters (avatar_uuid,
+avatar_path, moderation_status). This will cause TypeErrors.
+
+Code context:
+- File: profiler.py
+- Function: update_profile_avatar()
+- Change: Simplified from 5 params to 2 params (URL + timestamp)
+
+Recommendation: Update all callers to use the new URL-only interface.
+```
 
 ## Example 2: Understanding a File
 


### PR DESCRIPTION
…ndling

Enhanced the github-api skill based on real-world testing to handle edge cases:

**Key improvements:**
1. Added fallback strategy for 403 errors on .diff/.patch URLs
   - URLs redirect to patch-diff.githubusercontent.com which can return 403
   - Now falls back to HTML page when plain text fails

2. Fragment identifier detection (#discussion_r..., #issuecomment-...)
   - Review comments only visible in HTML, not .diff format
   - Automatically use HTML when fragments detected

3. Smart URL transformation workflow:
   - Check for fragments → Use HTML if present
   - Try plain text first → Fall back to HTML on error
   - Clear decision tree for when to use each format

4. Real-world example added:
   - PR #628 review comment as Example 1b
   - Shows actual workflow with fragment identifiers

**Files updated:**
- README.md: Added "Important Notes" section, updated workflow
- SKILL.md: Enhanced error handling, fallback strategy, best practices
- examples.md: Added PR review comment example (1b)

Testing confirmed: Fragment identifiers require HTML, .diff URLs can fail with 403, HTML fallback works for all content including discussions.