### PR TITLE
Fix vector extension init in from_connection

### DIFF
--- a/src/egregora/database/duckdb_manager.py
+++ b/src/egregora/database/duckdb_manager.py
@@ -147,7 +147,7 @@ class DuckDBStorageManager:
         instance.checkpoint_dir = checkpoint_dir or Path(".egregora/data")
         instance._conn = conn
         instance._vss_function = None
-        instance._init_vector_extensions(instance)  # Initialize VSS on instance
+        instance._init_vector_extensions()  # Initialize VSS on instance
         instance.ibis_conn = ibis.duckdb.from_connection(conn)
         instance._table_info_cache = {}
         logger.debug("DuckDBStorageManager created from existing connection")


### PR DESCRIPTION
## Summary
- fix DuckDBStorageManager.from_connection to initialize vector extensions without double-passing self
- prevent TypeError when creating storage manager from an existing DuckDB connection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926061a5d888325bbd1d6681c635a0d)