### PR TITLE
Simplify frame to records conversion fallback

### DIFF
--- a/src/egregora/enrichment/runners.py
+++ b/src/egregora/enrichment/runners.py
@@ -114,8 +114,6 @@ def _frame_to_records(frame: pd.DataFrame | pa.Table | list[dict[str, Any]]) -> 
         except (ValueError, TypeError, AttributeError) as exc:  # pragma: no cover - defensive
             msg = f"Failed to convert frame to records. Original error: {exc}"
             raise RuntimeError(msg) from exc
-    if isinstance(frame, list):
-        return [dict(row) for row in frame]
     return [dict(row) for row in frame]
 
 


### PR DESCRIPTION
### Summary
Simplifies `_frame_to_records` so every iterable path returns through the same fallback conversion logic.

### Motivation / Context
- Keeps the frame-to-records utility simple and consistent while still supporting pandas, PyArrow, and iterable inputs.

### Changes
- **Refactors**
  - Drop the redundant list-specific branch in `_frame_to_records` and rely on the shared fallback conversion.

### Implementation Details
- The shared fallback already handles iterables of dict-like rows, so removing the list branch keeps behavior unchanged while trimming duplicate code.

### Testing
- `pytest tests/enrichment` *(fails: directory not present in repository)*
- `pytest tests` *(fails: numerous e2e/integration expectations not satisfied in this environment; see log for missing modules and pipeline fixtures)*

### Risks & Rollback Plan
- Low risk; revert the single helper change if issues arise.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- N/A

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691740f700dc8325a466956af22ff4df)