### PR TITLE
Ensure skip output is set before early exit

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -59,6 +59,7 @@ jobs:
               if (isFork && eventName === 'pull_request') {
                 console.log("ℹ️ Fork detected on automatic trigger. Skipping (No secrets access).");
                 console.log("💡 To review this fork, a maintainer must comment '@gemini' on the PR.");
+                core.setOutput('skip', 'true');
                 return { skip: true };
               } else {
                 core.setFailed("❌ GEMINI_API_KEY is missing in Repo Secrets.");


### PR DESCRIPTION
## Summary
- set the `skip` output to `true` before returning early when secrets are missing so the workflow short-circuits cleanly on forked PRs without secrets

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd0dcc4d08325a8ae6b5cf5cc125b)