### PR TITLE
Refactor WhatsApp adapter into package modules

### DIFF
--- a/src/egregora/agents/avatar.py
+++ b/src/egregora/agents/avatar.py
@@ -27,7 +27,7 @@ from egregora.agents.enricher import (
     ensure_datetime,
     load_file_as_binary_content,
 )
-from egregora.input_adapters.whatsapp import extract_commands
+from egregora.input_adapters.whatsapp.commands import extract_commands
 from egregora.knowledge.profiles import remove_profile_avatar, update_profile_avatar
 from egregora.ops.media import detect_media_type, extract_urls
 from egregora.utils.cache import EnrichmentCache, make_enrichment_cache_key

--- a/src/egregora/input_adapters/__init__.py
+++ b/src/egregora/input_adapters/__init__.py
@@ -24,7 +24,7 @@ from egregora.input_adapters.base import InputAdapter
 from egregora.input_adapters.iperon_tjro import IperonTJROAdapter
 from egregora.input_adapters.registry import InputAdapterRegistry, get_global_registry
 from egregora.input_adapters.self_reflection import SelfInputAdapter
-from egregora.input_adapters.whatsapp import WhatsAppAdapter
+from egregora.input_adapters.whatsapp.adapter import WhatsAppAdapter
 
 # Legacy registry (deprecated in favor of InputAdapterRegistry)
 ADAPTER_REGISTRY: dict[str, type] = {

--- a/src/egregora/input_adapters/whatsapp/__init__.py
+++ b/src/egregora/input_adapters/whatsapp/__init__.py
@@ -1,0 +1,20 @@
+"""WhatsApp source adapter package."""
+
+from .adapter import DeliverMediaKwargs, WhatsAppAdapter
+from .commands import EGREGORA_COMMAND_PATTERN, extract_commands, filter_egregora_messages
+from .parsing import WhatsAppExport, parse_source
+from .utils import build_message_attrs, convert_media_to_markdown, discover_chat_file, normalize_media_markdown
+
+__all__ = [
+    "DeliverMediaKwargs",
+    "WhatsAppAdapter",
+    "EGREGORA_COMMAND_PATTERN",
+    "extract_commands",
+    "filter_egregora_messages",
+    "WhatsAppExport",
+    "parse_source",
+    "build_message_attrs",
+    "convert_media_to_markdown",
+    "discover_chat_file",
+    "normalize_media_markdown",
+]

--- a/src/egregora/input_adapters/whatsapp/adapter.py
+++ b/src/egregora/input_adapters/whatsapp/adapter.py
@@ -1,0 +1,190 @@
+"""Adapter implementation for WhatsApp exports."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, TypedDict, Unpack
+
+import ibis
+
+from egregora.data_primitives.document import Document, DocumentType
+from egregora.input_adapters.base import AdapterMeta, InputAdapter
+from egregora.utils.paths import slugify
+
+from .commands import EGREGORA_COMMAND_PATTERN
+from .parsing import WhatsAppExport, parse_source
+from .utils import convert_media_to_markdown, discover_chat_file
+
+logger = logging.getLogger(__name__)
+
+
+class _EmptyKwargs(TypedDict):
+    """Empty TypedDict for unused kwargs in adapter methods."""
+
+
+class DeliverMediaKwargs(TypedDict, total=False):
+    """Kwargs for WhatsAppAdapter.deliver_media method."""
+
+    zip_path: Path
+
+
+class WhatsAppAdapter(InputAdapter):
+    """Source adapter for WhatsApp ZIP exports."""
+
+    def __init__(self, *, author_namespace: uuid.UUID | None = None) -> None:
+        self._author_namespace = author_namespace
+
+    @property
+    def source_name(self) -> str:
+        return "WhatsApp"
+
+    @property
+    def source_identifier(self) -> str:
+        return "whatsapp"
+
+    @property
+    def content_summary(self) -> str:
+        return (
+            "This adapter parses a WhatsApp export to extract chat messages. Supported format: "
+            "WhatsApp ZIP exports (" "Chat export" in mobile clients)"
+        )
+
+    @property
+    def description(self) -> str:
+        return "Parses WhatsApp chat exports and attaches optional media references."
+
+    @property
+    def meta(self) -> AdapterMeta:
+        return AdapterMeta(
+            name="WhatsApp",
+            version="1.0.0",
+            source="whatsapp",
+            doc_url="https://github.com/franklinbaldo/egregora#whatsapp-exports",
+            ir_version="v1",
+        )
+
+    def parse(self, input_path: Path, *, timezone: str | None = None, **_kwargs: _EmptyKwargs) -> ibis.Table:
+        if not input_path.exists():
+            msg = f"Input path does not exist: {input_path}"
+            raise FileNotFoundError(msg)
+        if not input_path.is_file() or not str(input_path).endswith(".zip"):
+            msg = f"Expected a ZIP file, got: {input_path}"
+            raise ValueError(msg)
+        group_name, chat_file = discover_chat_file(input_path)
+        export = WhatsAppExport(
+            zip_path=input_path,
+            group_name=group_name,
+            group_slug=group_name.lower().replace(" ", "-"),
+            export_date=datetime.now(tz=UTC).date(),
+            chat_file=chat_file,
+            media_files=[],
+        )
+        messages_table = parse_source(
+            export,
+            timezone=timezone,
+            expose_raw_author=True,
+        )
+
+        @ibis.udf.scalar.python
+        def convert_media(message: str | None) -> str | None:
+            return convert_media_to_markdown(message)
+
+        messages_table = messages_table.mutate(text=convert_media(messages_table.text))
+
+        logger.debug("Parsed WhatsApp export with %s messages", messages_table.count().execute())
+        return messages_table
+
+    def deliver_media(self, media_reference: str, **kwargs: Unpack[DeliverMediaKwargs]) -> Document | None:
+        """Deliver media file from WhatsApp ZIP as a Document."""
+        if not self._validate_media_reference(media_reference):
+            return None
+        zip_path = self._get_validated_zip_path(kwargs)
+        if not zip_path:
+            return None
+
+        return self._extract_media_from_zip(zip_path, media_reference)
+
+    def _validate_media_reference(self, media_reference: str) -> bool:
+        if ".." in media_reference or "/" in media_reference or "\\" in media_reference:
+            logger.warning("Suspicious media reference (path traversal attempt): %s", media_reference)
+            return False
+        return True
+
+    def _get_validated_zip_path(self, kwargs: DeliverMediaKwargs) -> Path | None:
+        zip_path = kwargs.get("zip_path")
+        if not zip_path:
+            logger.warning("deliver_media() called without zip_path kwarg")
+            return None
+        if not isinstance(zip_path, Path):
+            zip_path = Path(zip_path)
+        if not zip_path.exists():
+            logger.warning("ZIP file does not exist: %s", zip_path)
+            return None
+        return zip_path
+
+    def _extract_media_from_zip(self, zip_path: Path, media_reference: str) -> Document | None:
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                found_path = self._find_media_in_zip(zf, media_reference)
+                if not found_path:
+                    logger.debug("Media file not found in ZIP: %s", media_reference)
+                    return None
+
+                file_content = zf.read(found_path)
+                logger.debug("Delivered media: %s", media_reference)
+
+                media_type = self._detect_media_type(Path(media_reference))
+                media_slug = slugify(Path(media_reference).stem) if media_reference else None
+
+                return Document(
+                    content=file_content,
+                    type=DocumentType.MEDIA,
+                    metadata={
+                        "original_filename": media_reference,
+                        "media_type": media_type,
+                        "slug": media_slug or None,
+                        "nav_exclude": True,
+                        "hide": ["navigation"],
+                    },
+                )
+        except zipfile.BadZipFile:
+            logger.exception("Invalid ZIP file: %s", zip_path)
+            return None
+        except (KeyError, OSError, PermissionError):
+            logger.exception("Failed to extract %s from %s", media_reference, zip_path)
+            return None
+
+    def _find_media_in_zip(self, zf: zipfile.ZipFile, media_reference: str) -> str | None:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            if Path(info.filename).name.lower() == media_reference.lower():
+                return info.filename
+        return None
+
+    def _detect_media_type(self, media_path: Path) -> str | None:
+        from egregora.ops.media import detect_media_type
+
+        media_type = detect_media_type(media_path)
+        return media_type
+
+    def get_metadata(self, input_path: Path, **_kwargs: _EmptyKwargs) -> dict[str, Any]:
+        if not input_path.exists():
+            msg = f"Input path does not exist: {input_path}"
+            raise FileNotFoundError(msg)
+        group_name, chat_file = discover_chat_file(input_path)
+        group_slug = group_name.lower().replace(" ", "-")
+        return {
+            "group_name": group_name,
+            "group_slug": group_slug,
+            "chat_file": chat_file,
+            "export_date": datetime.now(tz=UTC).date().isoformat(),
+        }
+
+    def is_command(self, message: str) -> bool:
+        """Identify if a message is an egregora control command."""
+        return EGREGORA_COMMAND_PATTERN.match(message.strip()) is not None

--- a/src/egregora/input_adapters/whatsapp/commands.py
+++ b/src/egregora/input_adapters/whatsapp/commands.py
@@ -1,0 +1,183 @@
+"""Command extraction and filtering for WhatsApp messages."""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from typing import TYPE_CHECKING, Any
+
+import ibis
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers
+    from ibis.expr.types import Table
+
+# Command parsing constants
+SET_COMMAND_PARTS = 2
+EGREGORA_COMMAND_PATTERN = re.compile("^/egregora\\s+(\\w+)\\s+(.+)$", re.IGNORECASE)
+
+# Regex patterns for command extraction
+_COMMAND_ACTION_PATTERN = r"^/egregora\s+([^\s]+)"
+_COMMAND_ARGS_PATTERN = r"^/egregora\s+[^\s]+\s*(.*)$"
+_FIRST_ARG_PATTERN = r"^([^\s]+)"
+_REMAINING_ARGS_PATTERN = r"^[^\s]+\s*(.*)$"
+
+
+def _parse_set_command(args: str) -> dict | None:
+    parts = args.split(maxsplit=1)
+    if len(parts) == SET_COMMAND_PARTS:
+        target = parts[0].lower()
+        value = parts[1].strip("\"'")
+        return {"command": "set", "target": target, "value": value}
+    return None
+
+
+def _parse_remove_command(args: str) -> dict:
+    return {"command": "remove", "target": args.lower(), "value": None}
+
+
+COMMAND_REGISTRY = {"set": _parse_set_command, "remove": _parse_remove_command}
+
+
+def _is_nan(value: Any) -> bool:
+    return isinstance(value, float) and math.isnan(value)
+
+
+SMART_QUOTES_TRANSLATION = str.maketrans(
+    {
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2018": "'",
+        "\u2019": "'",
+    }
+)
+
+logger = logging.getLogger(__name__)
+
+
+@ibis.udf.scalar.python
+def normalize_smart_quotes(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.translate(SMART_QUOTES_TRANSLATION)
+
+
+@ibis.udf.scalar.python
+def strip_wrapping_quotes(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.strip("\"'")
+
+
+@ibis.udf.scalar.python
+def _normalize_whitespace(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def extract_commands(messages: "Table") -> list[dict]:
+    """Extract egregora commands from parsed Table."""
+    normalized = messages.mutate(normalized_message=normalize_smart_quotes(messages.text))
+    filtered = normalized.filter(normalized.normalized_message.lower().startswith("/egregora"))
+    trimmed = filtered.mutate(trimmed_message=_normalize_whitespace(filtered.normalized_message))
+
+    parsed = trimmed.mutate(
+        action=trimmed.trimmed_message.re_extract(_COMMAND_ACTION_PATTERN, 1).lower(),
+        args_raw=trimmed.trimmed_message.re_extract(_COMMAND_ARGS_PATTERN, 1),
+    )
+
+    enriched = parsed.mutate(
+        args_trimmed=ibis.coalesce(parsed.args_raw, ibis.literal("")).strip(),
+    )
+
+    enriched = enriched.mutate(
+        target_candidate=enriched.args_trimmed.re_extract(_FIRST_ARG_PATTERN, 1),
+        value_candidate=enriched.args_trimmed.re_extract(_REMAINING_ARGS_PATTERN, 1),
+    )
+
+    enriched = enriched.mutate(
+        set_has_value=ibis.coalesce(
+            enriched.args_trimmed.length()
+            > ibis.coalesce(enriched.target_candidate.length(), ibis.literal(0)),
+            ibis.literal(value=False),
+        ),
+    )
+
+    command_cases = enriched.mutate(
+        command_name=(
+            ibis.cases(
+                ((enriched.action == "set") & enriched.set_has_value, ibis.literal("set")),
+                (enriched.action.isin(["remove", "unset", "opt-out", "opt-in"]), enriched.action),
+                else_=ibis.null(),
+            )
+        ),
+    )
+
+    command_cases = command_cases.mutate(
+        command_target=ibis.cases(
+            (command_cases.command_name == "set", command_cases.target_candidate.lower()),
+            (command_cases.command_name == "remove", command_cases.args_trimmed.lower()),
+            (command_cases.command_name == "unset", command_cases.args_trimmed.lower()),
+            else_=ibis.null(),
+        ),
+        command_value=ibis.cases(
+            (command_cases.command_name == "set", strip_wrapping_quotes(command_cases.value_candidate)),
+            else_=ibis.null(),
+        ),
+    )
+
+    commands_table = command_cases.filter(command_cases.command_name.notnull()).select(
+        command_cases.author_uuid,
+        command_cases.ts,
+        command_cases.text,
+        command_cases.command_name,
+        command_cases.command_target,
+        command_cases.command_value,
+    )
+
+    result_df = commands_table.execute()
+    if result_df.empty:
+        return []
+
+    commands: list[dict] = []
+    for row in result_df.to_dict(orient="records"):
+        command_payload = {"command": row["command_name"]}
+
+        target = row.get("command_target")
+        if target is not None and not _is_nan(target):
+            command_payload["target"] = target
+
+        value = row.get("command_value")
+        if value is not None and not _is_nan(value):
+            command_payload["value"] = value
+
+        commands.append(
+            {
+                "author": row["author_uuid"],
+                "timestamp": row["ts"],
+                "command": command_payload,
+                "message": row["text"],
+            }
+        )
+
+    if commands:
+        logger.info("Found %s egregora commands", len(commands))
+    return commands
+
+
+def filter_egregora_messages(messages: "Table") -> tuple["Table", int]:
+    """Remove all messages starting with /egregora from Table."""
+    mask = messages.text.lower().startswith("/egregora")
+    counts = messages.aggregate(
+        original_count=messages.count(),
+        removed_count=mask.sum(),
+    ).execute()
+    original_count = int(counts["original_count"][0] or 0)
+    if original_count == 0:
+        return (messages, 0)
+    removed_count = int(counts["removed_count"][0] or 0)
+    filtered_messages = messages.filter(~mask)
+    if removed_count > 0:
+        logger.info("Removed %s /egregora messages from table", removed_count)
+    return (filtered_messages, removed_count)

--- a/src/egregora/input_adapters/whatsapp/parsing.py
+++ b/src/egregora/input_adapters/whatsapp/parsing.py
@@ -1,0 +1,331 @@
+"""Parsing and normalization logic for WhatsApp exports."""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import unicodedata
+import zipfile
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
+
+import ibis
+import ibis.expr.datatypes as dt
+from dateutil import parser as date_parser
+from pydantic import BaseModel
+
+from egregora.database.ir_schema import IR_MESSAGE_SCHEMA
+from egregora.privacy.anonymizer import anonymize_table
+from egregora.privacy.uuid_namespaces import deterministic_author_uuid
+from egregora.utils.zip import ZipValidationError, ensure_safe_member_size, validate_zip_contents
+
+from .utils import build_message_attrs
+
+if TYPE_CHECKING:
+    from ibis.expr.types import Table
+
+logger = logging.getLogger(__name__)
+
+
+class WhatsAppExport(BaseModel):
+    """Metadata for a WhatsApp ZIP export."""
+
+    zip_path: Path
+    group_name: str
+    group_slug: str
+    export_date: date
+    chat_file: str
+    media_files: list[str]
+
+
+# WhatsApp message line pattern
+WHATSAPP_LINE_PATTERN = re.compile(
+    r"^(\d{1,2}[/\.\-]\d{1,2}[/\.\-]\d{2,4})(?:,\s*|\s+)(\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?)\s*[—\-]\s*([^:]+):\s*(.*)$"
+)
+
+# Text normalization
+_INVISIBLE_MARKS = re.compile(r"[\u200e\u200f\u202a-\u202e]")
+
+# Time parsing pattern
+_AM_PM_PATTERN = re.compile(r"([AaPp][Mm])$")
+
+
+# Define parsing strategies in order of preference
+_DATE_PARSING_STRATEGIES = [
+    lambda x: date_parser.isoparse(x),
+    lambda x: date_parser.parse(x, dayfirst=True),
+    lambda x: date_parser.parse(x, dayfirst=False),
+]
+
+
+def _normalize_text(value: str) -> str:
+    """Normalize unicode text."""
+    normalized = unicodedata.normalize("NFKC", value)
+    normalized = normalized.replace("\u202f", " ")
+    return _INVISIBLE_MARKS.sub("", normalized)
+
+
+def _parse_message_date(token: str) -> date | None:
+    """Parse date token into a date object using multiple parsing strategies."""
+    normalized = token.strip()
+    if not normalized:
+        return None
+
+    for strategy in _DATE_PARSING_STRATEGIES:
+        try:
+            parsed = strategy(normalized)
+            parsed = parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+            return parsed.date()
+        except (TypeError, ValueError, OverflowError):
+            continue
+
+    return None
+
+
+def _parse_message_time(time_token: str) -> datetime.time | None:
+    """Parse time token into a time object (naive, for later localization)."""
+    time_token = time_token.strip()
+
+    am_pm_match = _AM_PM_PATTERN.search(time_token)
+    if am_pm_match:
+        am_pm = am_pm_match.group(1).upper()
+        time_str = time_token[: am_pm_match.start()].strip()
+        try:
+            return datetime.strptime(f"{time_str} {am_pm}", "%I:%M %p").time()
+        except ValueError:
+            return None
+
+    try:
+        return datetime.strptime(time_token, "%H:%M").time()
+    except ValueError:
+        return None
+
+
+def _resolve_timezone(timezone: str | ZoneInfo | None) -> ZoneInfo:
+    """Resolve timezone string or object to ZoneInfo."""
+    if timezone is None:
+        return UTC
+    if isinstance(timezone, ZoneInfo):
+        return timezone
+    return ZoneInfo(timezone)
+
+
+@dataclass
+class MessageBuilder:
+    """Encapsulates message construction state, hiding internal tracking columns."""
+
+    tenant_id: str
+    source_identifier: str
+    current_date: date
+    timezone: ZoneInfo
+    message_count: int = 0
+    _current_entry: dict[str, Any] | None = None
+    _rows: list[dict[str, Any]] = field(default_factory=list)
+
+    def start_new_message(self, timestamp: datetime, author_raw: str, initial_text: str) -> None:
+        """Finalize pending message and start a new one."""
+        self.flush()
+        self.message_count += 1
+        self._current_entry = {
+            "timestamp": timestamp,
+            "date": self.current_date,
+            "author_raw": author_raw.strip(),
+            "_original_lines": [f"{timestamp} - {author_raw}: {initial_text}"],
+            "_continuation_lines": [initial_text],
+            "_import_order": self.message_count,
+        }
+
+    def append_line(self, line: str, text_part: str) -> None:
+        """Append a line to the current message."""
+        if self._current_entry:
+            self._current_entry["_original_lines"].append(line)
+            self._current_entry["_continuation_lines"].append(text_part)
+
+    def flush(self) -> None:
+        """Finalize and store the current message."""
+        if self._current_entry:
+            finalized = self._finalize_message(self._current_entry)
+            if finalized["text"]:
+                self._rows.append(finalized)
+            self._current_entry = None
+
+    def _finalize_message(self, msg: dict) -> dict:
+        """Transform internal builder state to public schema dict."""
+        message_text = "\n".join(msg["_continuation_lines"]).strip()
+        original_text = "\n".join(msg["_original_lines"]).strip()
+
+        author_raw = msg["author_raw"]
+        author_uuid = deterministic_author_uuid(self.tenant_id, self.source_identifier, author_raw)
+
+        return {
+            "ts": msg["timestamp"],
+            "date": msg["date"],
+            "message_date": msg["date"].isoformat(),
+            "author": author_raw,
+            "author_raw": author_raw,
+            "author_uuid": str(author_uuid),
+            "_author_uuid_hex": author_uuid.hex,
+            "text": message_text,
+            "original_line": original_text or None,
+            "tagged_line": None,
+            "_import_order": msg.get("_import_order", 0),
+        }
+
+    def get_rows(self) -> list[dict[str, Any]]:
+        """Return the list of built message rows."""
+        return self._rows
+
+
+class ZipMessageSource:
+    """Iterates over lines from a WhatsApp chat export inside a ZIP file."""
+
+    def __init__(self, export: WhatsAppExport) -> None:
+        self.export = export
+
+    def lines(self) -> Iterator[str]:
+        """Yield normalized lines from the source file."""
+        with zipfile.ZipFile(self.export.zip_path) as zf:
+            validate_zip_contents(zf)
+            ensure_safe_member_size(zf, self.export.chat_file)
+            try:
+                with zf.open(self.export.chat_file) as raw:
+                    text_stream = io.TextIOWrapper(raw, encoding="utf-8", errors="strict")
+                    for line in text_stream:
+                        yield _normalize_text(line.rstrip("\n"))
+            except UnicodeDecodeError as exc:
+                msg = f"Failed to decode chat file '{self.export.chat_file}': {exc}"
+                raise ZipValidationError(msg) from exc
+
+
+def _parse_whatsapp_lines(
+    source: ZipMessageSource,
+    export: WhatsAppExport,
+    timezone: str | ZoneInfo | None,
+) -> list[dict[str, Any]]:
+    """Pure Python parser for WhatsApp logs."""
+    tz = _resolve_timezone(timezone)
+    builder = MessageBuilder(
+        tenant_id=str(export.group_slug),
+        source_identifier="whatsapp",
+        current_date=export.export_date,
+        timezone=tz,
+    )
+
+    for line in source.lines():
+        match = WHATSAPP_LINE_PATTERN.match(line)
+
+        if match:
+            date_str, time_str, author_raw, message_part = match.groups()
+
+            msg_date = _parse_message_date(date_str)
+            if msg_date:
+                builder.current_date = msg_date
+
+            msg_time = _parse_message_time(time_str)
+
+            if not msg_time:
+                builder.flush()
+                continue
+
+            timestamp = datetime.combine(builder.current_date, msg_time, tzinfo=tz).astimezone(UTC)
+            builder.start_new_message(timestamp, author_raw, message_part)
+
+        else:
+            builder.append_line(line, line)
+
+    builder.flush()
+    return builder.get_rows()
+
+
+def _add_message_ids(messages: Table) -> Table:
+    """Add deterministic message_id column based on milliseconds since group creation."""
+    if int(messages.count().execute()) == 0:
+        return messages
+
+    min_ts = messages.ts.min()
+    delta_ms = ((messages.ts.epoch_seconds() - min_ts.epoch_seconds()) * 1000).round().cast("int64")
+
+    order_columns = [messages.ts]
+    if "_import_order" in messages.columns:
+        order_columns.append(messages["_import_order"])
+
+    if "author_raw" in messages.columns:
+        order_columns.append(messages.author_raw)
+    elif "author" in messages.columns:
+        order_columns.append(messages.author)
+
+    if "text" in messages.columns:
+        order_columns.append(messages.text)
+    elif "message" in messages.columns:
+        order_columns.append(messages.message)
+
+    row_number = ibis.row_number().over(order_by=order_columns)
+    return messages.mutate(message_id=delta_ms.cast("string") + "_" + row_number.cast("string"))
+
+
+def parse_source(
+    export: WhatsAppExport,
+    timezone: str | ZoneInfo | None = None,
+    *,
+    expose_raw_author: bool = False,
+    source_identifier: str = "whatsapp",
+) -> Table:
+    """Parse WhatsApp export using pure Ibis/DuckDB operations."""
+    source = ZipMessageSource(export)
+    rows = _parse_whatsapp_lines(source, export, timezone)
+
+    if not rows:
+        logger.warning("No messages found in %s", export.zip_path)
+        return ibis.memtable([], schema=IR_MESSAGE_SCHEMA)
+
+    messages = ibis.memtable(rows)
+    if "_import_order" in messages.columns:
+        messages = messages.order_by([messages.ts, messages["_import_order"]])
+    else:
+        messages = messages.order_by("ts")
+
+    messages = _add_message_ids(messages)
+
+    if "_import_order" in messages.columns:
+        messages = messages.drop("_import_order")
+
+    if not expose_raw_author:
+        messages = anonymize_table(messages)
+
+    helper_columns = ["_author_uuid_hex"]
+    columns_to_drop = [col for col in helper_columns if col in messages.columns]
+    if columns_to_drop:
+        messages = messages.drop(*columns_to_drop)
+
+    tenant_literal = ibis.literal(str(export.group_slug))
+    thread_literal = tenant_literal
+    source_literal = ibis.literal(source_identifier)
+    created_by_literal = ibis.literal("adapter:whatsapp")
+    string_null = ibis.literal(None, type=dt.string)
+    json_null = ibis.literal(None, type=dt.json)
+
+    attrs_column = build_message_attrs(
+        messages.original_line, messages.tagged_line, messages.message_date
+    ).cast(dt.json)
+
+    ir_messages = messages.mutate(
+        event_id=messages.message_id,
+        tenant_id=tenant_literal,
+        source=source_literal,
+        thread_id=thread_literal,
+        msg_id=messages.message_id,
+        ts=messages.ts.cast("timestamp('UTC')"),
+        media_url=string_null,
+        media_type=string_null,
+        attrs=attrs_column,
+        pii_flags=json_null,
+        created_at=messages.ts.cast("timestamp('UTC')"),
+        created_by_run=created_by_literal,
+    )
+
+    return ir_messages.select(*IR_MESSAGE_SCHEMA.names)

--- a/src/egregora/input_adapters/whatsapp/utils.py
+++ b/src/egregora/input_adapters/whatsapp/utils.py
@@ -1,0 +1,117 @@
+"""Shared utilities for the WhatsApp adapter."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+import zipfile
+
+import ibis
+import ibis.expr.datatypes as dt
+
+from egregora.ops.media import ATTACHMENT_MARKERS, WA_MEDIA_PATTERN, detect_media_type
+from egregora.utils.zip import validate_zip_contents
+
+_CHW_PATTERN_RAW = r"WhatsApp(?: Chat with|.*) (.+)\.txt"
+_CHAT_FILE_PATTERN = re.compile(_CHW_PATTERN_RAW)
+
+
+def discover_chat_file(zip_path: Path) -> tuple[str, str]:
+    """Find the chat .txt file in zip_path and infer the group name."""
+    with zipfile.ZipFile(zip_path) as zf:
+        validate_zip_contents(zf)
+        candidates: list[tuple[int, str, str]] = []
+        for member in zf.namelist():
+            if not member.endswith(".txt") or member.startswith("__"):
+                continue
+
+            match = _CHAT_FILE_PATTERN.match(Path(member).name)
+            file_info = zf.getinfo(member)
+            score = file_info.file_size
+            if match:
+                score += 1_000_000
+                group_name = match.group(1)
+            else:
+                group_name = Path(member).stem
+            candidates.append((score, group_name, member))
+
+        if not candidates:
+            msg = f"No WhatsApp chat file found in {zip_path}"
+            raise ValueError(msg)
+
+        candidates.sort(reverse=True, key=lambda item: item[0])
+        _, group_name, member = candidates[0]
+        return (group_name, member)
+
+
+def _convert_whatsapp_media_to_markdown(message: str) -> str:
+    """Convert WhatsApp media references to markdown format."""
+    if not message:
+        return message
+    result = message
+    media_files = WA_MEDIA_PATTERN.findall(message)
+    for filename in media_files:
+        media_type = detect_media_type(Path(filename)) or "file"
+        if media_type == "image":
+            markdown = f"![Image]({filename})"
+        elif media_type == "video":
+            markdown = f"[Video]({filename})"
+        elif media_type == "audio":
+            markdown = f"[Audio]({filename})"
+        elif media_type == "document":
+            markdown = f"[Document]({filename})"
+        else:
+            markdown = f"[File]({filename})"
+        for marker in ATTACHMENT_MARKERS:
+            pattern = re.escape(filename) + "\\s*" + re.escape(marker)
+            result = re.sub(pattern, markdown, result, flags=re.IGNORECASE)
+        if filename in result and markdown not in result:
+            result = re.sub("\\b" + re.escape(filename) + "\\b", markdown, result)
+    return result
+
+
+def build_message_attrs(
+    original_line: ibis.Expr,
+    tagged_line: ibis.Expr,
+    message_date: ibis.Expr,
+) -> ibis.Expr:
+    """Return message metadata serialized as JSON when any field is present."""
+    attrs_struct = ibis.struct(
+        {
+            "original_line": original_line,
+            "tagged_line": tagged_line,
+            "message_date": message_date,
+        }
+    )
+    has_metadata = ibis.coalesce(original_line, tagged_line, message_date).notnull()
+    attrs_json = attrs_struct.cast(dt.json).cast(dt.string)
+    empty_json = ibis.literal(None, type=dt.string)
+    return ibis.cases(
+        (has_metadata, attrs_json),
+        else_=empty_json,
+    )
+
+
+def convert_media_to_markdown(message: str | None) -> str | None:
+    """Convert media references to markdown, returning None for missing values."""
+    if message is None:
+        return None
+    return _convert_whatsapp_media_to_markdown(message)
+
+
+def normalize_media_markdown(messages: ibis.Table) -> ibis.Table:
+    """Normalize WhatsApp media references in a table of messages."""
+
+    @ibis.udf.scalar.python
+    def convert_media(message: str | None) -> str | None:
+        return convert_media_to_markdown(message)
+
+    return messages.mutate(text=convert_media(messages.text))
+
+
+__all__ = [
+    "discover_chat_file",
+    "build_message_attrs",
+    "convert_media_to_markdown",
+    "normalize_media_markdown",
+]

--- a/src/egregora/orchestration/write_pipeline.py
+++ b/src/egregora/orchestration/write_pipeline.py
@@ -46,7 +46,7 @@ from egregora.database.validation import validate_ir_schema
 from egregora.database.views import daily_aggregates_view
 from egregora.input_adapters import get_adapter
 from egregora.input_adapters.base import MediaMapping
-from egregora.input_adapters.whatsapp import extract_commands, filter_egregora_messages
+from egregora.input_adapters.whatsapp.commands import extract_commands, filter_egregora_messages
 from egregora.knowledge.profiles import filter_opted_out_authors, process_commands
 from egregora.ops.media import process_media_for_window
 from egregora.orchestration.context import PipelineContext


### PR DESCRIPTION
### Summary
- Refactor the WhatsApp input adapter into a dedicated package with separate modules for parsing, commands, utilities, and adapter logic.
- Preserve the public API via a new `__init__.py` while updating internal callers to import from the new module structure.

### Motivation / Context
- Improve maintainability and clarity by splitting the monolithic WhatsApp adapter into focused modules for parsing, command extraction, and adapter behavior.
- Align internal imports with the new structure to make future changes safer.

### Changes
- **Refactors**
  - Introduced `input_adapters/whatsapp/` package with `parsing.py`, `commands.py`, `utils.py`, and `adapter.py` modules.
  - Added package `__init__.py` to re-export existing WhatsApp adapter symbols.
  - Updated imports in orchestration and agent components to use the new module paths.

### Implementation Details
- Parsing, normalization, and message building now live in `parsing.py`, while command extraction utilities reside in `commands.py` and shared helpers in `utils.py`.
- WhatsApp adapter class moved to `adapter.py`, still exposing the same public API through the package initializer.
- Callers such as the write pipeline and avatar agent import directly from the new modules to reflect the new layout.

### Testing
- `python -m pytest tests/e2e/input_adapters/test_whatsapp_adapter.py -k "parser" -q` *(fails: missing duckdb dependency in environment).* 

### Risks & Rollback Plan
- Risk of import regressions mitigated by re-exporting public symbols via `__init__.py`. Rollback by reverting the package split to the previous single-module layout if issues arise.

### Breaking Changes / Migrations (if applicable)
- None expected; public imports are preserved.

### Release Notes (optional)
- Refactored WhatsApp adapter into structured package modules for parsing, commands, utilities, and adapter logic.

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926519b6ce88325af98c03bb8061026)