### PR TITLE
Remove commented ban-pandas hook from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,4 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   # Removed custom hooks - now handled by ruff + scripts/quality.sh
-  # - ban-pandas-imports: Now enforced by ruff's flake8-tidy-imports (TID251)
   # - check-complexity, check-dead-code, check-security: Use scripts/quality.sh instead


### PR DESCRIPTION
## Summary
- remove the outdated ban-pandas-imports comment from the pre-commit configuration since Ruff handles banned APIs

## Testing
- not run (not necessary for config cleanup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d332007a0832591fbe5c1f39040f6)