### PR TITLE
Handle load_egregora_config errors explicitly

### DIFF
--- a/src/egregora/config/settings.py
+++ b/src/egregora/config/settings.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -460,14 +460,21 @@ def load_egregora_config(site_root: Path) -> EgregoraConfig:
     logger.info("Loading config from %s", config_path)
 
     try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        raw_config = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.error("Failed to read config from %s: %s", config_path, exc)
+        raise
+
+    try:
+        data = yaml.safe_load(raw_config) or {}
+    except yaml.YAMLError as exc:
+        logger.error("Failed to parse YAML in %s: %s", config_path, exc)
+        raise
+
+    try:
         return EgregoraConfig(**data)
-    except yaml.YAMLError:
-        logger.exception("Failed to parse %s", config_path)
-        logger.warning("Creating default config due to YAML error")
-        return create_default_config(site_root)
-    except Exception:
-        logger.exception("Invalid config in %s", config_path)
+    except ValidationError as exc:
+        logger.error("Validation failed for %s: %s", config_path, exc)
         logger.warning("Creating default config due to validation error")
         return create_default_config(site_root)
 


### PR DESCRIPTION
### Summary
Improve configuration loading error handling and adjust supporting tests.

### Motivation / Context
The loader previously swallowed unexpected exceptions and always returned defaults, which could hide misconfigurations or filesystem issues. We now surface those errors while still providing defaults for validation problems.

### Changes
- Configuration
  - Read the config file and parse YAML in separate steps, logging explicit messages for `OSError` and YAML failures.
  - Catch `pydantic.ValidationError` to fall back to defaults while re-raising other exceptions.
- Tests
  - Update YAML error handling expectations and add coverage for propagating `OSError` conditions.

### Implementation Details
- Introduced targeted exception handling to avoid a blanket `except Exception`, improving observability and reliability.
- Tests use `pytest.raises` to assert propagation behavior and monkeypatch `Path.read_text` to simulate IO errors.

### Testing
- `pytest tests/unit/test_egregora_config.py` *(fails: requires additional optional dependencies such as `pydantic_ai` that are not installed in the container)*

### Risks & Rollback Plan
- Minimal risk: behavior only changes for configuration load failures. Rollback by reverting this commit if unexpected regressions occur.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- Improve configuration loader error handling to surface unexpected exceptions while preserving defaults for validation errors.

### Checklist
- [x] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691772738f048325ab1b6a7ce749c89a)