### PR TITLE
Refactor writer runner helpers for indexing and prompt orchestration

### DIFF
--- a/tests/unit/test_writer_runner_helpers.py
+++ b/tests/unit/test_writer_runner_helpers.py
@@ -16,9 +16,9 @@ from egregora.agents.writer.writer_runner import (
     WriterPromptContext,
     _build_writer_environment,
     _build_writer_prompt_context,
+    _detect_changed_documents,
     _fetch_format_documents,
     _index_documents,
-    _detect_changed_documents,
     _render_writer_prompt,
     _resolve_document_paths,
 )
@@ -110,7 +110,9 @@ def test_resolve_document_paths_filters_invalid() -> None:
     }
 
 
-def test_detect_changed_documents_identifies_new_and_changed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_detect_changed_documents_identifies_new_and_changed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     df = pd.DataFrame(
         {
             "storage_identifier": ["same", "changed", "new"],


### PR DESCRIPTION
## Summary
- break `index_documents_for_rag` into focused helper functions backed by a `DocumentIndexPlan`
- extract writer environment and prompt construction into reusable helpers
- add unit tests covering the new helper functionality

## Testing
- pytest tests/unit/test_writer_runner_helpers.py *(fails: ibis not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177284559c8325aa76ac7af3d0b7c3)