### PR TITLE
Fix RAG storage regression

### DIFF
--- a/src/egregora/agents/writer/context_builder.py
+++ b/src/egregora/agents/writer/context_builder.py
@@ -176,6 +176,7 @@ def build_rag_context_for_prompt(
                 query=table_markdown,
                 client=client,
                 rag_dir=store.parquet_path.parent,
+                storage=store.storage,
                 embedding_model=embedding_model,
                 top_k=top_k,
                 retrieval_mode=retrieval_mode,


### PR DESCRIPTION
## Summary
- pass the current storage manager into the async writer RAG helper so the new signature is satisfied when pydantic helpers are enabled
- make `VectorStore` keep track of its storage manager and provide a sensible default DuckDB database when one is not provided so existing call sites keep working

## Testing
- pytest tests/unit/test_rag_document_indexing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd1d968d083258cc012f6b2816543)