### PR TITLE
Document adapter-scoped anonymization namespaces

### DIFF
--- a/docs/architecture/adr-002-deterministic-uuids.md
+++ b/docs/architecture/adr-002-deterministic-uuids.md
@@ -8,7 +8,7 @@
 
 Egregora needs to generate pseudonymous identities for authors while maintaining:
 1. **Determinism**: Re-ingesting the same data must produce identical UUIDs
-2. **Multi-tenancy**: Different tenants must get isolated identity namespaces
+2. **Multi-tenancy**: Different tenants can opt into isolated identity namespaces
 3. **Privacy**: Real names must never reach the LLM API
 4. **Source separation**: Same person in different sources gets different UUIDs
 
@@ -44,16 +44,21 @@ EGREGORA_NAMESPACE (root)
 ### Implementation
 
 ```python
-from egregora.privacy.constants import NamespaceContext, deterministic_author_uuid
+import uuid
 
-# Generate tenant-scoped UUID
+from egregora.privacy.constants import NAMESPACE_AUTHOR, NamespaceContext, deterministic_author_uuid
+
 ctx = NamespaceContext(tenant_id="acme-corp", source="whatsapp")
-author_uuid = deterministic_author_uuid("acme-corp", "whatsapp", "Alice")
+tenant_namespace = uuid.uuid5(
+    NAMESPACE_AUTHOR,
+    f"tenant:{ctx.tenant_id}:source:{ctx.source}",
+)
+author_uuid = deterministic_author_uuid("Alice", namespace=tenant_namespace)
 
 # Properties:
-# 1. Deterministic: Same inputs → same UUID
-# 2. Isolated: Different tenant_id → different UUID
-# 3. Source-aware: Different source → different UUID
+# 1. Deterministic: Same author + namespace → same UUID
+# 2. Isolated (opt-in): Different tenant namespace → different UUID
+# 3. Source-aware: Namespace key can encode the adapter source
 ```
 
 ### Frozen Namespaces
@@ -70,8 +75,8 @@ All base namespaces are **frozen constants** in `src/egregora/privacy/constants.
 
 ### Positive
 
-✅ **Tenant isolation**: `acme-corp/Alice` ≠ `default/Alice`  
-✅ **Source separation**: `whatsapp/Alice` ≠ `slack/Alice`  
+✅ **Tenant isolation**: `acme-corp/Alice` ≠ `default/Alice` when adapters choose different namespaces
+✅ **Source separation**: Encode the source in the namespace key to separate `whatsapp/Alice` from `slack/Alice`
 ✅ **Determinism**: Re-ingest → identical UUIDs  
 ✅ **Privacy**: No PII in UUIDs (one-way hash)  
 ✅ **Auditability**: Can verify UUID generation from source data  
@@ -84,7 +89,7 @@ All base namespaces are **frozen constants** in `src/egregora/privacy/constants.
 
 ### Neutral
 
-ℹ️ **Complexity**: Requires tenant_id + source parameters everywhere  
+ℹ️ **Complexity**: Requires adapters to manage namespaces when isolation is required
 ℹ️ **Testing**: Property-based tests required to verify determinism  
 
 ## Migration Path
@@ -105,23 +110,27 @@ Property-based tests ensure correctness:
 ```python
 from hypothesis import given, strategies as st
 
-@given(st.text(min_size=1), st.text(min_size=1), st.text(min_size=1))
-def test_uuid5_determinism(tenant_id: str, source: str, author: str):
-    """Same inputs always produce same UUID."""
-    uuid1 = deterministic_author_uuid(tenant_id, source, author)
-    uuid2 = deterministic_author_uuid(tenant_id, source, author)
+@given(st.uuids(version=5), st.text(min_size=1))
+def test_uuid5_determinism(namespace: uuid.UUID, author: str):
+    """Same namespace + author always produce same UUID."""
+    uuid1 = deterministic_author_uuid(author, namespace=namespace)
+    uuid2 = deterministic_author_uuid(author, namespace=namespace)
     assert uuid1 == uuid2
 
 def test_tenant_isolation():
-    """Different tenants get different UUIDs for same author."""
-    uuid_acme = deterministic_author_uuid("acme", "whatsapp", "Alice")
-    uuid_default = deterministic_author_uuid("default", "whatsapp", "Alice")
+    """Different namespaces keep tenants isolated."""
+    tenant_ns = uuid.uuid5(NAMESPACE_AUTHOR, "tenant:acme:source:whatsapp")
+    default_ns = uuid.uuid5(NAMESPACE_AUTHOR, "tenant:default:source:whatsapp")
+    uuid_acme = deterministic_author_uuid("Alice", namespace=tenant_ns)
+    uuid_default = deterministic_author_uuid("Alice", namespace=default_ns)
     assert uuid_acme != uuid_default
 
 def test_source_separation():
-    """Different sources get different UUIDs for same author."""
-    uuid_whatsapp = deterministic_author_uuid("default", "whatsapp", "Alice")
-    uuid_slack = deterministic_author_uuid("default", "slack", "Alice")
+    """Different source keys generate distinct namespaces."""
+    whatsapp_ns = uuid.uuid5(NAMESPACE_AUTHOR, "tenant:default:source:whatsapp")
+    slack_ns = uuid.uuid5(NAMESPACE_AUTHOR, "tenant:default:source:slack")
+    uuid_whatsapp = deterministic_author_uuid("Alice", namespace=whatsapp_ns)
+    uuid_slack = deterministic_author_uuid("Alice", namespace=slack_ns)
     assert uuid_whatsapp != uuid_slack
 ```
 

--- a/docs/architecture/ir-v1-spec.md
+++ b/docs/architecture/ir-v1-spec.md
@@ -361,16 +361,28 @@ def deterministic_event_uuid(source: str, msg_id: str) -> uuid.UUID:
     key = f"{source}:{msg_id}"
     return uuid.uuid5(NS_EVENTS, key)
 
-def deterministic_author_uuid(tenant_id: str, source: str, author_raw: str) -> uuid.UUID:
-    """Generate deterministic author UUID."""
-    key = f"{tenant_id}:{source}:{author_raw}"
-    return uuid.uuid5(NS_AUTHORS, key)
+def deterministic_author_uuid(author_raw: str, *, namespace: uuid.UUID = NS_AUTHORS) -> uuid.UUID:
+    """Generate deterministic author UUID within a namespace."""
+    return uuid.uuid5(namespace, author_raw.strip().lower())
 
 def deterministic_thread_uuid(tenant_id: str, source: str, thread_key: str) -> uuid.UUID:
     """Generate deterministic thread UUID."""
     key = f"{tenant_id}:{source}:{thread_key}"
     return uuid.uuid5(NS_THREADS, key)
 ```
+
+Adapters **must** call `deterministic_author_uuid()` while parsing source data so
+that the IR table already contains anonymized identities. Passing a custom
+`namespace` derived from tenant or source metadata keeps pseudonyms isolated
+when required:
+
+```python
+tenant_namespace = uuid.uuid5(NS_AUTHORS, f"tenant:{tenant_id}:source:{source}")
+author_uuid = deterministic_author_uuid(author_raw, namespace=tenant_namespace)
+```
+
+The core validation layer assumes the adapter already performed this step and
+will not back-fill missing pseudonyms.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that input adapters must supply anonymized author_uuid values before returning IR data
- explain how adapters can optionally derive tenant-specific namespaces when calling deterministic_author_uuid
- refresh privacy and migration guides to reflect adapter-managed pseudonymization

## Testing
- not run (documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d8fbcea88325b3972d208852b474)