### PR TITLE
Stabilize self-reflection adapter

### DIFF
--- a/src/egregora/agents/shared/rag/indexing.py
+++ b/src/egregora/agents/shared/rag/indexing.py
@@ -255,9 +255,15 @@ def index_documents_for_rag(  # noqa: C901
         docs_table = ibis.memtable(rows)
         doc_count = len(rows)
 
-        docs_table = docs_table[docs_table["source_path"] != ""]
+        docs_table = docs_table.filter(docs_table["source_path"] != "")
 
-        if docs_table.count().execute().iloc[0, 0] == 0:
+        remaining = docs_table.count().execute()
+        if hasattr(remaining, "iloc"):
+            remaining_count = int(remaining.iloc[0, 0])
+        else:
+            remaining_count = int(remaining)
+
+        if remaining_count == 0:
             logger.warning("All document identifiers failed to resolve to paths")
             return 0
 


### PR DESCRIPTION
## Summary
- let the self-reflection adapter recognize a site root even when the  directory is missing if  exists
- inject the current output adapter when parsing so the adapter can reingest from any supported format without hardcoded paths
- guard the self-reflection test helper so it creates needed parent folders before writing temporary markdown samples
- rename the output adapter API from  to  and strengthen the bi-directional contract so we can reuse it for self-reflection, RAG, and future adapters
- require an output adapter (rather than falling back to crawling ) and consume the document inventory it exposes directly, so  builds IR rows from  instances instead of raw files
- teach the RAG indexing pipeline to use the documented  list so it stays compatible with the new contract and log its skip count with the preserved  value
- stop scaffolding the orphaned  template and keep DuckDB under  to avoid unused files and a root-level 
- fix the RAG filter to use Table.filter and handle ibis count returning ints (new ibis warning)

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/frank/workspace/egregora
configfile: pyproject.toml
plugins: asyncio-1.3.0, cov-7.0.0, returns-0.26.0, hypothesis-6.147.0, anyio-4.11.0, logfire-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 2 items

tests/e2e/input_adapters/test_self_reflection_adapter.py .               [ 50%]
tests/e2e/input_adapters/test_iperon_tjro_adapter.py .                   [100%]

============================== 2 passed in 0.89s ===============================
