### PR TITLE
Harden Repomix context generation

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -128,15 +128,19 @@ jobs:
       - name: 📄 Generate Context (Repomix)
         if: steps.setup.outputs.skip != 'true'
         run: |
-          # Copy trusted ignore file if it exists
+          # Run Repomix from the trusted checkout so PR-provided node_modules cannot
+          # shadow the CLI. Copy our vetted ignore file into the worktree so the
+          # generated context matches local expectations.
           [ -f .repomixignore ] && cp .repomixignore pr-code/.repomixignore
-          
-          cd pr-code
-          # Run repomix ignoring heavy files to save tokens
-          npx -y repomix@latest \
-            --output ../repomix.txt \
+
+          # Always execute the published Repomix package (not anything from pr-code)
+          # and explicitly point it at the untrusted checkout via a path argument so
+          # we never need to cd into pr-code where attacker-controlled scripts might
+          # run with repository secrets in scope.
+          npx --yes --package repomix@1.9.1 repomix ./pr-code \
+            --output repomix.txt \
             --ignore "**/*.lock,**/package-lock.json,**/node_modules/**,**/*.png,**/*.jpg"
-          
+
           echo "✅ Repository context generated."
 
       - name: 📄 Fetch Diff & Chat History


### PR DESCRIPTION
## Summary
- run Repomix from the trusted checkout and pass the pr-code path explicitly instead of cd'ing into the untrusted worktree
- always execute the published repomix@1.9.1 package via npx --package so PRs cannot shadow the CLI
- document the security reasoning in the workflow comments

## Testing
- not run (CI workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd55ee58c83258a95b931cdc49bd1)