### PR TITLE
Use shared ensure_datetime helper for avatar enrichment

### DIFF
--- a/src/egregora/enrichment/avatar.py
+++ b/src/egregora/enrichment/avatar.py
@@ -30,6 +30,7 @@ from egregora.enrichment.agents import (
 from egregora.enrichment.media import detect_media_type, extract_urls
 from egregora.input_adapters.whatsapp.parser import extract_commands
 from egregora.utils import EnrichmentCache, make_enrichment_cache_key
+from egregora.utils.time_utils import ensure_datetime
 
 if TYPE_CHECKING:
     from ibis.expr.types import Table
@@ -437,16 +438,6 @@ def download_avatar_from_url(
         return (avatar_uuid, avatar_path)
 
 
-def _ensure_datetime(timestamp: datetime | str) -> datetime:
-    """Ensure timestamp is a datetime object."""
-    if isinstance(timestamp, datetime):
-        return timestamp
-    if isinstance(timestamp, str):
-        return datetime.fromisoformat(timestamp)
-    msg = f"Unsupported timestamp type: {type(timestamp)}"
-    raise TypeError(msg)
-
-
 @dataclass
 class AvatarContext:
     """Context for avatar processing operations."""
@@ -570,7 +561,7 @@ def process_avatar_commands(
         target = command["target"]
         if cmd_type in ("set", "unset") and target == "avatar":
             if cmd_type == "set":
-                timestamp_dt = _ensure_datetime(timestamp_raw)
+                timestamp_dt = ensure_datetime(timestamp_raw)
                 result = _process_set_avatar_command(
                     author_uuid=author_uuid,
                     timestamp=timestamp_dt,


### PR DESCRIPTION
### Summary
- replace the avatar enrichment timestamp normalization helper with the shared `ensure_datetime`
- remove the duplicate `_ensure_datetime` implementation

### Motivation / Context
- avoid duplicated datetime parsing logic by reusing the centralized utility
- keeps avatar processing aligned with other modules using the shared helper

### Changes
- refactors avatar command processing to import `ensure_datetime` from `utils.time_utils`
- deletes the local `_ensure_datetime` implementation

### Implementation Details
- `process_avatar_commands` now delegates timestamp conversion to the shared helper, ensuring consistent parsing and error handling across the codebase

### Testing
- Not run (not requested)

### Risks & Rollback Plan
- Low risk: behavior should be equivalent; rollback by restoring the previous helper if issues arise

### Breaking Changes / Migrations (if applicable)
- None

### Release Notes (optional)
- Use shared datetime utility for avatar command processing

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d32e8ec38832595b8f5dfb65f6fed)