### PR TITLE
Fix OutputAdapter base imports

### DIFF
--- a/src/egregora/output_adapters/base.py
+++ b/src/egregora/output_adapters/base.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 import ibis
 import ibis.expr.datatypes as dt
 
+from egregora.data_primitives import DocumentMetadata, OutputSink, UrlConvention
 from egregora.data_primitives.document import Document, DocumentType
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- import OutputSink, UrlConvention, and DocumentMetadata in the base adapter module
- resolve NameError raised when importing the OutputAdapter class

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922364c0fd88325a3794ac5cc0a0863)