### PR TITLE
Update privacy exports to match anonymizer API

### DIFF
--- a/src/egregora/privacy/__init__.py
+++ b/src/egregora/privacy/__init__.py
@@ -6,7 +6,7 @@ This package handles all privacy-related operations:
 - Opt-out user management
 """
 
-from egregora.privacy.anonymizer import anonymize_author, anonymize_mentions, anonymize_table
+from egregora.privacy.anonymizer import anonymize_table
 from egregora.privacy.detector import (
     PrivacyViolationError,
     validate_newsletter_privacy,  # deprecated alias
@@ -15,8 +15,6 @@ from egregora.privacy.detector import (
 
 __all__ = [
     "PrivacyViolationError",
-    "anonymize_author",
-    "anonymize_mentions",
     "anonymize_table",
     "validate_newsletter_privacy",  # deprecated - use validate_text_privacy
     "validate_text_privacy",


### PR DESCRIPTION
## Summary
- stop re-exporting anonymize_author/anonymize_mentions that were removed from anonymizer
- keep privacy package __all__ consistent with the current anonymizer API

## Testing
- not run (import-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d2ab28208325b3fcb664538f68d0)