### PR TITLE
Update runner and provisioner versions

### DIFF
--- a/.github/workflows/pr-conflict-label.yml
+++ b/.github/workflows/pr-conflict-label.yml
@@ -30,7 +30,7 @@ jobs:
             await new Promise((resolve) => setTimeout(resolve, 5000));
 
             // Retrieve the latest mergeable state
-            const { data: prData } = await octokit.pulls.get({
+            const { data: prData } = await github.rest.pulls.get({
               owner,
               repo,
               pull_number,
@@ -40,7 +40,7 @@ jobs:
 
             // Ensure the label exists
             try {
-              await octokit.issues.getLabel({
+              await github.rest.issues.getLabel({
                 owner,
                 repo,
                 name: labelName,
@@ -48,7 +48,7 @@ jobs:
             } catch (error) {
               if (error.status === 404) {
                 try {
-                  await octokit.issues.createLabel({
+                  await github.rest.issues.createLabel({
                     owner,
                     repo,
                     name: labelName,
@@ -69,7 +69,7 @@ jobs:
 
             if (mergeableState === 'dirty') {
               if (!existingLabels.includes(labelName)) {
-                await octokit.issues.addLabels({
+                await github.rest.issues.addLabels({
                   owner,
                   repo,
                   issue_number: pull_number,
@@ -79,7 +79,7 @@ jobs:
             } else if (['clean', 'unstable'].includes(mergeableState)) {
               if (existingLabels.includes(labelName)) {
                 try {
-                  await octokit.issues.removeLabel({
+                  await github.rest.issues.removeLabel({
                     owner,
                     repo,
                     issue_number: pull_number,


### PR DESCRIPTION
The pr-conflict-label workflow was failing with:
  TypeError: Cannot read properties of undefined (reading 'get')

The issue was using `octokit` instead of `github` in the github-script action. In GitHub Actions, the Octokit client is exposed as `github.rest`, not `octokit`.

Changes:
- Replace all 5 instances of `octokit` with `github.rest`
- Affects: pulls.get, issues.getLabel, issues.createLabel, issues.addLabels, issues.removeLabel

This fixes the workflow error and allows the conflict labeler to work correctly.