### PR TITLE
Handle PII media links safely

### DIFF
--- a/src/egregora/enrichment/runners.py
+++ b/src/egregora/enrichment/runners.py
@@ -14,7 +14,7 @@ import re
 import tempfile
 import uuid
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -624,6 +624,7 @@ def _process_single_media(
         pii_detected = True
         media_doc.metadata["pii_deleted"] = True
         media_doc.metadata["public_url"] = None
+        media_doc = replace(media_doc, suggested_path=None)
 
     if not markdown_content:
         filename = media_doc.metadata.get("filename") or ref

--- a/src/egregora/ops/media.py
+++ b/src/egregora/ops/media.py
@@ -211,6 +211,9 @@ def _normalize_public_url(value: str | None) -> str | None:
 
 
 def _media_public_url(media_doc: Document) -> str | None:
+    if media_doc.metadata.get("pii_deleted"):
+        return None
+
     url = media_doc.metadata.get("public_url")
     if url:
         return _normalize_public_url(url)


### PR DESCRIPTION
## Summary
- skip deriving media public URLs from suggested paths when PII deletion is flagged
- clear PII-flagged media suggested paths before generating enrichment outputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa964401883258487456bc544be37)