### PR TITLE
Fix WhatsApp command filter column reference

### DIFF
--- a/src/egregora/input_adapters/whatsapp/parser.py
+++ b/src/egregora/input_adapters/whatsapp/parser.py
@@ -173,8 +173,8 @@ def filter_egregora_messages(messages: Table) -> tuple[Table, int]:
     if int(messages.count().execute()) == 0:
         return (messages, 0)
     original_count = int(messages.count().execute())
-    # IR v1: Use .text column instead of .message
-    filtered_messages = messages.filter(~messages.text.lower().startswith("/egregora"))
+    # IR v1 schema exposes the conversation text in the `message` column
+    filtered_messages = messages.filter(~messages.message.lower().startswith("/egregora"))
     removed_count = original_count - int(filtered_messages.count().execute())
     if removed_count > 0:
         logger.info("Removed %s /egregora messages from table", removed_count)


### PR DESCRIPTION
## Summary
- update the WhatsApp command filter to read from the schema's `message` column
- clarify the inline comment to reflect the current IR column name

## Testing
- pytest tests/e2e/test_whatsapp_real_scenario.py::test_egregora_commands_are_filtered_out *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917219c046883258c1a0ad03f32ed76)