### PR TITLE
Handle provider-qualified Gemini model URIs

### DIFF
--- a/.github/scripts/gemini-pr-review.js
+++ b/.github/scripts/gemini-pr-review.js
@@ -40,7 +40,9 @@ function normalizeModelName(model) {
   const trimmed = (model || fallback).trim();
   const aliasCandidate = MODEL_ALIAS_MAP[trimmed];
   const normalized = aliasCandidate || trimmed;
-  return normalized.startsWith('models/') ? normalized : `models/${normalized}`;
+  const hasProviderNamespace = normalized.includes(':');
+  const needsPrefix = !hasProviderNamespace && !normalized.startsWith('models/');
+  return needsPrefix ? `models/${normalized}` : normalized;
 }
 
 const resolvedModel = normalizeModelName(GEMINI_MODEL);


### PR DESCRIPTION
## Summary
- update `normalizeModelName` so provider-qualified Gemini URIs (e.g. `google-gla:gemini-flash-latest`) are not incorrectly prefixed with `models/`
- keep the previous alias handling and only add the `models/` prefix for bare model IDs

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de6c3a8dc8325b98623b7fb99f06c)