### PR TITLE
Address Codex feedback on backend URI handling

### DIFF
--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -511,15 +511,8 @@ def _create_database_backends(
 
     """
 
-    def _resolve_backend(value: str, *, allow_non_duckdb_uri: bool) -> tuple[Path | str, any]:
+    def _resolve_backend(value: str) -> tuple[Path | str, any]:
         if _is_connection_uri(value):
-            parsed = urlparse(value)
-            scheme = parsed.scheme.lower()
-            if scheme != "duckdb" and not allow_non_duckdb_uri:
-                raise ValueError(
-                    "Runs database supports only DuckDB connections. "
-                    f"Received URI with scheme '{parsed.scheme}'."
-                )
             return value, ibis.connect(value)
 
         db_path = Path(value).expanduser()
@@ -531,10 +524,8 @@ def _create_database_backends(
         db_path.parent.mkdir(parents=True, exist_ok=True)
         return db_path, ibis.connect(f"duckdb://{db_path}")
 
-    runtime_db_path, pipeline_backend = _resolve_backend(
-        config.database.pipeline_db, allow_non_duckdb_uri=True
-    )
-    runs_db_path, runs_backend = _resolve_backend(config.database.runs_db, allow_non_duckdb_uri=False)
+    runtime_db_path, pipeline_backend = _resolve_backend(config.database.pipeline_db)
+    runs_db_path, runs_backend = _resolve_backend(config.database.runs_db)
 
     return runtime_db_path, pipeline_backend, runs_backend
 


### PR DESCRIPTION
## Summary
- stop rejecting non-DuckDB connection URIs when resolving the runs database backend
- simplify the database resolution helper to accept any connection string and reuse it for both pipeline and runs backends

## Testing
- not run (duckdb dependency unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915291e13c08325b1c6583417354008)