### PR TITLE
fix: support legacy enrichment output formats

### DIFF
--- a/src/egregora/enrichment/simple_runner.py
+++ b/src/egregora/enrichment/simple_runner.py
@@ -132,7 +132,7 @@ def _create_enrichment_row(
 
 def _serve_enrichment_document(
     document: Document,
-    context: "EnrichmentRuntimeContext",
+    context: EnrichmentRuntimeContext,
     *,
     source_url: str | None = None,
     media_path: Path | None = None,
@@ -156,8 +156,8 @@ def _serve_enrichment_document(
             ``enrichments`` helpers.
         ValueError: If required contextual information is missing for the
             legacy persistence helpers.
-    """
 
+    """
     output_format = context.output_format
     serve_fn = getattr(output_format, "serve", None)
     if callable(serve_fn):


### PR DESCRIPTION
## Summary
- add a compatibility helper that persists enrichment documents using either the new OutputFormat.serve API or the legacy enrichments.write_* helpers
- update URL and media enrichment code paths to use the compatibility helper so enrichments continue to save successfully

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147fca35088325954aba7c76b079d0)