### PR TITLE
Fix ibis null checks in writer and RAG indexing

### DIFF
--- a/src/egregora/agents/shared/rag/indexing.py
+++ b/src/egregora/agents/shared/rag/indexing.py
@@ -315,7 +315,9 @@ def _identify_documents_to_index(docs_table: ibis.Table, store: VectorStore) -> 
 
     joined = docs_table.left_join(indexed_renamed, docs_table.source_path == indexed_renamed.indexed_path)
 
-    return joined.filter((joined.indexed_mtime.isnull()) | (joined.mtime_ns > joined.indexed_mtime)).select(
+    needs_index = (joined.indexed_mtime.isnull()) | (joined.mtime_ns > joined.indexed_mtime)
+
+    return joined.filter(needs_index).select(
         storage_identifier=joined.storage_identifier,
         source_path=joined.source_path,
         mtime_ns=joined.mtime_ns,

--- a/src/egregora/agents/writer.py
+++ b/src/egregora/agents/writer.py
@@ -1062,7 +1062,7 @@ def get_top_authors(table: Table, limit: int = 20) -> list[str]:
     """Get top N active authors by message count."""
     author_counts = (
         table.filter(~table.author_uuid.cast("string").isin(["system", "egregora"]))
-        .filter(table.author_uuid.notna())
+        .filter(table.author_uuid.notnull())
         .filter(table.author_uuid.cast("string") != "")
         .group_by("author_uuid")
         .aggregate(count=ibis._.count())


### PR DESCRIPTION
## Summary
- use ibis `notnull()` for author filtering in writer to avoid missing accessor errors
- refactor incremental RAG filter to explicitly use `isnull()` while preparing documents to index

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b1ca8fe883259cc43144cb7a7520)