### PR TITLE
Address review fixes for Eleventy Arrow adapter media and compression

### DIFF
--- a/src/egregora/output_adapters/eleventy_arrow_adapter.py
+++ b/src/egregora/output_adapters/eleventy_arrow_adapter.py
@@ -192,7 +192,7 @@ class EleventyArrowAdapter:
 
         # Write to Parquet
         parquet_path = self.data_dir / f"window_{window_index}.parquet"
-        pq.write_table(table, parquet_path)
+        pq.write_table(table, parquet_path, compression=None)
 
         logger.info(
             "Window %s: wrote %d documents to %s (%.2f KB)",


### PR DESCRIPTION
## Summary
- disable Parquet compression by explicitly setting compression to None when writing Eleventy windows

## Testing
- not run (missing duckdb dependency)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167b8304f8832593b1757b863f5c0f)