### PR TITLE
Fix duplicate parameters in index_documents_for_rag signature

### DIFF
--- a/src/egregora/agents/shared/rag/indexing.py
+++ b/src/egregora/agents/shared/rag/indexing.py
@@ -379,9 +379,6 @@ def _index_new_documents(to_index, store: VectorStore, *, embedding_model: str) 
 def index_documents_for_rag(
     output_format: OutputAdapter,
     store: VectorStore,
-    output_format: OutputSink,
-    rag_dir: Path,
-    storage: DuckDBStorageManager,
     *,
     embedding_model: str,
 ) -> int:


### PR DESCRIPTION
## Summary
- correct the `index_documents_for_rag` signature by removing duplicate and obsolete parameters
- ensure RAG indexing module imports without syntax errors

## Testing
- python -m compileall src/egregora/agents/shared/rag/indexing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261dd23de48325ae073eb9e7d3d06d)