### PR TITLE
Fix URL agent factory return value

### DIFF
--- a/src/egregora/enrichment/agents.py
+++ b/src/egregora/enrichment/agents.py
@@ -250,6 +250,8 @@ def make_url_agent(
             url=ctx.deps.url,
         )
 
+    return agent
+
 
 def make_media_agent(
     model_name: str, prompts_dir: Path | None = None


### PR DESCRIPTION
## Summary
- restore make_url_agent to return the constructed agent so URL enrichment is enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f524b5db48325b2c3de619101d182)