### PR TITLE
Fix relative imports flagged by linting

### DIFF
--- a/src/egregora/output_adapters/mkdocs/__init__.py
+++ b/src/egregora/output_adapters/mkdocs/__init__.py
@@ -1,6 +1,6 @@
 """MkDocs output adapter package."""
 
-from .adapter import (
+from egregora.output_adapters.mkdocs.adapter import (
     DEFAULT_BLOG_DIR,
     DEFAULT_DOCS_DIR,
     MEDIA_DIR_NAME,
@@ -17,7 +17,9 @@ from .adapter import (
     resolve_site_paths,
     secure_path_join,
 )
-from .url_convention import LegacyMkDocsUrlConvention
+from egregora.output_adapters.mkdocs.url_convention import (
+    LegacyMkDocsUrlConvention,
+)
 
 __all__ = [
     "DEFAULT_BLOG_DIR",

--- a/src/egregora/privacy/config.py
+++ b/src/egregora/privacy/config.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
-from .uuid_namespaces import NAMESPACE_AUTHOR
+from egregora.privacy.uuid_namespaces import NAMESPACE_AUTHOR
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- replace MkDocs adapter package re-exports with absolute imports
- update privacy configuration to import namespaces via absolute path to satisfy TID252

## Testing
- uv run pytest tests/linting/test_absolute_imports.py
- ruff check src/egregora --select TID252

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176a8ebf5c8325a7eea282ad194048)