### PR TITLE
Allow Eleventy media directory outside docs dir

### DIFF
--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -711,6 +711,21 @@ def _setup_content_directories(site_paths: any) -> None:
     }
 
     for label, directory in content_dirs.items():
+        if label == "media":
+            try:
+                directory.relative_to(site_paths.docs_dir)
+            except ValueError:
+                try:
+                    directory.relative_to(site_paths.site_root)
+                except ValueError as exc:
+                    msg = (
+                        "Media directory must reside inside the MkDocs docs_dir or the site root. "
+                        f"Expected parent {site_paths.docs_dir} or {site_paths.site_root}, got {directory}."
+                    )
+                    raise ValueError(msg) from exc
+            directory.mkdir(parents=True, exist_ok=True)
+            continue
+
         try:
             directory.relative_to(site_paths.docs_dir)
         except ValueError as exc:


### PR DESCRIPTION
## Summary
- relax the content directory validation to allow media directories outside the docs directory when they still live under the site root

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691620102ee48325957c83742b132f91)