### PR TITLE
Use shared IR message schema

### DIFF
--- a/src/egregora/database/ir_schema.py
+++ b/src/egregora/database/ir_schema.py
@@ -85,6 +85,39 @@ WHATSAPP_SCHEMA = MESSAGE_SCHEMA
 # ============================================================================
 
 # ----------------------------------------------------------------------------
+# Interchange Representation (IR) v1 Message Schema
+# ----------------------------------------------------------------------------
+
+IR_MESSAGE_SCHEMA = ibis.schema(
+    {
+        # Identity
+        # NOTE: UUID columns stored as dt.string in Ibis, DuckDB schema handles conversion to UUID type
+        "event_id": dt.string,
+        # Multi-Tenant
+        "tenant_id": dt.string,
+        "source": dt.string,
+        # Threading
+        "thread_id": dt.string,
+        "msg_id": dt.string,
+        # Temporal
+        "ts": dt.Timestamp(timezone="UTC"),
+        # Authors (PRIVACY BOUNDARY)
+        "author_raw": dt.string,
+        "author_uuid": dt.string,
+        # Content
+        "text": dt.String(nullable=True),
+        "media_url": dt.String(nullable=True),
+        "media_type": dt.String(nullable=True),
+        # Metadata
+        "attrs": dt.JSON(nullable=True),
+        "pii_flags": dt.JSON(nullable=True),
+        # Lineage
+        "created_at": dt.Timestamp(timezone="UTC"),
+        "created_by_run": dt.string,
+    }
+)
+
+# ----------------------------------------------------------------------------
 # RAG Vector Store Schemas
 # ----------------------------------------------------------------------------
 # NOTE: Windows are runtime-only constructs (see pipeline.py Window dataclass).
@@ -825,6 +858,7 @@ __all__ = [
     # Ephemeral schemas
     "CONVERSATION_SCHEMA",
     "DEFAULT_TIMEZONE",
+    "IR_MESSAGE_SCHEMA",
     # Elo schemas
     "ELO_HISTORY_SCHEMA",
     "ELO_RATINGS_SCHEMA",

--- a/src/egregora/database/validation.py
+++ b/src/egregora/database/validation.py
@@ -7,9 +7,9 @@ to the IR v1 schema specification at runtime. It combines:
 2. **Runtime validation**: Validates sample rows using Pydantic models
 3. **Adapter boundary enforcement**: Validates adapter outputs before pipeline
 
-**Canonical Schema**: The `IR_MESSAGE_SCHEMA` defined in this module is the
-single source of truth for the IR v1 specification. All adapters MUST produce
-tables conforming to this schema.
+**Canonical Schema**: The `IR_MESSAGE_SCHEMA` imported from
+`egregora.database.ir_schema` is the single source of truth for the IR v1
+specification. All adapters MUST produce tables conforming to this schema.
 
 Usage:
 
@@ -57,6 +57,7 @@ import ibis
 import ibis.expr.datatypes as dt
 from pydantic import BaseModel, Field, ValidationError, create_model
 
+from egregora.database.ir_schema import IR_MESSAGE_SCHEMA
 from egregora.privacy.uuid_namespaces import (
     deterministic_author_uuid,
     deterministic_event_uuid,
@@ -173,40 +174,6 @@ def ibis_schema_to_pydantic(
     if frozen:
         model.model_config = ConfigDict(frozen=True)
     return model
-
-
-# ============================================================================
-# IR v1 Schema Definition (Ibis)
-# ============================================================================
-
-IR_MESSAGE_SCHEMA = ibis.schema(
-    {
-        # Identity
-        # NOTE: UUID columns stored as dt.string in Ibis, DuckDB schema handles conversion to UUID type
-        "event_id": dt.string,
-        # Multi-Tenant
-        "tenant_id": dt.string,
-        "source": dt.string,
-        # Threading
-        "thread_id": dt.string,
-        "msg_id": dt.string,
-        # Temporal
-        "ts": dt.Timestamp(timezone="UTC"),
-        # Authors (PRIVACY BOUNDARY)
-        "author_raw": dt.string,
-        "author_uuid": dt.string,
-        # Content
-        "text": dt.String(nullable=True),
-        "media_url": dt.String(nullable=True),
-        "media_type": dt.String(nullable=True),
-        # Metadata
-        "attrs": dt.JSON(nullable=True),
-        "pii_flags": dt.JSON(nullable=True),
-        # Lineage
-        "created_at": dt.Timestamp(timezone="UTC"),
-        "created_by_run": dt.string,
-    }
-)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- move the IR message schema definition to the centralized `ir_schema` module and import it in validation
- keep validation utilities using the shared schema to avoid divergence

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d32b18d848325a5d8adfc99f1637b)