### PR TITLE
Review pull request 890

### DIFF
--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -200,6 +200,7 @@ def _create_writer_resources(ctx: PipelineContext) -> WriterResources:
         storage=ctx.storage,  # Added storage for RAG indexing
         embedding_model=ctx.embedding_model,
         retrieval_config=ctx.config.rag,
+        config=ctx.config,
         profiles_dir=ctx.profiles_dir,
         journal_dir=journal_dir,
         prompts_dir=prompts_dir,
@@ -207,6 +208,7 @@ def _create_writer_resources(ctx: PipelineContext) -> WriterResources:
         quota=ctx.quota_tracker,
         usage=ctx.usage_tracker,
         rate_limit=ctx.rate_limit,
+        cache=ctx.cache,
     )
 
 


### PR DESCRIPTION
Critical fixes for PR #890's tiered caching architecture:

## Fixed Issues

1. **NameError in _build_writer_prompt_context()** (writer.py:447-462)
   - Fixed: All `ctx.*` references → `resources.*`
   - Now correctly uses `resources.annotations_store`, `resources.rag_store`, etc.

2. **Incorrect _prepare_deps() implementation** (writer.py:671-684)
   - Changed signature: `ctx: PipelineContext` → `resources: WriterResources`
   - Fixed return: Now properly creates `WriterDeps` with correct fields
   - Removed invalid fields (`ctx`, `prompts_dir`, `quota`, etc.)

3. **Undefined ctx in write_posts_for_window()** (writer.py:842-982)
   - Fixed: All `ctx.*` references → `resources.*`
   - Lines fixed: 861, 868, 906, 911, 980

4. **Missing WriterResources fields**
   - Added: `config: EgregoraConfig` field
   - Added: `cache: Any  # PipelineCache` field
   - Updated: `_create_writer_resources()` to include new fields

5. **Missing imports**
   - Added: `from egregora.agents.shared.annotations import AnnotationStore`
   - Added: `from egregora.data_primitives.protocols import OutputAdapter`
   - Removed: Unused `OutputSink` import

## Impact

All critical bugs preventing runtime execution are now fixed:
- ✓ Module imports successfully
- ✓ No undefined variable references
- ✓ Proper dataclass structure
- ✓ Correct function signatures

## Testing

- ✓ Python imports verified
- ✓ Ruff linting passes (F401, F821)
- ✓ Type consistency validated

Addresses blocking issues from code review of PR #890.