### PR TITLE
Import uuid in privacy gate for author UUID validation

### DIFF
--- a/src/egregora/privacy/gate.py
+++ b/src/egregora/privacy/gate.py
@@ -33,6 +33,7 @@ Example:
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import wraps


### PR DESCRIPTION
## Summary
- import the uuid module before defining the author UUID validation UDF so annotations resolve correctly at runtime

## Testing
- not run (missing duckdb dependency in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e5402b3483258897bc3910eace8a)