### PR TITLE
Remove deprecated anonymizer re-exports from privacy init

### DIFF
--- a/src/egregora/privacy/__init__.py
+++ b/src/egregora/privacy/__init__.py
@@ -6,7 +6,7 @@ This package handles all privacy-related operations:
 - Opt-out user management
 """
 
-from egregora.privacy.anonymizer import anonymize_author, anonymize_mentions, anonymize_table
+from egregora.privacy.anonymizer import anonymize_table
 from egregora.privacy.detector import (
     PrivacyViolationError,
     validate_newsletter_privacy,  # deprecated alias
@@ -15,8 +15,6 @@ from egregora.privacy.detector import (
 
 __all__ = [
     "PrivacyViolationError",
-    "anonymize_author",
-    "anonymize_mentions",
     "anonymize_table",
     "validate_newsletter_privacy",  # deprecated - use validate_text_privacy
     "validate_text_privacy",


### PR DESCRIPTION
## Summary
- drop the anonymize_author and anonymize_mentions imports removed from anonymizer.py
- keep egregora.privacy importable by only re-exporting anonymize_table

## Testing
- not run (duckdb dependency unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d84b7a84832599a649bc0359dfbf)