### PR TITLE
Vectorize WhatsApp command extraction

### DIFF
--- a/src/egregora/input_adapters/whatsapp/parser.py
+++ b/src/egregora/input_adapters/whatsapp/parser.py
@@ -67,7 +67,6 @@ SMART_QUOTES_TRANSLATION = str.maketrans(
 @ibis.udf.scalar.python
 def normalize_smart_quotes(value: str | None) -> str:
     """Normalize smart quotes in command text for vectorized parsing."""
-
     if value is None:
         return ""
     return value.translate(SMART_QUOTES_TRANSLATION)
@@ -76,7 +75,6 @@ def normalize_smart_quotes(value: str | None) -> str:
 @ibis.udf.scalar.python
 def strip_wrapping_quotes(value: str | None) -> str | None:
     """Strip wrapping single/double quotes from string values."""
-
     if value is None:
         return None
     return value.strip("\"'")

--- a/tests/unit/test_whatsapp_parser_commands.py
+++ b/tests/unit/test_whatsapp_parser_commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import ibis
 
@@ -12,17 +12,17 @@ def test_extract_commands_handles_plain_and_smart_quotes() -> None:
         [
             {
                 "author": "alice",
-                "timestamp": datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                "timestamp": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
                 "message": '/egregora set alias "Frank"',
             },
             {
                 "author": "bob",
-                "timestamp": datetime(2024, 1, 1, 12, 1, tzinfo=timezone.utc),
+                "timestamp": datetime(2024, 1, 1, 12, 1, tzinfo=UTC),
                 "message": "/egregora set alias “Franklin”",
             },
             {
                 "author": "carol",
-                "timestamp": datetime(2024, 1, 1, 12, 2, tzinfo=timezone.utc),
+                "timestamp": datetime(2024, 1, 1, 12, 2, tzinfo=UTC),
                 "message": "hello there",
             },
         ]
@@ -34,13 +34,13 @@ def test_extract_commands_handles_plain_and_smart_quotes() -> None:
     assert commands == [
         {
             "author": "alice",
-            "timestamp": datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            "timestamp": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
             "message": '/egregora set alias "Frank"',
             "command": {"command": "set", "target": "alias", "value": "Frank"},
         },
         {
             "author": "bob",
-            "timestamp": datetime(2024, 1, 1, 12, 1, tzinfo=timezone.utc),
+            "timestamp": datetime(2024, 1, 1, 12, 1, tzinfo=UTC),
             "message": "/egregora set alias “Franklin”",
             "command": {"command": "set", "target": "alias", "value": "Franklin"},
         },


### PR DESCRIPTION
## Summary
- replace row-wise WhatsApp command parsing with an ibis pipeline that derives command metadata
- add ibis scalar UDFs to normalize smart quotes and trim wrapping quotes during vectorized parsing
- cover plain and smart-quote command messages with a regression test to lock in behaviour

## Testing
- pytest tests/unit/test_whatsapp_parser_commands.py *(fails: missing duckdb module in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917728985188325a69b7db53ee54939)