### PR TITLE
Introduce builder for applying CLI config overrides

### DIFF
--- a/src/egregora/config/overrides.py
+++ b/src/egregora/config/overrides.py
@@ -16,38 +16,30 @@ class ConfigOverrideBuilder:
         self._config = base_config.model_copy(deep=True)
 
     def _apply_updates(self, section_name: str, overrides: dict[str, Any], *, skip_none: bool = True) -> None:
-        updates = {
-            key: value for key, value in overrides.items() if not (skip_none and value is None)
-        }
+        updates = {key: value for key, value in overrides.items() if not (skip_none and value is None)}
         if updates:
             section = getattr(self._config, section_name)
             setattr(self._config, section_name, section.model_copy(update=updates))
 
-    def with_pipeline(self, **overrides: Any) -> "ConfigOverrideBuilder":
+    def with_pipeline(self, **overrides: Any) -> ConfigOverrideBuilder:
         """Apply pipeline-related overrides (e.g., step size, overlap)."""
-
         self._apply_updates("pipeline", overrides)
         return self
 
-    def with_enrichment(self, **overrides: Any) -> "ConfigOverrideBuilder":
+    def with_enrichment(self, **overrides: Any) -> ConfigOverrideBuilder:
         """Apply enrichment-related overrides."""
-
         # Allow explicit False values to be set, but skip missing (None) values
         self._apply_updates("enrichment", overrides)
         return self
 
-    def with_rag(self, **overrides: Any) -> "ConfigOverrideBuilder":
+    def with_rag(self, **overrides: Any) -> ConfigOverrideBuilder:
         """Apply RAG-related overrides (retrieval mode, nprobe, overfetch)."""
-
         self._apply_updates("rag", overrides)
         return self
 
-    def with_models(self, *, model: str | None = None, **overrides: Any) -> "ConfigOverrideBuilder":
+    def with_models(self, *, model: str | None = None, **overrides: Any) -> ConfigOverrideBuilder:
         """Apply model overrides, including broadcasting a single model to all agents."""
-
-        updates: dict[str, Any] = {
-            key: value for key, value in overrides.items() if value is not None
-        }
+        updates: dict[str, Any] = {key: value for key, value in overrides.items() if value is not None}
 
         if model:
             updates.update(
@@ -66,5 +58,4 @@ class ConfigOverrideBuilder:
 
     def build(self) -> EgregoraConfig:
         """Return the updated configuration instance."""
-
         return self._config

--- a/src/egregora/config/settings.py
+++ b/src/egregora/config/settings.py
@@ -500,7 +500,7 @@ class EgregoraConfig(BaseModel):
     )
 
     @classmethod
-    def from_cli_overrides(cls, base_config: EgregoraConfig, **cli_args: Any) -> EgregoraConfig:  # noqa: C901, PLR0912
+    def from_cli_overrides(cls, base_config: EgregoraConfig, **cli_args: Any) -> EgregoraConfig:
         """Create a new config instance with CLI overrides applied.
 
         Handles nested updates for pipeline, enrichment, rag, etc.
@@ -521,9 +521,7 @@ class EgregoraConfig(BaseModel):
         )
 
         builder.with_enrichment(
-            enabled=cli_args.get("enable_enrichment")
-            if "enable_enrichment" in cli_args
-            else None
+            enabled=cli_args.get("enable_enrichment") if "enable_enrichment" in cli_args else None
         )
 
         builder.with_rag(


### PR DESCRIPTION
## Summary
- add a ConfigOverrideBuilder to centralize validated updates for configuration overrides
- refactor `from_cli_overrides` to use the builder for clearer, chainable CLI handling

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926519740748325a8b9482997cbaad9)