### PR TITLE
fix(workflows): restrict auto-format to PR events only

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -3,9 +3,6 @@ name: Auto-format and lint
 on:
   pull_request:
     branches: [main]
-  push:
-    branches-ignore:
-      - 'main'
 
 permissions:
   contents: write


### PR DESCRIPTION
Previously, the auto-format workflow ran on every push to non-main branches, even if no PR existed. This caused unnecessary workflow runs.

Now the workflow only runs when:
- A PR is created (pull_request opened)
- Commits are pushed to a branch with an existing PR (pull_request synchronize)

This reduces CI load and ensures formatting only happens in PR context.