### PR TITLE
Fix eager legacy column access in IR v1 fallbacks

### DIFF
--- a/src/egregora/agents/shared/author_profiles.py
+++ b/src/egregora/agents/shared/author_profiles.py
@@ -418,7 +418,10 @@ def filter_opted_out_authors(
     if not opted_out:
         return (table, 0)
     logger.info("Found %s opted-out authors", len(opted_out))
-    author_column = getattr(table, "author_uuid", table.author)
+    if hasattr(table, "author_uuid"):
+        author_column = table.author_uuid
+    else:
+        author_column = table.author
 
     original_count = table.count().execute()
     filtered_table = table.filter(~author_column.isin(list(opted_out)))

--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -604,7 +604,10 @@ def _save_checkpoint(results: dict, messages_table: ir.Table, checkpoint_path: P
         return
 
     # Checkpoint based on messages in the filtered table
-    timestamp_column = getattr(messages_table, "ts", messages_table.timestamp)
+    if hasattr(messages_table, "ts"):
+        timestamp_column = messages_table.ts
+    else:
+        timestamp_column = messages_table.timestamp
 
     checkpoint_stats = messages_table.aggregate(
         max_timestamp=timestamp_column.max(),
@@ -651,7 +654,10 @@ def _apply_filters(
     if removed_count > 0:
         logger.warning("⚠️  %s messages removed from opted-out users", removed_count)
 
-    timestamp_column = getattr(messages_table, "ts", messages_table.timestamp)
+    if hasattr(messages_table, "ts"):
+        timestamp_column = messages_table.ts
+    else:
+        timestamp_column = messages_table.timestamp
 
     # Date range filtering
     if from_date or to_date:


### PR DESCRIPTION
## Summary
- guard the opted-out author filter so it only uses the legacy author column when author_uuid is absent
- update checkpoint and filter timestamp selection to check for the ts column before falling back to timestamp

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d9b346f88325a339d967555ff509)