### PR TITLE
Fix scaffold README instructions to use egregora write command

### DIFF
--- a/src/egregora/rendering/templates/site/README.md.jinja
+++ b/src/egregora/rendering/templates/site/README.md.jinja
@@ -20,10 +20,10 @@ The site will be available at `http://127.0.0.1:8000`.
 
 ```bash
 # Process a WhatsApp export
-egregora process \
-  --zip_file=whatsapp-export.zip \
+egregora write \
+  whatsapp-export.zip \
   --output=. \
-  --gemini_key=YOUR_KEY
+  --gemini-key=YOUR_KEY
 ```
 
 ### Build for production


### PR DESCRIPTION
## Summary
- update the site README template generated by `egregora init` to document the supported `egregora write` command
- replace the obsolete `egregora process --zip_file` example so new scaffolds point to a working command

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d084b88483259244778f555ab495)