### PR TITLE
Allow comma between WhatsApp date and time

### DIFF
--- a/src/egregora/sources/whatsapp/parser_sql.py
+++ b/src/egregora/sources/whatsapp/parser_sql.py
@@ -45,7 +45,7 @@ _IMPORT_SOURCE_COLUMN = "_import_source"
 # MUST have author and colon (to match pyparsing behavior)
 # Groups: (date, time, author, message)
 WHATSAPP_LINE_PATTERN = re.compile(
-    r"^(\d{1,2}[/\.\-]\d{1,2}[/\.\-]\d{2,4})\s+(\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?)\s*[—\-]\s*([^:]+):\s*(.*)$"
+    r"^(\d{1,2}[/\.\-]\d{1,2}[/\.\-]\d{2,4})(?:,\s*|\s+)(\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?)\s*[—\-]\s*([^:]+):\s*(.*)$"
 )
 
 # Text normalization


### PR DESCRIPTION
## Summary
- update the WhatsApp line regex to accept either whitespace or a comma+whitespace between the date and time tokens so real exports parse correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915acfcb0a88325a40bc39abe3a3315)