### PR TITLE
Fix ordering for markdown consolidation

### DIFF
--- a/src/egregora/agents/writer/context_builder.py
+++ b/src/egregora/agents/writer/context_builder.py
@@ -57,8 +57,15 @@ def consolidate_messages_to_markdown(table: Table) -> str:
         Markdown-formatted string suitable for chunk_markdown()
 
     """
-    # Execute table to dataframe
-    df = table.select("timestamp", "author", "message").execute()
+    # Execute table to dataframe with deterministic ordering
+    order_columns: list[Any] = []
+    if "timestamp" in table.columns:
+        order_columns.append(table["timestamp"])
+    if "message_id" in table.columns:
+        order_columns.append(table["message_id"])
+
+    ordered_table = table.order_by(order_columns) if order_columns else table
+    df = ordered_table.select("timestamp", "author", "message").execute()
 
     if df.empty:
         return ""


### PR DESCRIPTION
## Summary
- ensure `consolidate_messages_to_markdown` orders conversation rows deterministically before chunking
- keep chunk boundaries stable by sorting by timestamp and message_id when available

## Testing
- pytest tests/unit/test_chunked_rag_context.py::test_consolidate_messages_to_markdown -q *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176b06a88c832594533743bfcb4e36)