### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,12 +33,8 @@ jobs:
       - name: Set up Python 3.12
         run: uv python install 3.12
 
-      - name: Install MkDocs dependencies
-        run: |
-          uv pip install --system --extras docs .
-
       - name: Build site
-        run: mkdocs build --clean
+        run: uvx --python 3.12 --with ".[docs]" mkdocs build --clean
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
### Summary
- add a GitHub Pages workflow to build MkDocs documentation on pushes to main
- upload built site as artifact and deploy it via GitHub Pages environment

### Motivation / Context
- enable publishing the MkDocs documentation to GitHub Pages when docs change

### Changes
- new GitHub Actions workflow that installs MkDocs, builds the site, uploads the artifact, and deploys to Pages

### Implementation Details
- workflow triggers on main branch pushes affecting docs assets or the workflow itself and allows manual dispatch

### Testing
- not run (workflow-only change)

### Risks & Rollback Plan
- minimal risk; revert the workflow file if Pages deployments cause issues

### Breaking Changes / Migrations (if applicable)
- none

### Release Notes (optional)
- add GitHub Pages deployment workflow for MkDocs docs

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2d3d514c83259ac5dbdaa37ccbbd)