### PR TITLE
Fix config facade exports and remove stale ranking integration tests

### DIFF
--- a/src/egregora/config/__init__.py
+++ b/src/egregora/config/__init__.py
@@ -67,6 +67,7 @@ from egregora.config.schema import (
     EMBEDDING_DIM,
     # Pydantic V2 config models (persisted in .egregora/config.yml)
     EgregoraConfig,
+    EnrichmentConfig,
     EnrichmentRuntimeConfig,
     FeaturesConfig,
     MediaEnrichmentContext,
@@ -78,6 +79,7 @@ from egregora.config.schema import (
     # Runtime dataclasses (for function parameters, not persisted)
     ProcessConfig,
     RAGConfig,
+    WriterConfig,
     WriterRuntimeConfig,
     # Config loading/saving functions
     create_default_config,
@@ -121,8 +123,6 @@ __all__ = [
     "EMBEDDING_DIM",  # Embedding vector dimensions
     "MEDIA_DIR_NAME",  # Media subdirectory name
     "PROFILES_DIR_NAME",  # Profiles subdirectory name
-    "ComparisonConfig",  # Elo ranking comparison parameters
-    "ComparisonData",  # Comparison result data
     # ==========================================================================
     # Core Pydantic V2 Config Models (PRIMARY - Phase 2 modernization)
     # ==========================================================================
@@ -149,7 +149,6 @@ __all__ = [
     # Will eventually use EgregoraConfig internally.
     "ProcessConfig",  # CLI process command parameters
     "RAGConfig",  # Retrieval settings
-    "RankingCliConfig",  # Ranking CLI parameters
     # ==========================================================================
     # Site Paths & MkDocs Utilities
     # ==========================================================================

--- a/tests/integration/test_duckdb_sql_integrations.py
+++ b/tests/integration/test_duckdb_sql_integrations.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import ibis
-from egregora.agents.ranking.store import RankingStore
 
 from egregora.agents.shared.annotations import ANNOTATION_AUTHOR, AnnotationStore
 from egregora.config.schema import create_default_config
@@ -52,42 +51,6 @@ def _create_conversation_table(tmp_path: Path) -> tuple[duckdb.DuckDBPyConnectio
         database_schema.CONVERSATION_SCHEMA,
     )
     return backend.con, table_name
-
-
-def test_ranking_store_bulk_initialize_and_update(tmp_path: Path):
-    store = RankingStore(tmp_path / "rankings")
-
-    initial_posts = ["post-a", "post-b"]
-    inserted = store.initialize_ratings(initial_posts)
-    assert inserted == len(set(initial_posts))
-
-    next_posts = ["post-a", "post-c"]
-    inserted_again = store.initialize_ratings(next_posts)
-    assert inserted_again == len({"post-c"})
-
-    store.update_ratings("post-a", "post-b", 1600.0, 1400.0)
-
-    rating_a = store.get_rating("post-a")
-    rating_b = store.get_rating("post-b")
-
-    assert rating_a == {"elo_global": 1600.0, "games_played": 1}
-    assert rating_b == {"elo_global": 1400.0, "games_played": 1}
-
-
-def test_ranking_store_initialize_handles_empty_batches(tmp_path: Path):
-    store = RankingStore(tmp_path / "rankings")
-
-    assert store.initialize_ratings([]) == 0
-
-    temp_tables = store.conn.execute(
-        """
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE lower(table_name) = lower('__elo_init_posts')
-        """
-    ).fetchall()
-
-    assert temp_tables == []
 
 
 def test_annotation_store_uses_identity_column(tmp_path: Path):


### PR DESCRIPTION
## Summary
- re-export EnrichmentConfig and WriterConfig from the config facade while dropping removed ranking symbols from __all__
- delete DuckDB integration tests that depended on the removed ranking package

## Testing
- pytest tests/integration/test_duckdb_sql_integrations.py *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147fb93f1c832582a29aef631c9334)