### PR TITLE
Handle DuckDB failures during writer RAG indexing

### DIFF
--- a/src/egregora/agents/writer.py
+++ b/src/egregora/agents/writer.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import duckdb
 import ibis
 from ibis.expr.types import Table
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -950,7 +951,7 @@ def _index_new_content_in_rag(
         )
         if indexed_count > 0:
             logger.info("Indexed %d new/changed documents in RAG after writing", indexed_count)
-    except (ibis.common.exceptions.IbisError, OSError) as e:
+    except (duckdb.Error, ibis.common.exceptions.IbisError, OSError) as e:
         logger.warning("Failed to update RAG index after writing: %s", e)
 
 


### PR DESCRIPTION
## Summary
- import duckdb to capture database-specific errors raised during writer RAG indexing
- broaden exception handling in `_index_new_content_in_rag` to log DuckDB failures instead of crashing the pipeline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260a6e33e883258be2e31f9d93f22a)