### PR TITLE
Refactor write pipeline orchestration and WhatsApp helpers

### DIFF
--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 import tempfile
 import uuid
+from collections import deque
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from datetime import date as date_type
@@ -50,32 +52,40 @@ from egregora.utils.cache import EnrichmentCache
 if TYPE_CHECKING:
     import ibis.expr.types as ir
 logger = logging.getLogger(__name__)
-__all__ = ["process_whatsapp_export", "run"]
+__all__ = ["WhatsAppProcessOptions", "process_whatsapp_export", "run"]
+
+
+@dataclass(frozen=True)
+class WhatsAppProcessOptions:
+    """Runtime overrides for :func:`process_whatsapp_export`."""
+
+    output_dir: Path = Path("output")
+    step_size: int = 100
+    step_unit: str = "messages"
+    overlap_ratio: float = 0.2
+    enable_enrichment: bool = True
+    from_date: date_type | None = None
+    to_date: date_type | None = None
+    timezone: str | ZoneInfo | None = None
+    gemini_api_key: str | None = None
+    model: str | None = None
+    batch_threshold: int = 10
+    retrieval_mode: str = "ann"
+    retrieval_nprobe: int | None = None
+    retrieval_overfetch: int | None = None
+    max_prompt_tokens: int = 100_000
+    use_full_context_window: bool = False
+    client: genai.Client | None = None
 
 
 def process_whatsapp_export(
     zip_path: Path,
-    output_dir: Path = Path("output"),
     *,
-    step_size: int = 100,
-    step_unit: str = "messages",
-    overlap_ratio: float = 0.2,
-    enable_enrichment: bool = True,
-    from_date: date_type | None = None,
-    to_date: date_type | None = None,
-    timezone: str | ZoneInfo | None = None,
-    gemini_api_key: str | None = None,
-    model: str | None = None,
-    batch_threshold: int = 10,
-    retrieval_mode: str = "ann",
-    retrieval_nprobe: int | None = None,
-    retrieval_overfetch: int | None = None,
-    max_prompt_tokens: int = 100_000,
-    use_full_context_window: bool = False,
-    client: genai.Client | None = None,
+    options: WhatsAppProcessOptions | None = None,
 ) -> dict[str, dict[str, list[str]]]:
     """High-level helper for processing WhatsApp ZIP exports using :func:`run`."""
-    output_dir = output_dir.expanduser().resolve()
+    opts = options or WhatsAppProcessOptions()
+    output_dir = opts.output_dir.expanduser().resolve()
     site_paths = resolve_site_paths(output_dir)
 
     base_config = load_egregora_config(site_paths.site_root)
@@ -84,24 +94,30 @@ def process_whatsapp_export(
         update={
             "pipeline": base_config.pipeline.model_copy(
                 update={
-                    "step_size": step_size,
-                    "step_unit": step_unit,
-                    "overlap_ratio": overlap_ratio,
-                    "timezone": str(timezone) if timezone else None,
-                    "from_date": from_date.isoformat() if from_date else None,
-                    "to_date": to_date.isoformat() if to_date else None,
-                    "batch_threshold": batch_threshold,
-                    "max_prompt_tokens": max_prompt_tokens,
-                    "use_full_context_window": use_full_context_window,
+                    "step_size": opts.step_size,
+                    "step_unit": opts.step_unit,
+                    "overlap_ratio": opts.overlap_ratio,
+                    "timezone": str(opts.timezone) if opts.timezone else None,
+                    "from_date": opts.from_date.isoformat() if opts.from_date else None,
+                    "to_date": opts.to_date.isoformat() if opts.to_date else None,
+                    "batch_threshold": opts.batch_threshold,
+                    "max_prompt_tokens": opts.max_prompt_tokens,
+                    "use_full_context_window": opts.use_full_context_window,
                 }
             ),
-            "enrichment": base_config.enrichment.model_copy(update={"enabled": enable_enrichment}),
+            "enrichment": base_config.enrichment.model_copy(update={"enabled": opts.enable_enrichment}),
             "rag": base_config.rag.model_copy(
                 update={
-                    "mode": retrieval_mode,
-                    "nprobe": (retrieval_nprobe if retrieval_nprobe is not None else base_config.rag.nprobe),
+                    "mode": opts.retrieval_mode,
+                    "nprobe": (
+                        opts.retrieval_nprobe
+                        if opts.retrieval_nprobe is not None
+                        else base_config.rag.nprobe
+                    ),
                     "overfetch": (
-                        retrieval_overfetch if retrieval_overfetch is not None else base_config.rag.overfetch
+                        opts.retrieval_overfetch
+                        if opts.retrieval_overfetch is not None
+                        else base_config.rag.overfetch
                     ),
                 }
             ),
@@ -113,9 +129,9 @@ def process_whatsapp_export(
         input_path=zip_path,
         output_dir=output_dir,
         config=egregora_config,
-        api_key=gemini_api_key,
-        model_override=model,
-        client=client,
+        api_key=opts.gemini_api_key,
+        model_override=opts.model,
+        client=opts.client,
     )
 
 
@@ -137,6 +153,31 @@ class WindowProcessingContext:
     retrieval_nprobe: int
     retrieval_overfetch: int
     client: genai.Client
+
+
+@dataclass
+class PipelineEnvironment:
+    """Resources required to execute the write pipeline."""
+
+    site_paths: any
+    runtime_db_uri: str
+    pipeline_backend: any
+    runs_backend: any
+    cli_model_override: str | None
+    client: genai.Client
+    enrichment_cache: EnrichmentCache
+
+
+@dataclass
+class PreparedPipelineData:
+    """Artifacts produced during dataset preparation."""
+
+    messages_table: "ir.Table"
+    windows_iterator: any
+    checkpoint_path: Path
+    window_context: WindowProcessingContext
+    enable_enrichment: bool
+    embedding_model: str
 
 
 def _process_single_window(
@@ -222,90 +263,111 @@ def _process_single_window(
 def _process_window_with_auto_split(
     window: any, ctx: WindowProcessingContext, *, depth: int = 0, max_depth: int = 5
 ) -> dict[str, dict[str, list[str]]]:
-    """Process a window with automatic splitting if prompt exceeds model limit.
+    """Process a window with automatic splitting if prompt exceeds model limit."""
 
-    Uses calculated upfront splitting (not recursive trial-and-error).
-    Depth tracking is a safety mechanism for rare edge cases.
-
-    Args:
-        window: Window to process
-        ctx: Window processing context
-        depth: Current split depth (for logging and safety checks)
-        max_depth: Maximum split depth to prevent pathological cases
-
-    Returns:
-        Dict mapping window labels to {'posts': [...], 'profiles': [...]}
-
-    Raises:
-        RuntimeError: If max split depth reached (indicates miscalculation)
-
-    """
     from egregora.agents.model_limits import PromptTooLargeError
     from egregora.transformations import split_window_into_n_parts
 
-    # Constants
-    min_window_size = 5  # Minimum messages before we stop splitting
+    min_window_size = 5
+    results: dict[str, dict[str, list[str]]] = {}
+    queue: deque[tuple[any, int]] = deque([(window, depth)])
 
-    indent = "  " * depth
-    window_label = f"{window.start_time:%Y-%m-%d %H:%M} to {window.end_time:%H:%M}"
-    window_count = window.size
+    while queue:
+        current_window, current_depth = queue.popleft()
+        indent = "  " * current_depth
+        window_label = (
+            f"{current_window.start_time:%Y-%m-%d %H:%M} to {current_window.end_time:%H:%M}"
+        )
 
-    # Stop splitting if window too small or max depth reached
-    if window_count < min_window_size:
+        _warn_if_window_too_small(current_window.size, indent, window_label, min_window_size)
+        _ensure_split_depth(current_depth, max_depth, indent, window_label)
+
+        try:
+            window_results = _process_single_window(current_window, ctx, depth=current_depth)
+        except PromptTooLargeError as error:
+            split_work = _split_window_for_retry(
+                current_window,
+                error,
+                current_depth,
+                indent,
+                split_window_into_n_parts,
+            )
+            queue.extendleft(reversed(split_work))
+            continue
+
+        results.update(window_results)
+
+    return results
+
+
+def _warn_if_window_too_small(size: int, indent: str, label: str, minimum: int) -> None:
+    if size < minimum:
         logger.warning(
             "%s⚠️  Window %s too small to split (%d messages) - attempting anyway",
             indent,
-            window_label,
-            window_count,
+            label,
+            size,
         )
+
+
+def _ensure_split_depth(depth: int, max_depth: int, indent: str, label: str) -> None:
     if depth >= max_depth:
         error_msg = (
-            f"Max split depth {max_depth} reached for window {window_label}. "
+            f"Max split depth {max_depth} reached for window {label}. "
             "Window cannot be split enough to fit in model context (possible miscalculation). "
             "Try increasing --max-prompt-tokens or using --use-full-context-window."
         )
         logger.error("%s❌ %s", indent, error_msg)
         raise RuntimeError(error_msg)
 
-    try:
-        # Try to process the window normally
-        return _process_single_window(window, ctx, depth=depth)
 
-    except PromptTooLargeError as e:
-        # Prompt too large - split window and retry
-        logger.warning(
-            "%s⚡ [yellow]Splitting window[/] %s (prompt: %dk tokens > %dk limit)",
-            indent,
-            window_label,
-            e.estimated_tokens // 1000,
-            e.effective_limit // 1000,
+def _split_window_for_retry(
+    window: any,
+    error: Exception,
+    depth: int,
+    indent: str,
+    splitter: any,
+) -> list[tuple[any, int]]:
+    import math
+
+    estimated_tokens = getattr(error, "estimated_tokens", 0)
+    effective_limit = getattr(error, "effective_limit", 1) or 1
+
+    logger.warning(
+        "%s⚡ [yellow]Splitting window[/] %s (prompt: %dk tokens > %dk limit)",
+        indent,
+        f"{window.start_time:%Y-%m-%d %H:%M} to {window.end_time:%H:%M}",
+        estimated_tokens // 1000,
+        effective_limit // 1000,
+    )
+
+    num_splits = max(1, math.ceil(estimated_tokens / effective_limit))
+    logger.info("%s↳ [dim]Splitting into %d parts[/]", indent, num_splits)
+
+    split_windows = splitter(window, num_splits)
+    if not split_windows:
+        error_msg = (
+            f"Cannot split window {window.start_time:%Y-%m-%d %H:%M} to {window.end_time:%H:%M}"
+            " - all splits would be empty"
         )
+        logger.exception("%s❌ %s", indent, error_msg)
+        raise RuntimeError(error_msg) from error
 
-        # Calculate how many splits we need upfront (deterministic, not iterative)
-        import math
+    scheduled: list[tuple[any, int]] = []
+    for index, split_window in enumerate(split_windows, 1):
+        split_label = (
+            f"{split_window.start_time:%Y-%m-%d %H:%M} to {split_window.end_time:%H:%M}"
+        )
+        logger.info(
+            "%s↳ [dim]Processing part %d/%d: %s[/]",
+            indent,
+            index,
+            len(split_windows),
+            split_label,
+        )
+        scheduled.append((split_window, depth + 1))
 
-        num_splits = math.ceil(e.estimated_tokens / e.effective_limit)
-        logger.info("%s↳ [dim]Splitting into %d parts[/]", indent, num_splits)
-
-        split_windows = split_window_into_n_parts(window, num_splits)
-
-        if not split_windows:
-            error_msg = f"Cannot split window {window_label} - all splits would be empty"
-            logger.exception("%s❌ %s", indent, error_msg)
-            raise RuntimeError(error_msg) from e
-
-        # Process each split window
-        combined_results = {}
-        for i, split_window in enumerate(split_windows, 1):
-            split_label = f"{split_window.start_time:%Y-%m-%d %H:%M} to {split_window.end_time:%H:%M}"
-            logger.info("%s↳ [dim]Processing part %d/%d: %s[/]", indent, i, len(split_windows), split_label)
-            split_results = _process_window_with_auto_split(
-                split_window, ctx, depth=depth + 1, max_depth=max_depth
-            )
-            combined_results.update(split_results)
-
-        return combined_results
-
+    return scheduled
 
 RUN_EVENTS_TABLE_NAME = "run_events"
 
@@ -700,6 +762,37 @@ def _create_database_backends(
     return runtime_db_uri, pipeline_backend, runs_backend
 
 
+def _resolve_site_paths_or_raise(output_dir: Path, config: EgregoraConfig) -> any:
+    """Resolve site paths for the configured output format and validate structure."""
+
+    site_paths = _resolve_pipeline_site_paths(output_dir, config)
+    format_type = config.output.format
+
+    if format_type != "eleventy-arrow":
+        if not site_paths.mkdocs_path or not site_paths.mkdocs_path.exists():
+            msg = (
+                f"No mkdocs.yml found for site at {output_dir}. "
+                "Run 'egregora init <site-dir>' before processing exports."
+            )
+            raise ValueError(msg)
+
+        if not site_paths.docs_dir.exists():
+            msg = (
+                f"Docs directory not found: {site_paths.docs_dir}. "
+                "Re-run 'egregora init' to scaffold the MkDocs project."
+            )
+            raise ValueError(msg)
+    elif not site_paths.docs_dir.exists():
+        msg = (
+            "Eleventy content directory not found at "
+            f"{site_paths.docs_dir}. Run 'egregora init <site-dir> --output-format eleventy-arrow' "
+            "to scaffold the project before processing exports."
+        )
+        raise ValueError(msg)
+
+    return site_paths
+
+
 def _resolve_pipeline_site_paths(output_dir: Path, config: EgregoraConfig) -> SitePaths:
     """Resolve site paths for the configured output format."""
     output_dir = output_dir.expanduser().resolve()
@@ -731,82 +824,92 @@ def _resolve_pipeline_site_paths(output_dir: Path, config: EgregoraConfig) -> Si
     )
 
 
-def _setup_pipeline_environment(
-    output_dir: Path, config: EgregoraConfig, api_key: str | None, model_override: str | None
-) -> tuple[
-    any,
-    str,
-    any,
-    any,
-    str | None,
-    genai.Client,
-    EnrichmentCache,
-]:
-    """Set up pipeline environment including paths, backends, and clients.
+def _create_gemini_client(api_key: str | None) -> genai.Client:
+    """Create a Gemini client with retry configuration suitable for the pipeline."""
 
-    Args:
-        output_dir: Output directory for generated content
-        config: Egregora configuration
-        api_key: Google Gemini API key (optional override)
-        model_override: Model override for CLI --model flag
-
-    Returns:
-        Tuple of (site_paths, runtime_db_uri, pipeline_backend, runs_backend, model_override, client, enrichment_cache)
-
-    Raises:
-        ValueError: If mkdocs.yml or docs directory not found
-
-    """
-    output_dir = output_dir.expanduser().resolve()
-    site_paths = _resolve_pipeline_site_paths(output_dir, config)
-    format_type = config.output.format
-
-    if format_type != "eleventy-arrow":
-        if not site_paths.mkdocs_path or not site_paths.mkdocs_path.exists():
-            msg = f"No mkdocs.yml found for site at {output_dir}. Run 'egregora init <site-dir>' before processing exports."
-            raise ValueError(msg)
-
-        if not site_paths.docs_dir.exists():
-            msg = f"Docs directory not found: {site_paths.docs_dir}. Re-run 'egregora init' to scaffold the MkDocs project."
-            raise ValueError(msg)
-    elif not site_paths.docs_dir.exists():
-        msg = (
-            "Eleventy content directory not found at"
-            f" {site_paths.docs_dir}. Run 'egregora init <site-dir> --output-format eleventy-arrow' "
-            "to scaffold the project before processing exports."
-        )
-        raise ValueError(msg)
-
-    # Setup database backends (Ibis-based, database-agnostic)
-    runtime_db_uri, backend, runs_backend = _create_database_backends(site_paths.site_root, config)
-
-    # Setup Gemini client
-    # Configure aggressive retry options to handle rate limits efficiently
     http_options = genai.types.HttpOptions(
         retryOptions=genai.types.HttpRetryOptions(
-            attempts=5,  # Max retry attempts
-            initialDelay=2.0,  # Start with 2s delay
-            maxDelay=15.0,  # Cap at 15s (reduced from default 60s)
-            expBase=2.0,  # Exponential backoff multiplier
-            httpStatusCodes=[429, 503],  # Retry on rate limit and service unavailable
+            attempts=5,
+            initialDelay=2.0,
+            maxDelay=15.0,
+            expBase=2.0,
+            httpStatusCodes=[429, 503],
         )
     )
-    client = genai.Client(api_key=api_key, http_options=http_options)
+    return genai.Client(api_key=api_key, http_options=http_options)
 
-    # Setup enrichment cache
+
+def _setup_pipeline_environment(
+    output_dir: Path,
+    config: EgregoraConfig,
+    api_key: str | None,
+    model_override: str | None,
+    client: genai.Client | None,
+) -> PipelineEnvironment:
+    """Set up pipeline environment including paths, backends, and clients."""
+
+    resolved_output = output_dir.expanduser().resolve()
+    site_paths = _resolve_site_paths_or_raise(resolved_output, config)
+    runtime_db_uri, backend, runs_backend = _create_database_backends(site_paths.site_root, config)
+
+    client_instance = client or _create_gemini_client(api_key)
     cache_dir = Path(".egregora-cache") / site_paths.site_root.name
     enrichment_cache = EnrichmentCache(cache_dir)
 
-    return (
-        site_paths,
-        runtime_db_uri,
-        backend,
-        runs_backend,
-        model_override,
-        client,
-        enrichment_cache,
+    return PipelineEnvironment(
+        site_paths=site_paths,
+        runtime_db_uri=runtime_db_uri,
+        pipeline_backend=backend,
+        runs_backend=runs_backend,
+        cli_model_override=model_override,
+        client=client_instance,
+        enrichment_cache=enrichment_cache,
     )
 
+
+@contextmanager
+def _pipeline_environment(
+    output_dir: Path,
+    config: EgregoraConfig,
+    api_key: str | None,
+    model_override: str | None,
+    client: genai.Client | None,
+):
+    """Context manager that provisions and tears down pipeline resources."""
+
+    options = getattr(ibis, "options", None)
+    old_backend = getattr(options, "default_backend", None) if options else None
+    env = _setup_pipeline_environment(output_dir, config, api_key, model_override, client)
+
+    if options is not None:
+        options.default_backend = env.pipeline_backend
+
+    try:
+        yield env
+    finally:
+        try:
+            env.enrichment_cache.close()
+        finally:
+            try:
+                runs_backend = env.runs_backend
+                close_method = getattr(runs_backend, "close", None)
+                if callable(close_method):
+                    close_method()
+                elif hasattr(runs_backend, "con") and hasattr(runs_backend.con, "close"):
+                    runs_backend.con.close()
+            finally:
+                try:
+                    if env.client:
+                        env.client.close()
+                finally:
+                    if options is not None:
+                        options.default_backend = old_backend
+                    backend = env.pipeline_backend
+                    backend_close = getattr(backend, "close", None)
+                    if callable(backend_close):
+                        backend_close()
+                    elif hasattr(backend, "con") and hasattr(backend.con, "close"):
+                        backend.con.close()
 
 def _parse_and_validate_source(adapter: any, input_path: Path, timezone: str) -> ir.Table:
     """Parse source and validate IR schema.
@@ -917,6 +1020,109 @@ def _process_commands_and_avatars(
 
     return messages_table
 
+
+
+def _prepare_pipeline_data(
+    adapter: any,
+    input_path: Path,
+    config: EgregoraConfig,
+    env: PipelineEnvironment,
+    output_dir: Path,
+) -> PreparedPipelineData:
+    """Prepare messages, filters, and windowing context for processing."""
+
+    timezone = config.pipeline.timezone
+    step_size = config.pipeline.step_size
+    step_unit = config.pipeline.step_unit
+    overlap_ratio = config.pipeline.overlap_ratio
+    max_window_time_hours = config.pipeline.max_window_time
+    max_window_time = timedelta(hours=max_window_time_hours) if max_window_time_hours else None
+    enable_enrichment = config.enrichment.enabled
+    retrieval_mode = config.rag.mode
+    retrieval_nprobe = config.rag.nprobe
+    retrieval_overfetch = config.rag.overfetch
+
+    from_date: date_type | None = None
+    to_date: date_type | None = None
+    if config.pipeline.from_date:
+        from_date = date_type.fromisoformat(config.pipeline.from_date)
+    if config.pipeline.to_date:
+        to_date = date_type.fromisoformat(config.pipeline.to_date)
+
+    vision_model = get_model_for_task("enricher_vision", config, env.cli_model_override)
+    embedding_model = get_model_for_task("embedding", config, env.cli_model_override)
+
+    messages_table = _parse_and_validate_source(adapter, input_path, timezone)
+    _setup_content_directories(env.site_paths)
+    messages_table = _process_commands_and_avatars(
+        messages_table, env.site_paths, vision_model, env.enrichment_cache
+    )
+
+    checkpoint_path = env.site_paths.site_root / \".egregora\" / \"checkpoint.json\"
+    messages_table = _apply_filters(
+        messages_table,
+        env.site_paths,
+        from_date,
+        to_date,
+        checkpoint_path,
+    )
+
+    logger.info("🎯 [bold cyan]Creating windows:[/] step_size=%s, unit=%s", step_size, step_unit)
+    windows_iterator = create_windows(
+        messages_table,
+        step_size=step_size,
+        step_unit=step_unit,
+        overlap_ratio=overlap_ratio,
+        max_window_time=max_window_time,
+    )
+
+    posts_dir = env.site_paths.posts_dir
+    profiles_dir = env.site_paths.profiles_dir
+
+    from egregora.output_adapters import create_output_format
+
+    output_format = create_output_format(output_dir, format_type=config.output.format)
+
+    if config.rag.enabled:
+        logger.info("[bold cyan]📚 Indexing existing documents into RAG...[/]")
+        try:
+            from egregora.agents.writer.writer_runner import index_documents_for_rag
+
+            indexed_count = index_documents_for_rag(
+                output_format, env.site_paths.rag_dir, embedding_model=embedding_model
+            )
+            if indexed_count > 0:
+                logger.info("[green]✓ Indexed[/] %s documents into RAG", indexed_count)
+            else:
+                logger.info("[dim]No new documents to index[/]")
+        except Exception:
+            logger.exception("[yellow]⚠️  Failed to index documents into RAG[/]")
+
+    window_ctx = WindowProcessingContext(
+        adapter=adapter,
+        input_path=input_path,
+        site_paths=env.site_paths,
+        posts_dir=posts_dir,
+        profiles_dir=profiles_dir,
+        config=config,
+        enrichment_cache=env.enrichment_cache,
+        output_format=output_format,
+        enable_enrichment=enable_enrichment,
+        cli_model_override=env.cli_model_override,
+        retrieval_mode=retrieval_mode,
+        retrieval_nprobe=retrieval_nprobe,
+        retrieval_overfetch=retrieval_overfetch,
+        client=env.client,
+    )
+
+    return PreparedPipelineData(
+        messages_table=messages_table,
+        windows_iterator=windows_iterator,
+        checkpoint_path=checkpoint_path,
+        window_context=window_ctx,
+        enable_enrichment=enable_enrichment,
+        embedding_model=embedding_model,
+    )
 
 def _index_media_into_rag(
     enable_enrichment: bool,
@@ -1070,206 +1276,17 @@ def run(
     model_override: str | None = None,
     client: genai.Client | None = None,
 ) -> dict[str, dict[str, list[str]]]:
-    """Run the complete write pipeline workflow.
+    """Run the complete write pipeline workflow."""
 
-    MODERN (Phase 2): Uses EgregoraConfig instead of 16 individual parameters.
-
-    This is the main entry point for processing chat exports from any source.
-    It handles:
-    1. Source adapter selection and IR parsing
-    2. Command and avatar processing
-    3. Filtering (egregora messages, opted-out users, date range)
-    4. Window creation (flexible grouping by message count, time, or tokens)
-    5. Media extraction and enrichment (optional)
-    6. Post writing with LLM
-    7. RAG indexing
-
-    Args:
-        source: Source identifier ("whatsapp", "slack", etc.)
-        input_path: Path to input file (ZIP, JSON, etc.)
-        output_dir: Output directory for generated content
-        config: Egregora configuration (models, RAG, pipeline, enrichment, etc.)
-        api_key: Google Gemini API key (optional override)
-        model_override: Model override for CLI --model flag
-        client: Optional pre-configured genai.Client
-
-    Returns:
-        Dict mapping window IDs to {'posts': [...], 'profiles': [...]}
-
-    Raises:
-        ValueError: If source is unknown or configuration is invalid
-        RuntimeError: If pipeline execution fails
-
-    """
     logger.info("[bold cyan]🚀 Starting pipeline for source:[/] %s", source)
     adapter = get_adapter(source)
 
-    # Setup environment (paths, backends, clients)
-    if client is None:
-        (
-            site_paths,
-            runtime_db_uri,
-            backend,
-            runs_backend,
-            cli_model_override,
-            client,
-            enrichment_cache,
-        ) = _setup_pipeline_environment(output_dir, config, api_key, model_override)
-    else:
-        # If client is provided, still need to setup most things
-        output_dir = output_dir.expanduser().resolve()
-        site_paths = _resolve_pipeline_site_paths(output_dir, config)
-        format_type = config.output.format
-        if format_type != "eleventy-arrow":
-            if not site_paths.mkdocs_path or not site_paths.mkdocs_path.exists():
-                msg = f"No mkdocs.yml found for site at {output_dir}. Run 'egregora init <site-dir>' before processing exports."
-                raise ValueError(msg)
-            if not site_paths.docs_dir.exists():
-                msg = f"Docs directory not found: {site_paths.docs_dir}. Re-run 'egregora init' to scaffold the MkDocs project."
-                raise ValueError(msg)
-        elif not site_paths.docs_dir.exists():
-            msg = (
-                "Eleventy content directory not found at"
-                f" {site_paths.docs_dir}. Run 'egregora init <site-dir> --output-format eleventy-arrow' "
-                "to scaffold the project before processing exports."
-            )
-            raise ValueError(msg)
-        runtime_db_uri, backend, runs_backend = _create_database_backends(site_paths.site_root, config)
-        cli_model_override = model_override
-        cache_dir = Path(".egregora-cache") / site_paths.site_root.name
-        enrichment_cache = EnrichmentCache(cache_dir)
-
-    options = getattr(ibis, "options", None)
-    old_backend = getattr(options, "default_backend", None) if options else None
-    try:
-        if options is not None:
-            options.default_backend = backend
-
-        # Extract config values
-        timezone = config.pipeline.timezone
-        step_size = config.pipeline.step_size
-        step_unit = config.pipeline.step_unit
-        overlap_ratio = config.pipeline.overlap_ratio
-        max_window_time_hours = config.pipeline.max_window_time
-        max_window_time = timedelta(hours=max_window_time_hours) if max_window_time_hours else None
-        enable_enrichment = config.enrichment.enabled
-        retrieval_mode = config.rag.mode
-        retrieval_nprobe = config.rag.nprobe
-        retrieval_overfetch = config.rag.overfetch
-
-        # Parse date filters
-        from_date: date_type | None = None
-        to_date: date_type | None = None
-        if config.pipeline.from_date:
-            from_date = date_type.fromisoformat(config.pipeline.from_date)
-        if config.pipeline.to_date:
-            to_date = date_type.fromisoformat(config.pipeline.to_date)
-
-        # Get model identifiers
-        vision_model = get_model_for_task("enricher_vision", config, cli_model_override)
-        embedding_model = get_model_for_task("embedding", config, cli_model_override)
-
-        # Parse and validate source
-        messages_table = _parse_and_validate_source(adapter, input_path, timezone)
-
-        # Setup content directories
-        _setup_content_directories(site_paths)
-
-        # Process commands and avatars
-        messages_table = _process_commands_and_avatars(
-            messages_table, site_paths, vision_model, enrichment_cache
-        )
-
-        # Apply all filters
-        checkpoint_path = site_paths.site_root / ".egregora" / "checkpoint.json"
-        messages_table = _apply_filters(messages_table, site_paths, from_date, to_date, checkpoint_path)
-
-        logger.info("🎯 [bold cyan]Creating windows:[/] step_size=%s, unit=%s", step_size, step_unit)
-        windows_iterator = create_windows(
-            messages_table,
-            step_size=step_size,
-            step_unit=step_unit,
-            overlap_ratio=overlap_ratio,
-            max_window_time=max_window_time,
-        )
-
-        posts_dir = site_paths.posts_dir
-        profiles_dir = site_paths.profiles_dir
-
-        # Create OutputAdapter for RAG indexing (storage-agnostic)
-        from egregora.output_adapters import create_output_format
-
-        format_type = config.output.format
-        output_format = create_output_format(output_dir, format_type=format_type)
-
-        # Phase 7.5: Index all existing documents for RAG before window processing
-        # This ensures the writer agent has full context from previous runs
-        # Uses OutputAdapter.list_documents() - no filesystem assumptions
-        if config.rag.enabled:
-            logger.info("[bold cyan]📚 Indexing existing documents into RAG...[/]")
-            try:
-                from egregora.agents.writer.writer_runner import index_documents_for_rag
-
-                indexed_count = index_documents_for_rag(
-                    output_format, site_paths.rag_dir, embedding_model=embedding_model
-                )
-                if indexed_count > 0:
-                    logger.info("[green]✓ Indexed[/] %s documents into RAG", indexed_count)
-                else:
-                    logger.info("[dim]No new documents to index[/]")
-            except Exception:
-                # RAG indexing failure should not block pipeline
-                logger.exception("[yellow]⚠️  Failed to index documents into RAG[/]")
-
-        # Create window processing context
-        window_ctx = WindowProcessingContext(
-            adapter=adapter,
-            input_path=input_path,
-            site_paths=site_paths,
-            posts_dir=posts_dir,
-            profiles_dir=profiles_dir,
-            config=config,
-            enrichment_cache=enrichment_cache,
-            output_format=output_format,
-            enable_enrichment=enable_enrichment,
-            cli_model_override=cli_model_override,
-            retrieval_mode=retrieval_mode,
-            retrieval_nprobe=retrieval_nprobe,
-            retrieval_overfetch=retrieval_overfetch,
-            client=client,
-        )
-
-        # Process all windows with tracking
-        results = _process_all_windows(windows_iterator, window_ctx, runs_backend)
-
-        # Index media enrichments into RAG
-        _index_media_into_rag(enable_enrichment, results, site_paths, embedding_model)
-
-        # Save checkpoint after successful processing
-        _save_checkpoint(results, messages_table, checkpoint_path)
+    with _pipeline_environment(output_dir, config, api_key, model_override, client) as env:
+        dataset = _prepare_pipeline_data(adapter, input_path, config, env, output_dir)
+        results = _process_all_windows(dataset.windows_iterator, dataset.window_context, env.runs_backend)
+        _index_media_into_rag(dataset.enable_enrichment, results, env.site_paths, dataset.embedding_model)
+        _save_checkpoint(results, dataset.messages_table, dataset.checkpoint_path)
 
         logger.info("[bold green]🎉 Pipeline completed successfully![/]")
         return results
-    finally:
-        try:
-            if "enrichment_cache" in locals():
-                enrichment_cache.close()
-        finally:
-            try:
-                if "runs_backend" in locals():
-                    close_method = getattr(runs_backend, "close", None)
-                    if callable(close_method):
-                        close_method()
-                    elif hasattr(runs_backend, "con") and hasattr(runs_backend.con, "close"):
-                        runs_backend.con.close()
-            finally:
-                if client:
-                    client.close()
-        if options is not None:
-            options.default_backend = old_backend
-        if "backend" in locals():
-            backend_close = getattr(backend, "close", None)
-            if callable(backend_close):
-                backend_close()
-            elif hasattr(backend, "con") and hasattr(backend.con, "close"):
-                backend.con.close()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,7 +288,7 @@ def mock_batch_client(monkeypatch):
     Usage:
         def test_with_mock(mock_batch_client):
             # All API calls are now mocked
-            process_whatsapp_export(...)
+            process_whatsapp_export(..., options=WhatsAppProcessOptions())
     """
     # Patch genai.Client - this is the main client used everywhere
     monkeypatch.setattr(

--- a/tests/e2e/test_with_golden_fixtures.py
+++ b/tests/e2e/test_with_golden_fixtures.py
@@ -16,7 +16,10 @@ import pytest
 from pydantic_ai.models.test import TestModel
 
 from egregora.config import resolve_site_paths
-from egregora.orchestration.write_pipeline import process_whatsapp_export
+from egregora.orchestration.write_pipeline import (
+    WhatsAppProcessOptions,
+    process_whatsapp_export,
+)
 from tests.utils.mock_batch_client import create_mock_genai_client
 
 if TYPE_CHECKING:
@@ -97,8 +100,7 @@ def test_pipeline_with_golden_fixtures(
     client = create_mock_genai_client()
 
     # Run the pipeline - enrichment remains disabled because we do not stub binary uploads here.
-    process_whatsapp_export(
-        zip_path=whatsapp_fixture.zip_path,
+    options = WhatsAppProcessOptions(
         output_dir=output_dir,
         step_size=100,
         step_unit="messages",
@@ -106,6 +108,10 @@ def test_pipeline_with_golden_fixtures(
         enable_enrichment=False,  # Binary uploads remain hard to stub in this test harness
         retrieval_mode="exact",  # Exact mode avoids VSS extension dependency (see docstring)
         client=client,
+    )
+    process_whatsapp_export(
+        whatsapp_fixture.zip_path,
+        options=options,
     )
 
     # Verify that the basic output structure was created

--- a/tests/utils/vcr_adapter.py
+++ b/tests/utils/vcr_adapter.py
@@ -134,8 +134,9 @@ class VCRCompatibleClient:
         >>> api_key = os.getenv("GOOGLE_API_KEY")
         >>> client = VCRCompatibleClient(api_key)
         >>>
-        >>> # Use in pipeline just like genai.Client
-        >>> process_whatsapp_export(..., client=client)
+        >>> from egregora.orchestration.write_pipeline import WhatsAppProcessOptions
+        >>> options = WhatsAppProcessOptions(client=client)
+        >>> process_whatsapp_export(..., options=options)
 
     """
 


### PR DESCRIPTION
## Summary
- introduce a WhatsAppProcessOptions dataclass and update CLI/tests to consume it instead of many keyword arguments
- extract reusable helpers for site path validation, environment setup, dataset preparation, and iterative window splitting in the write pipeline
- simplify run() orchestration around a context-managed environment while keeping test utilities in sync with the new API

## Testing
- pytest tests/unit/test_write_pipeline.py tests/e2e/test_whatsapp_real_scenario.py tests/e2e/test_with_golden_fixtures.py *(fails: missing duckdb dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917684f070c83258ada86753e076b70)