### PR TITLE
Remove runs table DDL duplicate

### DIFF
--- a/docs/DUPLICATION_REDUCTION_PLAN.md
+++ b/docs/DUPLICATION_REDUCTION_PLAN.md
@@ -20,26 +20,17 @@ This document outlines strategies to reduce duplication across the Egregora code
 
 ### Current State
 
-The `runs` table schema exists in three places:
-- `schema/runs_v1.sql` - SQL DDL with documentation
-- `src/egregora/database/ir_schema.py:RUNS_TABLE_DDL` - Python string copy
-- `src/egregora/database/ir_schema.py:RUNS_TABLE_SCHEMA` - Ibis schema
+The `runs` table schema is defined once in Python:
+- `src/egregora/database/ir_schema.py:RUNS_TABLE_SCHEMA` - Ibis schema used for creation
 
-### Problem
+### Solution: Single Python Source
 
-Manual synchronization is error-prone. The SQL file even admits: "Single source of truth: src/egregora/database/ir_schema.py:RUNS_TABLE_DDL"
+**Rationale**: Generating the table definition from `RUNS_TABLE_SCHEMA` via `create_table_if_not_exists` removes manual SQL copies and keeps creation logic in one place.
 
-### Solution: Delete `schema/runs_v1.sql`
-
-**Rationale**: Since Python is already the canonical source, the SQL file is pure documentation that can drift. The `RUNS_TABLE_DDL` string in Python serves the same purpose.
-
-**Action Items**:
+**Action Items (complete):**
 1. Delete `schema/runs_v1.sql`
 2. Move important documentation comments into the Python module docstring
-3. Keep `RUNS_TABLE_DDL` as the executable source
-4. Keep `RUNS_TABLE_SCHEMA` for Ibis operations
-
-**Alternative Considered**: Generate SQL from Ibis schema programmatically. However, this adds complexity and the current `_ibis_to_duckdb_type()` function already handles this for table creation.
+3. Use `RUNS_TABLE_SCHEMA` as the executable source for table creation
 
 ---
 

--- a/docs/SIMPLIFICATION_PLAN.md
+++ b/docs/SIMPLIFICATION_PLAN.md
@@ -185,7 +185,7 @@ For an alpha, local-first tool with a single developer (or very small team):
 
 **Changes Made**:
 1. ✅ Removed `src/egregora/utils/fingerprinting.py` (32 LOC)
-2. ✅ Removed `input_fingerprint` column from `RUNS_TABLE_SCHEMA` and `RUNS_TABLE_DDL`
+2. ✅ Removed `input_fingerprint` column from `RUNS_TABLE_SCHEMA`
 3. ✅ Removed `fingerprint_table()` and `fingerprint_window()` from `tracking.py` (97 LOC)
 4. ✅ Removed `input_fingerprint` parameter from `record_run()` function
 5. ✅ Removed unused imports (`hashlib`, `pyarrow`, `ensure_deterministic_order`)

--- a/schema/README.md
+++ b/schema/README.md
@@ -46,11 +46,8 @@ To modify the IR schema:
 
 The IR schema was previously maintained in multiple formats (SQL, JSON, Python) which created unnecessary synchronization burden. As of 2025-11-17, all lockfiles have been removed in favor of the Python-only schema. This simplification embraces the alpha mindset: reduce complexity, one canonical source.
 
-Similarly, the `runs` table schema (previously in `runs_v1.sql`) was consolidated into:
-```
-src/egregora/database/ir_schema.py:RUNS_TABLE_SCHEMA  # Ibis schema
-src/egregora/database/ir_schema.py:RUNS_TABLE_DDL     # SQL DDL string
-```
+Similarly, the `runs` table schema (previously in `runs_v1.sql`) was consolidated into
+`src/egregora/database/ir_schema.py:RUNS_TABLE_SCHEMA` as the single source of truth.
 
 This directory now only contains this README as documentation.
 

--- a/src/egregora/database/ir_schema.py
+++ b/src/egregora/database/ir_schema.py
@@ -259,7 +259,7 @@ ELO_HISTORY_SCHEMA = ibis.schema(
 #   Build lineage: Use recursive CTE on parent_run_id
 #
 # Note: This is the SINGLE SOURCE OF TRUTH for the runs table schema.
-# The SQL DDL below (RUNS_TABLE_DDL) is used for table creation.
+# Tables are created from this schema via create_table_if_not_exists.
 # ----------------------------------------------------------------------------
 
 RUNS_TABLE_SCHEMA = ibis.schema(
@@ -813,7 +813,6 @@ __all__ = [
     "RAG_INDEX_META_SCHEMA",
     "RAG_SEARCH_RESULT_SCHEMA",
     # Runs schema
-    "RUNS_TABLE_DDL",
     "RUNS_TABLE_SCHEMA",
     "WHATSAPP_CONVERSATION_SCHEMA",
     "WHATSAPP_SCHEMA",


### PR DESCRIPTION
### Summary
- Treat `RUNS_TABLE_SCHEMA` as the sole definition of the runs table and reference the existing `create_table_if_not_exists` workflow.
- Drop the unused `RUNS_TABLE_DDL` export and related commentary.
- Update documentation to reflect the single-source schema.

### Motivation / Context
- Reduce duplication between manual SQL DDL and the Ibis schema so the runs table has one canonical definition used for creation.

### Changes
- **Database:** Clarified runs schema comments to point at `create_table_if_not_exists` and removed the `RUNS_TABLE_DDL` export.
- **Docs:** Revised duplication and simplification plans plus schema README to note the Ibis schema as the only source of truth for the runs table.

### Implementation Details
- Runs table creation continues to rely on `create_table_if_not_exists`, removing references to a separate DDL string for consistency with other tables.
- Documentation now describes the Ibis schema as the executable source and marks prior duplication cleanup as complete.

### Testing
- Not run (not requested).

### Risks & Rollback Plan
- Low risk: removing an unused export and aligning docs. Roll back by restoring the previous `RUNS_TABLE_DDL` references if needed.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- Runs table now created solely from `RUNS_TABLE_SCHEMA`; manual SQL DDL removed.

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250a0c08cc83258c04a538b106b0b1)