### PR TITLE
Update runner and provisioner versions

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -15,14 +15,14 @@ jobs:
   auto-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
 
       - name: Run ruff check --fix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -57,7 +57,7 @@ jobs:
       contents: read  # Checkout code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -80,7 +80,7 @@ jobs:
       actions: write   # Upload artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let prNumber, prData;
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('pr_author', prData.user.login);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -208,7 +208,7 @@ jobs:
             Keep the entire review under 1000 words. Be concise and actionable.
 
       - name: Post review as PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           GEMINI_REVIEW: ${{ steps.gemini.outputs.summary }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}

--- a/.github/workflows/jules-pr-review.yml
+++ b/.github/workflows/jules-pr-review.yml
@@ -20,11 +20,11 @@ jobs:
       !contains(github.event.pull_request.title, '[skip-jules]')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for better context
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/pr-auto-rebase.yml
+++ b/.github/workflows/pr-auto-rebase.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-conflict-label.yml
+++ b/.github/workflows/pr-conflict-label.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update conflict label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labelName = 'has-conflicts';


### PR DESCRIPTION
Update all GitHub Actions workflow dependencies to latest stable versions:

- actions/checkout: v4 → v6
- actions/github-script: v7 → v8
- actions/setup-node: v4 → v6
- astral-sh/setup-uv: v3 → v5

All updated actions require minimum Actions Runner version v2.329.0, which is already in use according to CI logs.

Changes:
- ci.yml: Updated checkout action (3 instances)
- gemini-pr-review.yml: Updated checkout and github-script actions
- jules-pr-review.yml: Updated checkout and setup-node actions
- code-quality.yml: Updated checkout action
- auto-format.yml: Updated checkout and setup-uv actions
- pr-auto-rebase.yml: Updated checkout action
- pr-conflict-label.yml: Updated github-script action

Rationale:
- v6 of checkout includes performance improvements and latest features
- v8 of github-script updates runtime to Node 24
- v6 of setup-node updates runtime to Node 24
- v5 of setup-uv is the latest stable release