### PR TITLE
Remove Hugo adapter from output registry

### DIFF
--- a/src/egregora/output_adapters/__init__.py
+++ b/src/egregora/output_adapters/__init__.py
@@ -5,20 +5,17 @@ from egregora.output_adapters.eleventy_arrow import (
     EleventyArrowAdapter,
     EleventyArrowOutputAdapter,
 )
-from egregora.output_adapters.hugo import HugoOutputAdapter
 
 # MkDocsAdapter: Unified MkDocs adapter
 from egregora.output_adapters.mkdocs import MkDocsAdapter
 
 # Register output formats on module import
 output_registry.register(MkDocsAdapter)
-output_registry.register(HugoOutputAdapter)
 output_registry.register(EleventyArrowOutputAdapter)
 
 __all__ = [
     "EleventyArrowAdapter",
     "EleventyArrowOutputAdapter",
-    "HugoOutputAdapter",
     "MkDocsAdapter",
     "OutputAdapter",
     "create_output_format",

--- a/src/egregora/output_adapters/base.py
+++ b/src/egregora/output_adapters/base.py
@@ -812,7 +812,7 @@ def create_output_format(site_root: Path, format_type: str = "mkdocs") -> Output
 
     Args:
         site_root: Root directory for the site
-        format_type: Output format type from config ('mkdocs', 'hugo', etc.)
+        format_type: Output format type from config (e.g., 'mkdocs')
 
     Returns:
         Initialized OutputAdapter instance
@@ -824,12 +824,10 @@ def create_output_format(site_root: Path, format_type: str = "mkdocs") -> Output
     Examples:
         >>> # From config: output.format = "mkdocs"
         >>> fmt = create_output_format(site_root, format_type="mkdocs")
-        >>> # From config: output.format = "hugo"
-        >>> fmt = create_output_format(site_root, format_type="hugo")
 
     Note:
         This function automatically ensures the registry is populated by
-        importing egregora.rendering (which registers MkDocs and Hugo formats).
+        importing egregora.rendering (which registers the supported formats).
 
     """
     # Ensure registry is populated by importing rendering module


### PR DESCRIPTION
## Summary
- Remove the Hugo output adapter from the default registry so it is no longer treated as a supported format
- Update output adapter factory documentation to reference only registered adapters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d32b5e7cc8325a457b9d84554577a)