### PR TITLE
docs: streamline CLAUDE.md and add UrlConvention pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,263 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Note:** For the most recent breaking changes (last 60 days), see [CLAUDE.md](CLAUDE.md#breaking-changes).
+
+## [Unreleased]
+
+### 2025-11-27 - Async RAG Migration with Dual-Queue Embedding Router
+
+#### Changed
+- **BREAKING:** All RAG APIs are now fully async
+  - Before: `index_documents([doc])` (blocking)
+  - After: `await index_documents([doc])` (async)
+  - Migration: Wrap in `asyncio.run()` for sync callers
+
+#### Added
+- Dual-queue embedding router (`egregora.rag.embedding_router`)
+  - Single endpoint: Low-latency (1 request/sec)
+  - Batch endpoint: High-throughput (1000 embeddings/min)
+  - Independent rate limit tracking per endpoint
+  - Automatic 429 fallback and retry with exponential backoff
+- Asymmetric embeddings support
+  - Documents: `RETRIEVAL_DOCUMENT` task type
+  - Queries: `RETRIEVAL_QUERY` task type
+- New RAG settings:
+  - `embedding_max_batch_size: 100`
+  - `embedding_timeout: 60.0`
+  - `embedding_max_retries: 3`
+
+#### Fixed
+- O(n²) performance issue in text chunking
+- Chunk overlap to prevent context loss
+
+#### Migration Guide
+1. **Async Context (Pydantic-AI tools):** Add `await`
+2. **Sync Context (pipeline orchestration):** Wrap in `asyncio.run()`
+3. **Tests:** Add `@pytest.mark.asyncio` decorator
+4. **Custom Embedding Functions:** Must be async:
+   ```python
+   async def embed_fn(texts: Sequence[str], task_type: str) -> list[list[float]]
+   ```
+
+#### Files Changed
+- `src/egregora/rag/__init__.py` - Async API signatures
+- `src/egregora/rag/lancedb_backend.py` - Async backend methods
+- `src/egregora/rag/embedding_router.py` - New dual-queue router
+- `src/egregora/rag/embeddings_async.py` - New async embedding API
+- `src/egregora/agents/writer.py` - Tool updated with `await`
+- `src/egregora/orchestration/write_pipeline.py` - Wrapped in `asyncio.run()`
+- `tests/unit/rag/*.py` - All tests converted to async
+
+---
+
+### 2025-11-27 - LanceDB RAG Backend
+
+#### Added
+- New `egregora.rag` package with LanceDB-based vector storage
+- Clean protocol-based design with `RAGBackend` interface
+- Simplified API:
+  ```python
+  from egregora.rag import index_documents, search, RAGQueryRequest
+  await index_documents([doc])
+  response = await search(RAGQueryRequest(text="query", top_k=5))
+  ```
+- Configuration:
+  ```yaml
+  paths:
+    lancedb_dir: .egregora/lancedb
+  rag:
+    enabled: true
+    top_k: 5
+    min_similarity_threshold: 0.7
+    indexable_types: ["POST"]
+  ```
+
+#### Changed
+- **BREAKING:** Similarity scores now use cosine metric (was L2 distance)
+  - Scores in [-1, 1] range
+  - Re-indexing recommended
+- **BREAKING:** Filters API changed from `dict[str, Any]` to SQL `str`
+  - Before: `filters={"category": "programming"}`
+  - After: `filters="category = 'programming'"`
+- **BREAKING:** Removed `top_k_default` parameter from backend initialization
+  - Use `RAGQueryRequest.top_k` instead
+- **BREAKING:** Increased `top_k` maximum from 20 to 100
+
+#### Removed
+- Dependencies: `langchain-text-splitters`, `langchain-core`
+
+#### Deprecated
+- `egregora.agents.shared.rag` module (use `egregora.rag` instead)
+
+#### Fixed
+- Potential SQL injection in delete operations with proper string escaping
+
+---
+
+### 2025-11-26 - Resumability & Fixes
+
+#### Changed
+- **BREAKING:** `mkdocs-blogging-plugin` renamed to `blog` in `mkdocs.yml` templates
+  - Before: `plugins: - blogging`
+  - After: `plugins: - blog`
+  - Impact: Custom `mkdocs.yml` files will fail to build
+
+#### Migration
+```yaml
+# Update mkdocs.yml
+plugins:
+  - blog  # was 'blogging'
+```
+
+---
+
+### 2025-11-25 - RAG Indexing Optimization
+
+#### Changed
+- **BREAKING:** RAG operations centralized as VectorStore methods
+  - Before: `index_documents_for_rag(output, rag_dir, storage, ...)`
+  - After: `store.index_documents(output, embedding_model=...)`
+- **BREAKING:** Reduced RAG export surface
+  - Removed: All internal functions from `egregora.agents.shared.rag`
+  - Now exported: Only `VectorStore` and `DatasetMetadata`
+- **BREAKING:** Removed `resolve_document_path()` from OutputSink protocol
+  - Filesystem-specific method didn't belong in general output protocol
+- **BREAKING:** RAG directory now uses settings instead of hardcoded paths
+  - Before: `site_root / ".egregora" / "rag"` (hardcoded)
+  - After: `config.paths.rag_dir` (configurable, default: `.egregora/rag`)
+
+#### Added
+- VectorStore facade with methods:
+  - `index_documents(output_format, *, embedding_model)`
+  - `index_media(docs_dir, *, embedding_model)`
+  - `query_media(query, ...)`
+  - `query_similar_posts(table, ...)`
+  - `is_available()` (static)
+  - `embed_query(query_text, *, model)` (static)
+
+#### Improved
+- Exception handling: Catches `OSError`, `ValueError`, `PromptTooLargeError` explicitly
+  - Before: `except Exception: # noqa: BLE001`
+  - Unexpected errors now propagate with full stack traces
+
+#### Migration
+```python
+# Before
+from egregora.agents.shared.rag import index_documents_for_rag, query_media
+indexed = index_documents_for_rag(output, rag_dir, storage, embedding_model=model)
+results = query_media(query, store, media_types=types, ...)
+
+# After
+from egregora.agents.shared.rag import VectorStore
+store = VectorStore(rag_dir / "chunks.parquet", storage=storage)
+indexed = store.index_documents(output, embedding_model=model)
+results = store.query_media(query, media_types=types, ...)
+```
+
+---
+
+### 2025-11-23 - Multi-PR Merge
+
+#### Added
+- **Tiered Caching Architecture** (PR #890)
+  - L1: Asset enrichment results (URLs, media)
+  - L2: Vector search results with index metadata invalidation
+  - L3: Writer output with semantic hashing (zero-cost re-runs)
+  - CLI: `--refresh` flag to invalidate cache tiers
+  - Usage: `egregora write export.zip --refresh=writer` or `--refresh=all`
+
+#### Changed
+- **BREAKING:** Writer input format: Markdown → XML (PR #889)
+  - Before: Conversation passed as Markdown table
+  - After: Compact XML format via `_build_conversation_xml()`
+  - Template: `src/egregora/templates/conversation.xml.jinja`
+  - Impact: Custom prompt templates must use `conversation_xml` (not `markdown_table`)
+  - Rationale: ~40% token reduction, better structure preservation
+
+#### Fixed
+- VSS extension now loaded explicitly before HNSW operations (PR #893)
+- Fallback avatar generation using getavataaars.com (deterministic from UUID hash)
+- Banner path conversion to web-friendly relative URLs
+- Idempotent scaffold (detects existing mkdocs.yml)
+
+#### Refactored
+- **WhatsApp Parser** (PR #894)
+  - Removed: Hybrid DuckDB+Python `_parse_messages_duckdb()`
+  - Added: Pure Python `_parse_whatsapp_lines()` generator
+  - No API changes, internal refactor only
+  - Rationale: Eliminates serialization overhead, single-pass processing
+
+#### Removed
+- **Privacy Validation** (PR #892)
+  - Removed: Mandatory `validate_text_privacy()` from `AnnotationStore.save_annotation()`
+  - Rationale: Allow public datasets (judicial records) with legitimate PII
+  - Impact: Privacy validation is now optional, use at input adapter level
+- **Circular Import Cleanup** (PR #891)
+  - Removed: Lazy `__getattr__` shim in `agents/__init__.py`
+  - Changed: Writer agent expects `output_format` in execution context (not direct import)
+  - Migration: Ensure `PipelineContext.output_format` is set before writer execution
+
+---
+
+### 2025-11-22 - OutputAdapter Iterator & Auto-generation
+
+#### Changed
+- **BREAKING:** `OutputAdapter.documents() → Iterator[Document]`
+  - Before: `def documents(self) -> list[Document]`
+  - After: `def documents(self) -> Iterator[Document]`
+  - Migration: Use `list(adapter.documents())` if you need random access
+  - Rationale: Memory efficiency for sites with 1000s of documents
+
+#### Added
+- Statistics page auto-generation
+  - Generates `posts/{date}-statistics.md` after pipeline runs
+  - Uses `daily_aggregates_view` (View Registry pattern)
+  - Non-critical path: errors don't block completion
+- Interactive init
+  - `egregora init` now prompts for site name
+  - Auto-detects non-TTY (CI/CD) and disables prompts
+  - Use `--no-interactive` to explicitly disable
+
+---
+
+### 2025-11-17 - Infrastructure Simplification
+
+#### Removed
+- ~1,500 LOC removed:
+  - Event-sourced `run_events` → simple `runs` table (INSERT + UPDATE pattern)
+  - IR schema: Python single source of truth (no SQL/JSON lockfiles)
+  - Validation: Manual `validate_ir_schema()` calls (decorator removed)
+  - Fingerprinting: Removed (file existence checks only)
+
+#### Changed
+- Checkpointing: Opt-in via `--resume` (default: full rebuild)
+
+---
+
+## Migration Tips
+
+### General Principles
+1. **Read breaking changes carefully** - Test changes in development first
+2. **Update dependencies** - Run `uv sync --all-extras` after updating
+3. **Check configuration** - Many changes introduce new config options
+4. **Run tests** - `uv run pytest tests/unit/` for quick sanity check
+5. **Use VCR cassettes** - First run of integration tests needs `GOOGLE_API_KEY`
+
+### Getting Help
+- File issues: https://github.com/franklinbaldo/egregora/issues
+- Check docs: [docs/](docs/)
+- Read CLAUDE.md: [CLAUDE.md](CLAUDE.md)
+
+---
+
+## Semantic Versioning
+
+Since we're pre-1.0, breaking changes can occur in any release. Once we hit 1.0:
+- **MAJOR** version: Breaking changes
+- **MINOR** version: New features (backward compatible)
+- **PATCH** version: Bug fixes (backward compatible)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,75 +632,50 @@ if step == PipelineStep.ENRICHMENT:
 
 ### URL Generation (UrlConvention Protocol)
 
+**See [docs/architecture/protocols.md](docs/architecture/protocols.md#url-generation) for complete documentation.**
+
+Quick summary: `UrlConvention` protocol enables deterministic URL generation for documents.
+
 ```python
 from egregora.data_primitives.protocols import UrlContext, UrlConvention
-from egregora.data_primitives import Document
 
 # UrlContext: frozen dataclass with context for URL generation
-ctx = UrlContext(
-    base_url="https://example.com",
-    site_prefix="/blog",
-    base_path=Path("/output/docs"),
-    locale="en"
-)
+ctx = UrlContext(base_url="https://example.com", site_prefix="/blog")
 
 # UrlConvention: Protocol for deterministic URL generation
 # Pure function pattern: same document → same URL (no I/O, no side effects)
-class MyUrlConvention:
-    @property
-    def name(self) -> str:
-        return "my-convention"
-
-    @property
-    def version(self) -> str:
-        return "v1"  # For compatibility checks
-
-    def canonical_url(self, document: Document, ctx: UrlContext) -> str:
-        # Deterministic URL calculation
-        return f"{ctx.base_url}{ctx.site_prefix}/{document.slug}"
-
 # Pattern ensures stable URLs across rebuilds (critical for SEO/links)
 ```
 
+**Key properties:**
+- Deterministic: same document → same URL
+- Pure: no I/O, no side effects
+- Versioned: `name` and `version` properties for compatibility checks
+
 ## Configuration
+
+**See [docs/configuration.md](docs/configuration.md) for complete auto-generated reference.**
 
 **File:** `.egregora/config.yml`
 
-**Key settings groups** (13 Pydantic V2 classes in `config/settings.py`):
-- `models` - LLM models (writer, enricher, reader, embedding, banner)
-- `rag` - RAG config (enabled, top_k, indexable_types, embedding_*)
-- `writer` - Custom instructions for writer agent
-- `enrichment` - URL/media enrichment settings
-- `pipeline` - Windowing (step_size, step_unit, overlap_ratio), date filtering, checkpointing
-- `paths` - All directory paths (egregora_dir, rag_dir, lancedb_dir, docs_dir, posts_dir, etc.)
-- `database` - DuckDB paths (pipeline_db, runs_db)
-- `output` - Output format (mkdocs/hugo)
-- `reader` - ELO ranking settings
-- `quota` - LLM usage budgets
+**Key settings groups** (13 Pydantic V2 classes):
+- `models`, `rag`, `writer`, `enrichment`, `pipeline`, `paths`, `database`, `output`, `reader`, `quota`
 
-**Example minimal config:**
+**Minimal config:**
 ```yaml
 models:
   writer: google-gla:gemini-flash-latest
   embedding: google-gla:gemini-embedding-001
-
 rag:
   enabled: true
-
 pipeline:
   step_size: 1
   step_unit: days
 ```
 
-**Custom prompts:** Place Jinja2 templates in `.egregora/prompts/` (overrides `src/egregora/prompts/`)
+**Custom prompts:** `.egregora/prompts/` (overrides `src/egregora/prompts/`)
 
-**Programmatic overrides:**
-```python
-from egregora.config.overrides import ConfigOverrideBuilder
-overrides = ConfigOverrideBuilder()
-overrides.set_model("writer", "google-gla:gemini-pro-latest")
-config = overrides.build(base_config)
-```
+**Regenerate docs:** `python dev_tools/generate_config_docs.py`
 
 ## Testing
 

--- a/dev_tools/generate_config_docs.py
+++ b/dev_tools/generate_config_docs.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Generate configuration documentation from Pydantic models.
+
+This script auto-generates docs/configuration.md from the Pydantic V2 models
+in egregora.config.settings, ensuring documentation stays in sync with code.
+
+Usage:
+    python dev_tools/generate_config_docs.py
+"""
+
+from pathlib import Path
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+from egregora.config.settings import (
+    DatabaseSettings,
+    EgregoraConfig,
+    EnrichmentSettings,
+    FeaturesSettings,
+    ModelSettings,
+    OutputSettings,
+    PathsSettings,
+    PipelineSettings,
+    PrivacySettings,
+    QuotaSettings,
+    RAGSettings,
+    ReaderSettings,
+    WriterAgentSettings,
+)
+
+
+def format_type(field_info: FieldInfo) -> str:
+    """Format field type for documentation."""
+    annotation = field_info.annotation
+
+    # Handle Optional types
+    origin = get_origin(annotation)
+    if origin is type(None) or (origin and any(arg is type(None) for arg in get_args(annotation))):
+        # Extract non-None type
+        args = get_args(annotation)
+        if args:
+            non_none = next((arg for arg in args if arg is not type(None)), None)
+            if non_none:
+                type_str = getattr(non_none, "__name__", str(non_none))
+                return f"`{type_str}` (optional)"
+
+    # Handle list types
+    if origin is list:
+        args = get_args(annotation)
+        if args:
+            inner_type = getattr(args[0], "__name__", str(args[0]))
+            return f"`list[{inner_type}]`"
+
+    # Handle dict types
+    if origin is dict:
+        return "`dict`"
+
+    # Simple types
+    type_name = getattr(annotation, "__name__", str(annotation))
+    return f"`{type_name}`"
+
+
+def get_default_value(field_info: FieldInfo) -> str:
+    """Get formatted default value."""
+    if field_info.is_required():
+        return "**required**"
+
+    default = field_info.default
+    if default is None:
+        return "`null`"
+    if isinstance(default, str):
+        return f'`"{default}"`'
+    if isinstance(default, (int, float, bool)):
+        return f"`{default}`"
+    if isinstance(default, list):
+        return f"`{default}`"
+
+    return f"`{default}`"
+
+
+def document_model(model: type[BaseModel], level: int = 3) -> str:
+    """Generate markdown documentation for a Pydantic model."""
+    lines = []
+    heading = "#" * level
+
+    # Model name and docstring
+    lines.append(f"{heading} {model.__name__}")
+    lines.append("")
+    if model.__doc__:
+        lines.append(model.__doc__.strip())
+        lines.append("")
+
+    # Fields table
+    lines.append("| Field | Type | Default | Description |")
+    lines.append("|-------|------|---------|-------------|")
+
+    for field_name, field_info in model.model_fields.items():
+        type_str = format_type(field_info)
+        default_str = get_default_value(field_info)
+        description = field_info.description or ""
+
+        lines.append(f"| `{field_name}` | {type_str} | {default_str} | {description} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_config_docs() -> str:
+    """Generate complete configuration documentation."""
+    lines = [
+        "# Configuration Reference",
+        "",
+        "Complete reference for `.egregora/config.yml` configuration file.",
+        "",
+        "**Auto-generated from Pydantic models** - Do not edit manually!",
+        "To regenerate: `python dev_tools/generate_config_docs.py`",
+        "",
+        "## Overview",
+        "",
+        "Egregora uses Pydantic V2 for configuration with 13 settings classes:",
+        "",
+    ]
+
+    # List all settings classes
+    settings_classes = [
+        ModelSettings,
+        RAGSettings,
+        WriterAgentSettings,
+        PrivacySettings,
+        EnrichmentSettings,
+        PipelineSettings,
+        PathsSettings,
+        DatabaseSettings,
+        OutputSettings,
+        ReaderSettings,
+        FeaturesSettings,
+        QuotaSettings,
+    ]
+
+    for cls in settings_classes:
+        lines.append(f"- [`{cls.__name__}`](#{cls.__name__.lower()}) - {cls.__doc__ or 'Configuration settings'}")
+
+    lines.extend(
+        [
+            "",
+            "## Root Configuration",
+            "",
+            "The root configuration class is `EgregoraConfig`, which contains all other settings.",
+            "",
+        ]
+    )
+
+    # Document EgregoraConfig
+    lines.append(document_model(EgregoraConfig, level=3))
+
+    # Document each settings class
+    lines.append("## Settings Classes")
+    lines.append("")
+
+    for cls in settings_classes:
+        lines.append(document_model(cls, level=3))
+
+    # Add example configuration
+    lines.extend(
+        [
+            "## Example Configuration",
+            "",
+            "```yaml",
+            "# Minimal configuration",
+            "models:",
+            '  writer: google-gla:gemini-flash-latest',
+            '  embedding: google-gla:gemini-embedding-001',
+            "",
+            "rag:",
+            "  enabled: true",
+            "  top_k: 5",
+            "",
+            "pipeline:",
+            "  step_size: 1",
+            "  step_unit: days",
+            "```",
+            "",
+            "```yaml",
+            "# Complete configuration with all options",
+            "models:",
+            '  writer: google-gla:gemini-flash-latest',
+            '  enricher: google-gla:gemini-flash-latest',
+            '  enricher_vision: google-gla:gemini-flash-latest',
+            '  ranking: google-gla:gemini-flash-latest',
+            '  editor: google-gla:gemini-flash-latest',
+            '  reader: google-gla:gemini-flash-latest',
+            '  embedding: google-gla:gemini-embedding-001',
+            '  banner: google-gla:gemini-imagen-latest',
+            "",
+            "rag:",
+            "  enabled: true",
+            "  top_k: 5",
+            "  min_similarity_threshold: 0.7",
+            '  indexable_types: ["POST"]',
+            "  embedding_max_batch_size: 100",
+            "  embedding_timeout: 60.0",
+            "  embedding_max_retries: 3",
+            "",
+            "writer:",
+            "  custom_instructions: |",
+            "    Write in a conversational tone.",
+            "    Focus on clarity and simplicity.",
+            "",
+            "enrichment:",
+            "  enabled: true",
+            "  enable_url: true",
+            "  enable_media: true",
+            "  max_enrichments: 100",
+            "",
+            "pipeline:",
+            "  step_size: 1",
+            "  step_unit: days",
+            "  overlap_ratio: 0.0",
+            "  timezone: UTC",
+            "  checkpoint_enabled: false",
+            "",
+            "paths:",
+            "  egregora_dir: .egregora",
+            "  docs_dir: docs",
+            "  posts_dir: docs/posts",
+            "",
+            "database:",
+            "  pipeline_db: .egregora/pipeline.duckdb",
+            "  runs_db: .egregora/runs.duckdb",
+            "",
+            "output:",
+            "  format: mkdocs",
+            "",
+            "reader:",
+            "  enabled: true",
+            "  comparisons_per_post: 5",
+            "  k_factor: 32",
+            "",
+            "quota:",
+            "  daily_llm_requests: null",
+            "  per_second_limit: 1.0",
+            "  concurrency: 5",
+            "```",
+            "",
+            "## Custom Prompts",
+            "",
+            "Override default prompts by placing Jinja2 templates in `.egregora/prompts/`:",
+            "",
+            "- `writer.jinja` - Writer agent prompt",
+            "- `banner.jinja` - Banner agent prompt",
+            "- `reader_system.jinja` - Reader system prompt",
+            "- `media_detailed.jinja` - Media enrichment prompt",
+            "- `url_detailed.jinja` - URL enrichment prompt",
+            "",
+            "## Programmatic Configuration",
+            "",
+            "```python",
+            "from egregora.config.overrides import ConfigOverrideBuilder",
+            "from egregora.config.settings import EgregoraConfig",
+            "",
+            "# Load base config",
+            "config = EgregoraConfig.load()",
+            "",
+            "# Build overrides",
+            "overrides = ConfigOverrideBuilder()",
+            'overrides.set_model("writer", "google-gla:gemini-pro-latest")',
+            "overrides.set_rag_enabled(False)",
+            "",
+            "# Apply overrides",
+            "config = overrides.build(config)",
+            "```",
+            "",
+            "## Related Documentation",
+            "",
+            "- [CLAUDE.md](../CLAUDE.md) - Quick reference",
+            "- [Architecture Overview](architecture/README.md) - System architecture",
+            "- [Protocols](architecture/protocols.md) - Core protocols",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Generate configuration documentation."""
+    print("Generating configuration documentation...")
+
+    # Generate docs
+    docs = generate_config_docs()
+
+    # Write to file
+    output_path = Path("docs/configuration.md")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(docs)
+
+    print(f"✓ Generated {output_path}")
+    print(f"  {len(docs.splitlines())} lines")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/architecture/protocols.md
+++ b/docs/architecture/protocols.md
@@ -1,0 +1,402 @@
+# Core Protocols
+
+Egregora uses Protocol classes (PEP 544) to define interfaces without inheritance. This document describes all core protocols in the codebase.
+
+## Table of Contents
+
+- [URL Generation](#url-generation)
+- [Input Adapters](#input-adapters)
+- [Output Adapters](#output-adapters)
+- [RAG Backend](#rag-backend)
+- [Database Protocols](#database-protocols)
+
+---
+
+## URL Generation
+
+### UrlContext
+
+**Module:** `egregora.data_primitives.protocols`
+
+Frozen dataclass providing context information for URL generation.
+
+```python
+@dataclass(frozen=True, slots=True)
+class UrlContext:
+    """Context information required when generating canonical URLs."""
+
+    base_url: str = ""           # Base URL (e.g., "https://example.com")
+    site_prefix: str = ""        # Site prefix (e.g., "/blog")
+    base_path: Path | None = None  # Filesystem base path
+    locale: str | None = None    # Locale for i18n (e.g., "en", "pt-BR")
+```
+
+**Usage:**
+```python
+ctx = UrlContext(
+    base_url="https://mysite.com",
+    site_prefix="/posts",
+    base_path=Path("/output/docs"),
+    locale="en"
+)
+```
+
+### UrlConvention
+
+**Module:** `egregora.data_primitives.protocols`
+
+Protocol for deterministic URL generation strategies.
+
+```python
+class UrlConvention(Protocol):
+    """Contract for deterministic URL generation strategies.
+
+    Pure function pattern: same document → same URL
+    No I/O, no side effects - just URL calculation.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return a short identifier describing the convention."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Return a semantic version or timestamp string for compatibility checks."""
+        ...
+
+    def canonical_url(self, document: Document, ctx: UrlContext) -> str:
+        """Calculate the canonical URL for ``document`` within ``ctx``."""
+        ...
+```
+
+**Key Properties:**
+- **Deterministic:** Same document always produces same URL
+- **Pure:** No I/O operations, no side effects
+- **Versioned:** `name` and `version` for compatibility tracking
+- **Context-aware:** Uses `UrlContext` for environment-specific configuration
+
+**Example Implementation:**
+```python
+class MkDocsUrlConvention:
+    """MkDocs-compatible URL convention."""
+
+    @property
+    def name(self) -> str:
+        return "mkdocs-standard"
+
+    @property
+    def version(self) -> str:
+        return "v1.0"
+
+    def canonical_url(self, document: Document, ctx: UrlContext) -> str:
+        # Posts: /posts/{slug}/
+        # Pages: /{slug}/
+        if document.type == DocumentType.POST:
+            path = f"/posts/{document.slug}/"
+        else:
+            path = f"/{document.slug}/"
+
+        return f"{ctx.base_url}{ctx.site_prefix}{path}"
+```
+
+**Why This Matters:**
+- **SEO:** Stable URLs across rebuilds prevent broken links
+- **Testing:** Pure functions are easy to test
+- **Flexibility:** Swap conventions without changing callers
+- **Compatibility:** Version tracking enables gradual migration
+
+---
+
+## Input Adapters
+
+### InputAdapter
+
+**Module:** `egregora.data_primitives.protocols`
+
+Protocol for bringing data INTO the pipeline.
+
+```python
+@runtime_checkable
+class InputAdapter(Protocol):
+    """Adapter for reading external data sources and converting to IR."""
+
+    def read(self) -> Iterator[Table]:
+        """Read from source and yield Ibis tables conforming to IR_MESSAGE_SCHEMA.
+
+        Returns:
+            Iterator of Ibis tables with IR_MESSAGE_SCHEMA columns
+        """
+        ...
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return metadata about the input source."""
+        ...
+```
+
+**Available Implementations:**
+- `WhatsAppAdapter` - Parse WhatsApp chat exports
+- `IperonTJROAdapter` - Brazilian judicial records API
+- `SelfInputAdapter` - Re-ingest existing posts
+
+**Key Responsibilities:**
+- Parse external format
+- Convert to `IR_MESSAGE_SCHEMA`
+- Handle privacy/anonymization at source
+- Yield data as Ibis tables (not pandas)
+
+**Example:**
+```python
+class MyAdapter:
+    def __init__(self, source_path: Path):
+        self.source_path = source_path
+
+    def read(self) -> Iterator[Table]:
+        # Parse your format
+        data = parse_my_format(self.source_path)
+
+        # Convert to IR_MESSAGE_SCHEMA
+        table = ibis.memtable(data).select(
+            message_id=...,
+            conversation_id=...,
+            author_id=...,
+            content=...,
+            timestamp=...,
+            # ... all IR_MESSAGE_SCHEMA columns
+        )
+
+        yield table
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "source_type": "my-format",
+            "source_path": str(self.source_path),
+            "version": "1.0"
+        }
+```
+
+---
+
+## Output Adapters
+
+### OutputAdapter
+
+**Module:** `egregora.data_primitives.protocols`
+
+Protocol for taking data OUT of the pipeline.
+
+```python
+@runtime_checkable
+class OutputAdapter(Protocol):
+    """Adapter for persisting documents to external formats."""
+
+    def persist(self, document: Document) -> None:
+        """Persist document to output format.
+
+        Must be idempotent - repeated calls with same document should overwrite.
+        """
+        ...
+
+    def documents(self) -> Iterator[Document]:
+        """Iterate over all documents in output format.
+
+        Returns:
+            Iterator for memory efficiency (not list)
+        """
+        ...
+```
+
+**Available Implementations:**
+- `MkDocsAdapter` - Generate MkDocs sites
+- `ParquetAdapter` - Export to Parquet format
+
+**Key Responsibilities:**
+- Convert `Document` to target format
+- Idempotent writes (overwrite on repeat)
+- Lazy document iteration
+- Handle filesystem layout
+
+**Example:**
+```python
+class MyOutputAdapter:
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+
+    def persist(self, document: Document) -> None:
+        # Calculate path
+        path = self.output_dir / f"{document.slug}.html"
+
+        # Convert Document to target format
+        html = render_to_html(document)
+
+        # Write (idempotent - overwrites)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(html)
+
+    def documents(self) -> Iterator[Document]:
+        # Lazy iteration (not list)
+        for path in self.output_dir.glob("*.html"):
+            yield parse_html_to_document(path)
+```
+
+---
+
+## RAG Backend
+
+### RAGBackend
+
+**Module:** `egregora.rag.backend`
+
+Protocol for vector storage backends.
+
+```python
+class RAGBackend(Protocol):
+    """Protocol for RAG vector storage backends."""
+
+    async def index_documents(
+        self,
+        documents: Sequence[Document],
+        *,
+        embedding_fn: Callable[[Sequence[str], str], Awaitable[list[list[float]]]]
+    ) -> int:
+        """Index documents for retrieval.
+
+        Args:
+            documents: Documents to index
+            embedding_fn: Async function to generate embeddings
+                         Signature: (texts, task_type) -> embeddings
+
+        Returns:
+            Number of chunks indexed
+        """
+        ...
+
+    async def search(
+        self,
+        request: RAGQueryRequest
+    ) -> RAGQueryResponse:
+        """Search indexed documents.
+
+        Args:
+            request: Search request with query text, top_k, filters
+
+        Returns:
+            Response with scored results
+        """
+        ...
+
+    async def delete_all(self) -> None:
+        """Delete all indexed documents."""
+        ...
+```
+
+**Available Implementations:**
+- `LanceDBRAGBackend` - LanceDB vector storage (current)
+
+**Key Properties:**
+- **Fully async:** All methods are async
+- **Embedding injection:** Backend doesn't know about embedding models
+- **Chunking:** Backend handles chunking internally
+- **Task types:** Supports asymmetric embeddings (RETRIEVAL_DOCUMENT vs RETRIEVAL_QUERY)
+
+**Example Usage:**
+```python
+from egregora.rag import LanceDBRAGBackend, RAGQueryRequest, index_documents
+
+# Index documents
+backend = LanceDBRAGBackend(db_path=Path(".egregora/lancedb"))
+count = await index_documents([doc1, doc2, doc3])
+print(f"Indexed {count} chunks")
+
+# Search
+request = RAGQueryRequest(
+    text="how to use RAG",
+    top_k=5,
+    min_similarity=0.7
+)
+response = await backend.search(request)
+
+for hit in response.hits:
+    print(f"{hit.score:.2f}: {hit.text[:100]}")
+```
+
+---
+
+## Database Protocols
+
+### Storage Protocols
+
+**Module:** `egregora.database.protocols`
+
+Protocols for database storage and retrieval.
+
+```python
+class TableStorage(Protocol):
+    """Protocol for table storage operations."""
+
+    def write_table(
+        self,
+        table: Table,
+        name: str,
+        *,
+        checkpoint: bool = False
+    ) -> None:
+        """Write Ibis table to storage."""
+        ...
+
+    def read_table(self, name: str) -> Table:
+        """Read Ibis table from storage."""
+        ...
+
+    def table_exists(self, name: str) -> bool:
+        """Check if table exists."""
+        ...
+```
+
+---
+
+## Best Practices
+
+### Protocol Design
+
+1. **Keep protocols small** - Single Responsibility Principle
+2. **Use `@runtime_checkable`** - Enable `isinstance()` checks
+3. **Document return types** - Protocols are contracts
+4. **Avoid concrete dependencies** - Depend on abstractions
+
+### Implementation Guidelines
+
+1. **Pure functions when possible** - UrlConvention example
+2. **Idempotent operations** - OutputAdapter.persist()
+3. **Lazy iteration** - Use `Iterator` not `list`
+4. **Async by default** - RAGBackend example
+
+### Testing Protocols
+
+```python
+# Test with mock implementation
+class MockOutputAdapter:
+    def __init__(self):
+        self.documents_dict = {}
+
+    def persist(self, document: Document) -> None:
+        self.documents_dict[document.id] = document
+
+    def documents(self) -> Iterator[Document]:
+        yield from self.documents_dict.values()
+
+# Verify protocol compliance
+from egregora.data_primitives.protocols import OutputAdapter
+assert isinstance(MockOutputAdapter(), OutputAdapter)
+```
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Quick reference and key patterns
+- [Architecture Overview](./README.md) - System architecture
+- [RAG Architecture](./rag.md) - RAG implementation details
+- [Pipeline Design](./pipeline.md) - Pipeline stages and transforms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,397 @@
+# Configuration Reference
+
+Complete reference for `.egregora/config.yml` configuration file.
+
+**Auto-generated from Pydantic models** - Do not edit manually!
+To regenerate: `python dev_tools/generate_config_docs.py`
+
+## Overview
+
+Egregora uses Pydantic V2 for configuration with 13 settings classes:
+
+- [`ModelSettings`](#modelsettings) - LLM model configuration for different tasks.
+
+    - Pydantic-AI agents expect provider-prefixed IDs like ``google-gla:gemini-flash-latest``
+    - Direct Google GenAI SDK calls expect ``models/<name>`` identifiers
+    
+- [`RAGSettings`](#ragsettings) - Retrieval-Augmented Generation (RAG) configuration.
+
+    Uses LanceDB for vector storage and similarity search.
+    Embedding API uses dual-queue router for optimal throughput.
+    
+- [`WriterAgentSettings`](#writeragentsettings) - Blog post writer configuration.
+- [`PrivacySettings`](#privacysettings) - Privacy and data protection settings (YAML configuration).
+
+    .. note::
+       Currently all privacy features (anonymization, PII detection) are always enabled.
+       This config section is reserved for future configurable privacy controls.
+
+    .. warning::
+       This Pydantic model (for YAML config) has the same name as the dataclass in
+       ``egregora.privacy.config.PrivacySettings`` (for runtime policy). They are NOT
+       duplicates - they serve different purposes:
+
+       - **This class**: YAML configuration placeholder (persisted to config.yml)
+       - **privacy.config.PrivacySettings**: Runtime policy with tenant isolation, PII
+         detection settings, and re-identification escrow (never persisted)
+
+       When privacy configuration becomes user-configurable, this class will hold the
+       YAML settings which get mapped to runtime PrivacySettings instances.
+    
+- [`EnrichmentSettings`](#enrichmentsettings) - Enrichment settings for URLs and media.
+- [`PipelineSettings`](#pipelinesettings) - Pipeline execution settings.
+- [`PathsSettings`](#pathssettings) - Site directory paths configuration.
+
+    All paths are relative to site_root (output directory).
+    Provides defaults that match the standard .egregora/ structure.
+    
+- [`DatabaseSettings`](#databasesettings) - Database configuration for pipeline and observability.
+
+    All values must be valid Ibis connection URIs (e.g. DuckDB, Postgres, SQLite).
+    
+- [`OutputSettings`](#outputsettings) - Output format configuration.
+
+    Specifies which output format to use for generated content.
+    
+- [`ReaderSettings`](#readersettings) - Reader agent configuration for post evaluation and ranking.
+- [`FeaturesSettings`](#featuressettings) - Feature flags for experimental or optional functionality.
+- [`QuotaSettings`](#quotasettings) - Configuration for LLM usage budgets and concurrency.
+
+## Root Configuration
+
+The root configuration class is `EgregoraConfig`, which contains all other settings.
+
+### EgregoraConfig
+
+Root configuration for Egregora.
+
+    This model defines the complete .egregora/config.yml schema.
+
+    Example config.yml:
+    ```yaml
+    models:
+      writer: google-gla:gemini-flash-latest
+      enricher: google-gla:gemini-flash-latest
+
+    rag:
+      enabled: true
+      top_k: 5
+      min_similarity_threshold: 0.7
+
+    writer:
+      custom_instructions: "Write in a casual, friendly tone"
+      enable_banners: true
+
+    privacy:
+      anonymization_enabled: true
+      pii_detection_enabled: true
+
+    pipeline:
+      step_size: 1
+      step_unit: days
+
+    database:
+      pipeline_db: duckdb:///./.egregora/pipeline.duckdb
+      runs_db: duckdb:///./.egregora/runs.duckdb
+
+    output:
+      format: mkdocs
+    ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `models` | `ModelSettings` | `PydanticUndefined` | LLM model configuration |
+| `rag` | `RAGSettings` | `PydanticUndefined` | RAG configuration |
+| `writer` | `WriterAgentSettings` | `PydanticUndefined` | Writer configuration |
+| `reader` | `ReaderSettings` | `PydanticUndefined` | Reader agent configuration |
+| `privacy` | `PrivacySettings` | `PydanticUndefined` | Privacy settings |
+| `enrichment` | `EnrichmentSettings` | `PydanticUndefined` | Enrichment settings |
+| `pipeline` | `PipelineSettings` | `PydanticUndefined` | Pipeline settings |
+| `paths` | `PathsSettings` | `PydanticUndefined` | Site directory paths (relative to site root) |
+| `database` | `DatabaseSettings` | `PydanticUndefined` | Database configuration (pipeline and run tracking) |
+| `output` | `OutputSettings` | `PydanticUndefined` | Output format settings |
+| `features` | `FeaturesSettings` | `PydanticUndefined` | Feature flags |
+| `quota` | `QuotaSettings` | `PydanticUndefined` | LLM usage quota tracking |
+
+## Settings Classes
+
+### ModelSettings
+
+LLM model configuration for different tasks.
+
+    - Pydantic-AI agents expect provider-prefixed IDs like ``google-gla:gemini-flash-latest``
+    - Direct Google GenAI SDK calls expect ``models/<name>`` identifiers
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `writer` | `str` | `"google-gla:gemini-flash-latest"` | Model for blog post generation (pydantic-ai format) |
+| `enricher` | `str` | `"google-gla:gemini-flash-latest"` | Model for URL/text enrichment (pydantic-ai format) |
+| `enricher_vision` | `str` | `"google-gla:gemini-flash-latest"` | Model for image/video enrichment (pydantic-ai format) |
+| `ranking` | `str` | `"google-gla:gemini-flash-latest"` | Model for post ranking (pydantic-ai format) |
+| `editor` | `str` | `"google-gla:gemini-flash-latest"` | Model for interactive post editing (pydantic-ai format) |
+| `reader` | `str` | `"google-gla:gemini-flash-latest"` | Model for reader agent (pydantic-ai format) |
+| `embedding` | `str` | `"models/gemini-embedding-001"` | Model for vector embeddings (Google GenAI format: models/...) |
+| `banner` | `str` | `"models/gemini-2.5-flash-image"` | Model for banner/cover image generation (Google GenAI format) |
+
+### RAGSettings
+
+Retrieval-Augmented Generation (RAG) configuration.
+
+    Uses LanceDB for vector storage and similarity search.
+    Embedding API uses dual-queue router for optimal throughput.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `True` | Enable RAG for writer agent |
+| `top_k` | `int` | `5` | Number of top results to retrieve |
+| `min_similarity_threshold` | `float` | `0.7` | Minimum similarity threshold for results |
+| `indexable_types` | `list[str]` | `['POST']` | Document types to index in RAG (e.g., ['POST', 'NOTE']) |
+| `embedding_max_batch_size` | `int` | `100` | Maximum texts per batch embedding request (Google API limit: 100) |
+| `embedding_timeout` | `float` | `60.0` | HTTP timeout for embedding requests in seconds |
+| `embedding_max_retries` | `int` | `5` | Maximum consecutive errors before failing (per endpoint) |
+
+### WriterAgentSettings
+
+Blog post writer configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `custom_instructions` | `str` (optional) | `null` | Custom instructions to guide the writer agent |
+
+### PrivacySettings
+
+Privacy and data protection settings (YAML configuration).
+
+    .. note::
+       Currently all privacy features (anonymization, PII detection) are always enabled.
+       This config section is reserved for future configurable privacy controls.
+
+    .. warning::
+       This Pydantic model (for YAML config) has the same name as the dataclass in
+       ``egregora.privacy.config.PrivacySettings`` (for runtime policy). They are NOT
+       duplicates - they serve different purposes:
+
+       - **This class**: YAML configuration placeholder (persisted to config.yml)
+       - **privacy.config.PrivacySettings**: Runtime policy with tenant isolation, PII
+         detection settings, and re-identification escrow (never persisted)
+
+       When privacy configuration becomes user-configurable, this class will hold the
+       YAML settings which get mapped to runtime PrivacySettings instances.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+
+### EnrichmentSettings
+
+Enrichment settings for URLs and media.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `True` | Enable enrichment pipeline |
+| `enable_url` | `bool` | `True` | Enrich URLs with LLM-generated descriptions |
+| `enable_media` | `bool` | `True` | Enrich images/videos with LLM-generated descriptions |
+| `max_enrichments` | `int` | `50` | Maximum number of enrichments per run |
+
+### PipelineSettings
+
+Pipeline execution settings.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `step_size` | `int` | `1` | Size of each processing window (number of messages, hours, days, etc.) |
+| `step_unit` | `WindowUnit` | `"WindowUnit.DAYS"` | Unit for windowing: 'messages' (count), 'hours'/'days' (time), 'bytes' (max packing) |
+| `overlap_ratio` | `float` | `0.2` | Fraction of window to overlap for context continuity (0.0-0.5, default 0.2 = 20%) |
+| `max_window_time` | `int` (optional) | `null` | Maximum time span per window in hours (optional constraint) |
+| `timezone` | `str` (optional) | `null` | Timezone for timestamp parsing (e.g., 'America/New_York') |
+| `batch_threshold` | `int` | `10` | Minimum items before batching API calls |
+| `from_date` | `str` (optional) | `null` | Start date for filtering (ISO format: YYYY-MM-DD) |
+| `to_date` | `str` (optional) | `null` | End date for filtering (ISO format: YYYY-MM-DD) |
+| `max_prompt_tokens` | `int` | `100000` | Maximum tokens per prompt (default 100k, even if model supports more). Prevents context overflow and controls costs. |
+| `use_full_context_window` | `bool` | `False` | Use full model context window (overrides max_prompt_tokens cap) |
+| `max_windows` | `int` (optional) | `1` | Maximum windows to process per run (1=single window, 0=all windows, None=all) |
+| `checkpoint_enabled` | `bool` | `False` | Enable incremental processing with checkpoints (opt-in). Default: always rebuild from scratch for simplicity. |
+
+### PathsSettings
+
+Site directory paths configuration.
+
+    All paths are relative to site_root (output directory).
+    Provides defaults that match the standard .egregora/ structure.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `egregora_dir` | `str` | `".egregora"` | Egregora internal directory (contains config, rag, cache) |
+| `rag_dir` | `str` | `".egregora/rag"` | RAG database and embeddings storage (DuckDB backend) |
+| `lancedb_dir` | `str` | `".egregora/lancedb"` | LanceDB vector database directory (LanceDB backend) |
+| `cache_dir` | `str` | `".egregora/.cache"` | API response cache |
+| `prompts_dir` | `str` | `".egregora/prompts"` | Custom prompt overrides |
+| `docs_dir` | `str` | `"docs"` | Documentation/content directory |
+| `posts_dir` | `str` | `"blog/posts"` | Blog posts directory |
+| `profiles_dir` | `str` | `"profiles"` | Author profiles directory |
+| `media_dir` | `str` | `"media"` | Media files (images, videos) directory |
+| `journal_dir` | `str` | `"journal"` | Agent execution journals directory |
+
+### DatabaseSettings
+
+Database configuration for pipeline and observability.
+
+    All values must be valid Ibis connection URIs (e.g. DuckDB, Postgres, SQLite).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pipeline_db` | `str` | `"duckdb:///./.egregora/pipeline.duckdb"` | Pipeline database connection URI (e.g. 'duckdb:///absolute/path.duckdb', 'duckdb:///./.egregora/pipeline.duckdb' for a site-relative file, or 'postgres://user:pass@host:5432/dbname'). |
+| `runs_db` | `str` | `"duckdb:///./.egregora/runs.duckdb"` | Run tracking database connection URI (e.g. 'duckdb:///absolute/runs.duckdb', 'duckdb:///./.egregora/runs.duckdb' for a site-relative file, or 'postgres://user:pass@host:5432/dbname'). |
+
+### OutputSettings
+
+Output format configuration.
+
+    Specifies which output format to use for generated content.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `format` | `Literal` | `"mkdocs"` | Output format: 'mkdocs' (default), 'hugo', or future formats (database, s3) |
+| `mkdocs_config_path` | `str` (optional) | `null` | Path to mkdocs.yml config file, relative to site root. If None, defaults to '.egregora/mkdocs.yml' |
+
+### ReaderSettings
+
+Reader agent configuration for post evaluation and ranking.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `False` | Enable reader agent for post quality evaluation |
+| `comparisons_per_post` | `int` | `5` | Number of pairwise comparisons per post for ELO ranking |
+| `k_factor` | `int` | `32` | ELO K-factor controlling rating volatility (16=stable, 64=volatile) |
+| `database_path` | `str` | `".egregora/reader.duckdb"` | Path to reader database for ELO ratings and comparison history |
+
+### FeaturesSettings
+
+Feature flags for experimental or optional functionality.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ranking_enabled` | `bool` | `False` | Enable Elo-based post ranking (deprecated: use reader.enabled instead) |
+| `annotations_enabled` | `bool` | `True` | Enable conversation annotations/threading |
+
+### QuotaSettings
+
+Configuration for LLM usage budgets and concurrency.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `daily_llm_requests` | `int` | `220` | Soft limit for daily LLM calls (writer + enrichment). |
+| `per_second_limit` | `int` | `1` | Maximum number of LLM calls allowed per second (for async guard). |
+| `concurrency` | `int` | `1` | Maximum number of simultaneous LLM tasks (enrichment, writing, etc). |
+
+## Example Configuration
+
+```yaml
+# Minimal configuration
+models:
+  writer: google-gla:gemini-flash-latest
+  embedding: google-gla:gemini-embedding-001
+
+rag:
+  enabled: true
+  top_k: 5
+
+pipeline:
+  step_size: 1
+  step_unit: days
+```
+
+```yaml
+# Complete configuration with all options
+models:
+  writer: google-gla:gemini-flash-latest
+  enricher: google-gla:gemini-flash-latest
+  enricher_vision: google-gla:gemini-flash-latest
+  ranking: google-gla:gemini-flash-latest
+  editor: google-gla:gemini-flash-latest
+  reader: google-gla:gemini-flash-latest
+  embedding: google-gla:gemini-embedding-001
+  banner: google-gla:gemini-imagen-latest
+
+rag:
+  enabled: true
+  top_k: 5
+  min_similarity_threshold: 0.7
+  indexable_types: ["POST"]
+  embedding_max_batch_size: 100
+  embedding_timeout: 60.0
+  embedding_max_retries: 3
+
+writer:
+  custom_instructions: |
+    Write in a conversational tone.
+    Focus on clarity and simplicity.
+
+enrichment:
+  enabled: true
+  enable_url: true
+  enable_media: true
+  max_enrichments: 100
+
+pipeline:
+  step_size: 1
+  step_unit: days
+  overlap_ratio: 0.0
+  timezone: UTC
+  checkpoint_enabled: false
+
+paths:
+  egregora_dir: .egregora
+  docs_dir: docs
+  posts_dir: docs/posts
+
+database:
+  pipeline_db: .egregora/pipeline.duckdb
+  runs_db: .egregora/runs.duckdb
+
+output:
+  format: mkdocs
+
+reader:
+  enabled: true
+  comparisons_per_post: 5
+  k_factor: 32
+
+quota:
+  daily_llm_requests: null
+  per_second_limit: 1.0
+  concurrency: 5
+```
+
+## Custom Prompts
+
+Override default prompts by placing Jinja2 templates in `.egregora/prompts/`:
+
+- `writer.jinja` - Writer agent prompt
+- `banner.jinja` - Banner agent prompt
+- `reader_system.jinja` - Reader system prompt
+- `media_detailed.jinja` - Media enrichment prompt
+- `url_detailed.jinja` - URL enrichment prompt
+
+## Programmatic Configuration
+
+```python
+from egregora.config.overrides import ConfigOverrideBuilder
+from egregora.config.settings import EgregoraConfig
+
+# Load base config
+config = EgregoraConfig.load()
+
+# Build overrides
+overrides = ConfigOverrideBuilder()
+overrides.set_model("writer", "google-gla:gemini-pro-latest")
+overrides.set_rag_enabled(False)
+
+# Apply overrides
+config = overrides.build(config)
+```
+
+## Related Documentation
+
+- [CLAUDE.md](../CLAUDE.md) - Quick reference
+- [Architecture Overview](architecture/README.md) - System architecture
+- [Protocols](architecture/protocols.md) - Core protocols


### PR DESCRIPTION
Reduced CLAUDE.md from 1,240 to 980 lines (-260 lines, -21%) while adding critical UrlConvention documentation.

## Compressions

### Removed CLI Commands section (-112 lines)
- Duplicated Quick Reference
- CLI details available via `egregora <command> --help`

### Compressed Agents section (100 → 22 lines, -78%)
- Reduced from detailed descriptions to concise bullet points
- Kept essential info: module, purpose, config keys, usage
- Detailed agent docs belong in architecture docs, not AI guide

### Compressed Configuration (155 → 39 lines, -75%)
- Removed exhaustive YAML (was duplicating Pydantic models)
- Kept minimal example + settings group summary
- Full config reference should be auto-generated from Pydantic models

### Trimmed Breaking Changes
- Removed 2025-11-17 Infrastructure Simplification
- Kept only last ~30 days of changes
- Added pointer to CHANGELOG.md for full history

## Additions

### UrlConvention Protocol in Key Patterns (+30 lines)
- Added UrlContext dataclass documentation
- Added UrlConvention Protocol pattern
- Example implementation showing pure function pattern
- Critical for deterministic URL generation (SEO, stable links)

Pattern ensures:
- Same document → same URL (deterministic)
- No I/O, no side effects (pure function)
- Versioned for compatibility checks (name, version properties)

## Impact

**Token efficiency:** 21% reduction in context size for AI agents **Maintainability:** Less duplication, clearer separation of concerns **Completeness:** Added missing UrlConvention pattern documentation

**Next steps:**
- Create docs/architecture/protocols.md for detailed protocol docs
- Auto-generate config reference from Pydantic models
- Move Breaking Changes to CHANGELOG.md