### PR TITLE
fix: implement get_adapter_metadata in WhatsAppAdapter

### DIFF
--- a/src/egregora/input_adapters/whatsapp/adapter.py
+++ b/src/egregora/input_adapters/whatsapp/adapter.py
@@ -13,11 +13,10 @@ import ibis
 
 from egregora.data_primitives.document import Document, DocumentType
 from egregora.input_adapters.base import AdapterMeta, InputAdapter
+from egregora.input_adapters.whatsapp.commands import EGREGORA_COMMAND_PATTERN
+from egregora.input_adapters.whatsapp.parsing import WhatsAppExport, parse_source
+from egregora.input_adapters.whatsapp.utils import convert_media_to_markdown, discover_chat_file
 from egregora.utils.paths import slugify
-
-from .commands import EGREGORA_COMMAND_PATTERN
-from .parsing import WhatsAppExport, parse_source
-from .utils import convert_media_to_markdown, discover_chat_file
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +56,7 @@ class WhatsAppAdapter(InputAdapter):
     def description(self) -> str:
         return "Parses WhatsApp chat exports and attaches optional media references."
 
-    @property
-    def meta(self) -> AdapterMeta:
+    def get_adapter_metadata(self) -> AdapterMeta:
         return AdapterMeta(
             name="WhatsApp",
             version="1.0.0",
@@ -169,8 +167,7 @@ class WhatsAppAdapter(InputAdapter):
     def _detect_media_type(self, media_path: Path) -> str | None:
         from egregora.ops.media import detect_media_type
 
-        media_type = detect_media_type(media_path)
-        return media_type
+        return detect_media_type(media_path)
 
     def get_metadata(self, input_path: Path, **_kwargs: _EmptyKwargs) -> dict[str, Any]:
         if not input_path.exists():


### PR DESCRIPTION
## Summary
Fixes a regression where `WhatsAppAdapter` failed to load because it didn't implement the abstract method `get_adapter_metadata` required by the `InputAdapter` interface.

## Bug
`TypeError: Can't instantiate abstract class WhatsAppAdapter without an implementation for abstract method 'get_adapter_metadata'`

## Fix
Renamed `meta` property to `get_adapter_metadata` method to satisfy the interface.

## Verification
✅ Verified with E2E blog generation on main branch. Generated 5 posts successfully.