### PR TITLE
Update WhatsApp adapters to use deterministic author namespace

### DIFF
--- a/src/egregora/input_adapters/adapters/whatsapp.py
+++ b/src/egregora/input_adapters/adapters/whatsapp.py
@@ -23,6 +23,7 @@ import ibis
 
 from egregora.data_primitives import GroupSlug
 from egregora.database.validation import create_ir_table
+from egregora.privacy.uuid_namespaces import NAMESPACE_AUTHOR
 from egregora.sources.base import AdapterMeta, InputAdapter
 from egregora.sources.whatsapp.models import WhatsAppExport
 from egregora.sources.whatsapp.parser import (
@@ -131,7 +132,7 @@ class WhatsAppAdapter(InputAdapter):
     """
 
     def __init__(self, *, author_namespace: uuid.UUID | None = None) -> None:
-        self._author_namespace = author_namespace or uuid.NAMESPACE_URL
+        self._author_namespace = author_namespace or NAMESPACE_AUTHOR
 
     @property
     def source_name(self) -> str:

--- a/src/egregora/input_adapters/whatsapp.py
+++ b/src/egregora/input_adapters/whatsapp.py
@@ -23,6 +23,7 @@ import ibis
 
 from egregora.data_primitives import GroupSlug
 from egregora.database.validation import create_ir_table
+from egregora.privacy.uuid_namespaces import NAMESPACE_AUTHOR
 from egregora.sources.base import AdapterMeta, InputAdapter
 from egregora.sources.whatsapp.models import WhatsAppExport
 from egregora.sources.whatsapp.parser import (
@@ -131,7 +132,7 @@ class WhatsAppAdapter(InputAdapter):
     """
 
     def __init__(self, *, author_namespace: uuid.UUID | None = None) -> None:
-        self._author_namespace = author_namespace or uuid.NAMESPACE_URL
+        self._author_namespace = author_namespace or NAMESPACE_AUTHOR
 
     @property
     def source_name(self) -> str:


### PR DESCRIPTION
## Summary
- update the WhatsApp adapters to default to the shared privacy author namespace constant
- keep ingested author UUIDs aligned with PrivacyGate deterministic validation

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167cc4b8c88325b63c65a38ec0867c)