### PR TITLE
Handle execution-time ordering failures in fingerprinting

### DIFF
--- a/src/egregora/database/tracking.py
+++ b/src/egregora/database/tracking.py
@@ -168,7 +168,11 @@ def fingerprint_table(table: ibis.Table) -> str:
             # Some backends may not support ordering by complex column types
             ordered_table = table
 
-    sample = ordered_table.limit(1000).execute()
+    try:
+        sample = ordered_table.limit(1000).execute()
+    except (IbisError, NotImplementedError, TypeError):
+        # Ordering can fail during execution even if building the expression succeeds
+        sample = table.limit(1000).execute()
     data_str = sample.to_csv(index=False)
 
     # Combine schema + data


### PR DESCRIPTION
## Summary
- wrap fingerprint sampling in a try/except to catch backend ordering failures during execution
- fall back to the original unsorted limit when execute raises so hashing still succeeds

## Testing
- uv run pytest tests/unit/test_runs_tracking.py::test_fingerprint_table_deterministic

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176d8c779083259b5acf42c7397654)