### PR TITLE
Refine connection URI detection logic

### DIFF
--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -632,9 +632,7 @@ def _is_connection_uri(value: str) -> bool:
 
     parsed = urlparse(value)
     # Handle Windows drive letters (e.g. C:/path or C:\path)
-    return bool(parsed.scheme) and not (
-        len(parsed.scheme) == 1 and value[1:3] in {":/", ":\\"}
-    )
+    return bool(parsed.scheme) and not (len(parsed.scheme) == 1 and value[1:3] in {":/", ":\\"})
 
 
 def _create_database_backends(


### PR DESCRIPTION
## Summary
- collapse the `_is_connection_uri` guard conditions into a single boolean return
- preserve the early empty-value guard while relying on short-circuit evaluation for URI validation

## Testing
- `pytest tests/unit/test_write_pipeline.py` *(fails: missing duckdb dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691740f9ab8483258a3e93d112e1e196)