### PR TITLE
Adjust document type test for annotation documents

### DIFF
--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -326,6 +326,7 @@ class TestDocumentTypes:
             "ENRICHMENT_URL",
             "ENRICHMENT_MEDIA",
             "MEDIA",
+            "ANNOTATION",
         }
 
         actual_types = {dt.name for dt in DocumentType}


### PR DESCRIPTION
## Summary
- include the annotation document type in the document enumeration test

## Testing
- uv run pytest tests/core/test_document.py::TestDocumentTypes::test_all_document_types_exist -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171f29068c8325b7bfa239b2c290a9)