### PR TITLE
fix: preserve annotation document identity

### DIFF
--- a/src/egregora/agents/shared/annotations/__init__.py
+++ b/src/egregora/agents/shared/annotations/__init__.py
@@ -146,8 +146,16 @@ class Annotation:
             "parent_type": self.parent_type,
             "author": self.author,
         }
+        identity_header = (
+            "<!--\n"
+            f"annotation_id: {self.id}\n"
+            f"parent_type: {self.parent_type}\n"
+            f"parent_id: {self.parent_id}\n"
+            "-->\n\n"
+        )
+
         return Document(
-            content=self.commentary,
+            content=f"{identity_header}{self.commentary}",
             type=DocumentType.ANNOTATION,
             metadata=metadata,
             created_at=self.created_at,


### PR DESCRIPTION
## Summary
- add an identity header to annotation documents so duplicate commentary still hashes uniquely
- extend annotation document tests to cover the header and ensure per-annotation document IDs

## Testing
- uv run pytest tests/unit/test_annotation_documents.py tests/integration/test_annotations_store.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915aa7ecc908325ae9dc8b92bd1a264)