### PR TITLE
Fix unit test config import path

### DIFF
--- a/tests/unit/test_write_pipeline.py
+++ b/tests/unit/test_write_pipeline.py
@@ -1,7 +1,7 @@
 """Unit tests for write pipeline utilities."""
 
 from egregora.agents.model_limits import get_model_context_limit
-from egregora.config import EgregoraConfig
+from egregora.config.settings import EgregoraConfig
 from egregora.orchestration.write_pipeline import _calculate_max_window_size
 
 


### PR DESCRIPTION
## Summary
- update the write pipeline unit test to import `EgregoraConfig` directly from `egregora.config.settings`

## Testing
- pytest tests/unit/test_write_pipeline.py *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691712259f488325af0fcaccf3978cd1)