### PR TITLE
Document pre-commit hook setup across root docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,13 @@ uv run egregora runs show <run_id>      # Run details
 cd output && uvx --with mkdocs-material --with mkdocs-blogging-plugin mkdocs serve
 ```
 
+## Pre-commit Hooks Are Mandatory
+
+Every contributor must install the repository's pre-commit hooks immediately after cloning so local commits run the same linting,
+formatting, and security checks as CI. Run `python dev_tools/setup_hooks.py` (preferred) or `uv run pre-commit install` before
+opening a pull request, and re-run the command whenever the hook list changes. If the hooks are missing, your commits may fail in
+CI and will be blocked from merging.
+
 **VCR cassettes**: First run needs `GOOGLE_API_KEY`, subsequent runs replay from `tests/cassettes/`.
 
 ## Parallel Subagent Delegation

--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -10,6 +10,9 @@ This PR removes ~1,500 lines of code across 5 major simplifications while mainta
 
 **All 377 unit tests pass** (excluding 3 pre-existing failures unrelated to these changes).
 
+> **Contributor requirement:** After cloning, run `python dev_tools/setup_hooks.py` (or `uv run pre-commit install`) so the
+> repository's pre-commit hooks run on every commit. This keeps local changes aligned with the checks enforced in CI.
+
 ---
 
 ## Changes Overview

--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ Contributions are welcome! We use an **alpha mindset**:
 1. Read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 2. Review [CLAUDE.md](CLAUDE.md) for modern patterns
 3. Check [BREAKING_CHANGES.md](BREAKING_CHANGES.md) for recent changes
-4. Install pre-commit hooks: `python dev_tools/setup_hooks.py`
+4. Install pre-commit hooks **before creating a branch**: run `python dev_tools/setup_hooks.py` (or `uv run pre-commit install`)
+   so the same formatting, linting, and security checks run locally on every commit.
 
 ### Common Tasks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,3 +19,10 @@ Use this section to tell people how to report a vulnerability.
 Tell them where to go, how often they can expect to get an update on a
 reported vulnerability, what to expect if the vulnerability is accepted or
 declined, etc.
+
+## Secure Development Practices
+
+To reduce the risk of regressions that could impact security, all contributors must install the repository's pre-commit hooks
+right after cloning. Run `python dev_tools/setup_hooks.py` (or `uv run pre-commit install`) so linting, formatting, and security
+scans execute locally on every commit—the same checks that run in CI. Contributions submitted without the hooks will be asked to
+install them before review continues.


### PR DESCRIPTION
## Summary
- document that contributors must install the repository's pre-commit hooks in every root-level guide (CLAUDE, README, PR summary, and security policy)
- call out both `python dev_tools/setup_hooks.py` and `uv run pre-commit install` so contributors know either command works
- explain that the hooks keep local commits aligned with CI linting/security checks

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd5c23cf083259894fd151635b76a)