### PR TITLE
Fix SiteScaffolder import in scaffolding

### DIFF
--- a/src/egregora/init/scaffolding.py
+++ b/src/egregora/init/scaffolding.py
@@ -10,8 +10,8 @@ import logging
 from pathlib import Path
 from typing import cast
 
+from egregora.data_primitives.protocols import SiteScaffolder
 from egregora.output_adapters import create_output_format
-from egregora.output_adapters.base import SiteScaffolder
 from egregora.output_adapters.mkdocs import derive_mkdocs_paths
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- import `SiteScaffolder` from `egregora.data_primitives.protocols` where it is defined
- keep scaffolding helpers working without ImportError

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224723b2a8832589040b74fac15dc5)