### PR TITLE
Tighten site scaffolding type hints

### DIFF
--- a/src/egregora/output_adapters/mkdocs/adapter.py
+++ b/src/egregora/output_adapters/mkdocs/adapter.py
@@ -436,7 +436,9 @@ class MkDocsOutputAdapter(OutputAdapter):
             logger.info("MkDocs site scaffold created at %s", site_root)
             return (new_mkdocs_path, True)
 
-    def _create_site_structure(self, site_paths: Any, env: Any, context: dict[str, Any]) -> None:
+    def _create_site_structure(
+        self, site_paths: SitePaths, env: Environment, context: dict[str, Any]
+    ) -> None:
         """Create essential directories and index files for the blog structure.
 
         Args:
@@ -445,6 +447,9 @@ class MkDocsOutputAdapter(OutputAdapter):
             context: Template rendering context
 
         """
+        assert isinstance(site_paths, SitePaths), "site_paths must be a SitePaths instance"
+        assert isinstance(env, Environment), "env must be a Jinja2 Environment"
+
         # Create .egregora/ structure
         self._create_egregora_structure(site_paths, env)
 
@@ -457,13 +462,15 @@ class MkDocsOutputAdapter(OutputAdapter):
         # Create .egregora/config.yml
         self._create_egregora_config(site_paths, env)
 
-    def _create_content_directories(self, site_paths: Any) -> None:
+    def _create_content_directories(self, site_paths: SitePaths) -> None:
         """Create main content directories for the site.
 
         Args:
             site_paths: SitePaths configuration object
 
         """
+        assert isinstance(site_paths, SitePaths), "site_paths must be a SitePaths instance"
+
         posts_dir = site_paths.posts_dir
         profiles_dir = site_paths.profiles_dir
         media_dir = site_paths.media_dir
@@ -483,7 +490,9 @@ class MkDocsOutputAdapter(OutputAdapter):
         journal_dir.mkdir(exist_ok=True)
         (journal_dir / ".gitkeep").touch()
 
-    def _create_template_files(self, site_paths: Any, env: Any, context: dict[str, Any]) -> None:
+    def _create_template_files(
+        self, site_paths: SitePaths, env: Environment, context: dict[str, Any]
+    ) -> None:
         """Create starter template files from Jinja2 templates.
 
         Args:
@@ -492,6 +501,9 @@ class MkDocsOutputAdapter(OutputAdapter):
             context: Template rendering context
 
         """
+        assert isinstance(site_paths, SitePaths), "site_paths must be a SitePaths instance"
+        assert isinstance(env, Environment), "env must be a Jinja2 Environment"
+
         site_root = site_paths.site_root
         profiles_dir = site_paths.profiles_dir
         media_dir = site_paths.media_dir
@@ -513,7 +525,7 @@ class MkDocsOutputAdapter(OutputAdapter):
                 content = template.render(**context)
                 target_path.write_text(content, encoding="utf-8")
 
-    def _create_egregora_config(self, site_paths: Any, env: Any) -> None:
+    def _create_egregora_config(self, site_paths: SitePaths, env: Environment) -> None:
         """Create .egregora/config.yml from template.
 
         Args:
@@ -521,6 +533,9 @@ class MkDocsOutputAdapter(OutputAdapter):
             env: Jinja2 environment for rendering templates
 
         """
+        assert isinstance(site_paths, SitePaths), "site_paths must be a SitePaths instance"
+        assert isinstance(env, Environment), "env must be a Jinja2 Environment"
+
         config_path = site_paths.config_path
         if not config_path.exists():
             try:


### PR DESCRIPTION
### Summary
- Require concrete `SitePaths` and Jinja `Environment` instances when building MkDocs scaffolding helpers.
- Add runtime assertions so unexpected inputs surface immediately during scaffolding.

### Motivation / Context
- Align scaffolding helpers with the real types they operate on to catch integration mistakes earlier.
- Addresses the request to stop accepting `Any` for the core MkDocs site creation helpers.

### Changes
- **MkDocs scaffolding**
  - Update `_create_site_structure`, `_create_content_directories`, `_create_template_files`, and `_create_egregora_config` to accept `SitePaths`/`Environment` instead of `Any`.
  - Add assertions guarding `SitePaths` and `Environment` arguments before performing filesystem or template work.

### Implementation Details
- Changes are localized to the MkDocs adapter so the stricter annotations align with actual call sites while providing defensive runtime checks for legacy integrations.

### Testing
- `uv run mypy src` *(fails: project currently reports numerous missing stub packages and unrelated typing issues)*

### Risks & Rollback Plan
- Low risk; new assertions may surface invalid callers sooner but behavior is otherwise unchanged.
- Rollback by reverting this commit if necessary.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- Tightened MkDocs scaffolding helpers to require explicit `SitePaths` and Jinja environments.

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691772920ff08325bcc5047b6fc063ba)