### PR TITLE
Fix PrivacySettings default namespace regression follow-up

### DIFF
--- a/src/egregora/input_adapters/whatsapp.py
+++ b/src/egregora/input_adapters/whatsapp.py
@@ -23,7 +23,6 @@ import ibis
 
 from egregora.data_primitives import GroupSlug
 from egregora.database.validation import create_ir_table
-from egregora.privacy.uuid_namespaces import NAMESPACE_AUTHOR
 from egregora.sources.base import AdapterMeta, InputAdapter
 from egregora.sources.whatsapp.models import WhatsAppExport
 from egregora.sources.whatsapp.parser import (
@@ -132,7 +131,7 @@ class WhatsAppAdapter(InputAdapter):
     """
 
     def __init__(self, *, author_namespace: uuid.UUID | None = None) -> None:
-        self._author_namespace = author_namespace or NAMESPACE_AUTHOR
+        self._author_namespace = author_namespace
 
     @property
     def source_name(self) -> str:


### PR DESCRIPTION
## Summary
- apply the namespace fallback removal to `egregora.input_adapters.whatsapp.WhatsAppAdapter` so tenant-scoped UUIDs are produced

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a01b5ab88325a12715ff04f4672f)