### PR TITLE
Add workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/pr-conflict-label.yml
+++ b/.github/workflows/pr-conflict-label.yml
@@ -1,0 +1,94 @@
+name: PR Conflict Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update conflict label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelName = 'has-conflicts';
+            const labelColor = 'd73a4a';
+            const labelDescription = 'Pull request has merge conflicts';
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            // Allow GitHub time to calculate mergeability
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            // Retrieve the latest mergeable state
+            const { data: prData } = await octokit.pulls.get({
+              owner,
+              repo,
+              pull_number,
+            });
+
+            const mergeableState = prData.mergeable_state;
+
+            // Ensure the label exists
+            try {
+              await octokit.issues.getLabel({
+                owner,
+                repo,
+                name: labelName,
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                try {
+                  await octokit.issues.createLabel({
+                    owner,
+                    repo,
+                    name: labelName,
+                    color: labelColor,
+                    description: labelDescription,
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                }
+              } else {
+                throw error;
+              }
+            }
+
+            const existingLabels = prData.labels.map((label) => label.name);
+
+            if (mergeableState === 'dirty') {
+              if (!existingLabels.includes(labelName)) {
+                await octokit.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  labels: [labelName],
+                });
+              }
+            } else if (['clean', 'unstable'].includes(mergeableState)) {
+              if (existingLabels.includes(labelName)) {
+                try {
+                  await octokit.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pull_number,
+                    name: labelName,
+                  });
+                } catch (removeError) {
+                  if (removeError.status !== 404) {
+                    throw removeError;
+                  }
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
- add a pull_request_target workflow that checks the mergeable state of PRs
- automatically create and manage the `has-conflicts` label based on mergeability

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171f133c188325a6d3ba59f7793bdf)