### PR TITLE
refactor: address quality feedback for Egregora V3 Core

### DIFF
--- a/docs/v3_development_plan.md
+++ b/docs/v3_development_plan.md
@@ -1,0 +1,53 @@
+# Egregora V3 Development Plan
+
+## Project Goal
+Refactor Egregora into a clean, synchronous, modular architecture (`src/egregora_v3`) following a Test-Driven Development (TDD) approach. The goal is to eliminate technical debt, unify data structures, and simplify the cognitive engine.
+
+## Core Principles
+1.  **Synchronous-First:** The core pipeline and internal interfaces must be synchronous (`def`). Concurrency is handled explicitly via `ThreadPoolExecutor` for I/O bound tasks, never `async`/`await` in the core logic.
+2.  **Document Unification:** All content types (`Post`, `Profile`, `Journal`, `Enrichment`, `Media`) are specialized instances of a single `Document` primitive.
+3.  **Strict Layering:** Dependencies flow inwards only: `Pipeline` -> `Engine` -> `Infra` -> `Core`. The Core layer has zero dependencies on outer layers.
+4.  **LLM Abstraction:** The cognitive engine uses `pydantic-ai` Agents wrapped in a synchronous `LLMModel` interface to decouple the pipeline from specific LLM implementations.
+5.  **Adapter-Driven Privacy:** Privacy (anonymization, redaction) is the responsibility of the Input Adapter. The core pipeline expects data to be "ready to use" by agents.
+
+## Architecture Layers
+
+| Layer | Module (`src/egregora_v3/`) | Responsibility | Key Components |
+| :--- | :--- | :--- | :--- |
+| **L4: Orchestration** | `pipeline/` | Manages the workflow flow (Ingest, Window, Process, Publish). CLI entry point. | `PipelineRunner`, `WindowingEngine` |
+| **L3: Cognitive Engine** | `engine/` | The "brains." Handles LLM interactions, tools, and prompts. Logic is divorced from I/O. | `WriterAgent`, `EnricherAgent`, `PydanticAgentWrapper` |
+| **L2: Data Infrastructure**| `infra/` | Implementations of external resources: databases, vector stores, file I/O, adapters. | `DuckDBRepository`, `LanceDBVectorStore`, `MkDocsAdapter` |
+| **L1: Core Domain** | `core/` | Defines the system's "grammar": data structures, configuration, and ports (Protocols). **No business logic or I/O.** | `types`, `config`, `ports` |
+
+---
+
+## Implementation Phases (TDD Execution)
+
+### Phase 1: Core Foundation & Interfaces (Complete)
+*   **1.1 Types:** Define `Document`, `FeedItem` (replaces Message), `DocumentType`. Implement content-addressed ID generation.
+*   **1.2 Config:** Implement `EgregoraConfig` using Pydantic V2 with strict path resolution.
+*   **1.3 Ports:** Define Protocols (`InputAdapter`, `DocumentRepository`, `VectorStore`, `LLMModel`, `UrlConvention`, `OutputSink`, `Agent`).
+
+### Phase 2: Data Infrastructure
+*   **2.1 Adapter:** Implement `WhatsAppAdapter` to parse export files into `FeedItem` streams.
+*   **2.2 Repository:** Implement `DuckDBRepository` using Ibis for synchronous CRUD operations on `Document` and `FeedItem`.
+*   **2.3 Vector Store:** Implement `LanceDBVectorStore` for RAG indexing and search.
+*   **2.4 Output:** Implement `MkDocsAdapter` (OutputSink) and `StandardUrlConvention` for persisting documents to disk.
+
+### Phase 3: Cognitive Engine
+*   **3.1 LLM Client:** Implement `PydanticAgentWrapper` implementing `LLMModel`. Handles sync execution of `pydantic-ai` agents.
+*   **3.2 Tools:** Implement `WriteDocumentTool`, `SearchRagTool`, etc., injecting L2 infrastructure components.
+*   **3.3 Agents:** Implement `Agent` protocol.
+    *   `EnricherAgent`: Enriches items/media.
+    *   `WriterAgent`: Generates posts from item windows.
+
+### Phase 4: Pipeline Orchestration
+*   **4.1 Windowing:** Implement `WindowingEngine` to split item streams into overlapping windows based on time or count.
+*   **4.2 Steps:** Implement functional pipeline steps (`anonymize`, `extract_media`).
+*   **4.3 Runner:** Implement `PipelineRunner` to coordinate the full flow: Ingest -> Window -> Enrich -> Write -> Persist.
+*   **4.4 CLI:** Implement `egregora` CLI using `typer`.
+
+## Testing Strategy
+*   **Unit Tests:** Strict isolation for Agents and Core logic.
+*   **Integration Tests:** Verify Infrastructure implementations against real (or dockerized) databases.
+*   **E2E Tests:** Run the full pipeline with a mocked LLM to verify data flow and file generation.

--- a/src/egregora_v3/__init__.py
+++ b/src/egregora_v3/__init__.py
@@ -1,0 +1,1 @@
+"""Egregora V3 Package."""

--- a/src/egregora_v3/core/__init__.py
+++ b/src/egregora_v3/core/__init__.py
@@ -1,0 +1,1 @@
+"""Egregora V3 Core Domain."""

--- a/src/egregora_v3/core/config.py
+++ b/src/egregora_v3/core/config.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelSettings(BaseModel):
+    """Configuration for LLM models."""
+
+    writer: str = Field(default="google-gla:gemini-2.0-flash", description="Model for writing posts")
+    enricher: str = Field(default="google-gla:gemini-2.0-flash", description="Model for enrichment")
+    embedding: str = Field(default="models/gemini-embedding-001", description="Model for embeddings")
+
+    # Fallback/Secondary provider
+    fallback_enabled: bool = Field(default=True, description="Enable fallback to secondary provider")
+    fallback_model: str = Field(default="openrouter:google/gemini-flash-1.5", description="Fallback model ID")
+
+
+class PathsSettings(BaseModel):
+    """Path configuration.
+
+    All paths are relative to the 'site_root' unless absolute.
+    """
+
+    site_root: Path = Field(default=Path(), description="Root directory of the site")
+
+    # Content
+    posts_dir: Path = Field(default=Path("posts"), description="Posts directory")
+    profiles_dir: Path = Field(default=Path("profiles"), description="Profiles directory")
+    media_dir: Path = Field(default=Path("media"), description="Media directory")
+
+    # Internal
+    egregora_dir: Path = Field(default=Path(".egregora"), description="Internal directory")
+    db_path: Path = Field(default=Path(".egregora/pipeline.duckdb"), description="DuckDB file path")
+    lancedb_path: Path = Field(default=Path(".egregora/lancedb"), description="LanceDB directory")
+
+    @property
+    def abs_posts_dir(self) -> Path:
+        return self._resolve(self.posts_dir)
+
+    @property
+    def abs_profiles_dir(self) -> Path:
+        return self._resolve(self.profiles_dir)
+
+    @property
+    def abs_media_dir(self) -> Path:
+        return self._resolve(self.media_dir)
+
+    @property
+    def abs_db_path(self) -> Path:
+        return self._resolve(self.db_path)
+
+    @property
+    def abs_lancedb_path(self) -> Path:
+        return self._resolve(self.lancedb_path)
+
+    def _resolve(self, path: Path) -> Path:
+        if path.is_absolute():
+            return path
+        return self.site_root / path
+
+
+class PipelineSettings(BaseModel):
+    """Pipeline execution settings."""
+
+    step_size: int = 1
+    step_unit: Literal["days", "messages", "hours"] = "days"
+    max_tokens: int = 100_000
+
+
+class EgregoraConfig(BaseModel):
+    """Root configuration for Egregora V3."""
+
+    models: ModelSettings = Field(default_factory=ModelSettings)
+    paths: PathsSettings = Field(default_factory=PathsSettings)
+    pipeline: PipelineSettings = Field(default_factory=PipelineSettings)
+
+    model_config = ConfigDict(extra="ignore")
+
+    @classmethod
+    def load(cls, site_root: Path) -> "EgregoraConfig":
+        """Loads configuration from .egregora/config.yml in the site_root.
+
+        If file doesn't exist, returns default config.
+        Raises error if file exists but is invalid.
+        """
+        config_path = site_root / ".egregora" / "config.yml"
+
+        data = {}
+        if config_path.exists():
+            with config_path.open(encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+
+        # Inject site_root into paths config
+        # We modify the dictionary before instantiation to ensure immutability/clean construction
+        paths_data = data.get("paths")
+
+        if paths_data is None:
+            paths_data = {}
+        elif not isinstance(paths_data, dict):
+            msg = f"Configuration 'paths' must be a dictionary, got {type(paths_data).__name__}"
+            raise ValueError(msg)
+
+        paths_data["site_root"] = site_root
+        data["paths"] = paths_data
+
+        return cls(**data)

--- a/src/egregora_v3/core/ports.py
+++ b/src/egregora_v3/core/ports.py
@@ -1,0 +1,92 @@
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID
+
+from egregora_v3.core.types import Document, DocumentType, FeedItem
+
+
+@runtime_checkable
+class InputAdapter(Protocol):
+    """Parses a source input into a stream of FeedItems."""
+
+    def parse(self, source: Path) -> Iterator[FeedItem]:
+        ...
+
+
+@runtime_checkable
+class DocumentRepository(Protocol):
+    """Persists and retrieves Document and FeedItem primitives."""
+
+    # Documents
+    def save(self, doc: Document) -> None: ...
+    def get(self, doc_id: UUID) -> Document | None: ...
+    def list_by_type(self, doc_type: DocumentType) -> list[Document]: ...
+    def exists(self, doc_id: UUID) -> bool: ...
+
+    # FeedItems (Messages)
+    def save_item(self, item: FeedItem) -> None: ...
+    def get_item(self, item_id: UUID) -> FeedItem | None: ...
+    def get_items_by_source(self, source: str) -> list[FeedItem]: ...
+
+
+@runtime_checkable
+class VectorStore(Protocol):
+    """Manages vector embeddings for Documents (RAG)."""
+
+    def add(self, docs: list[Document]) -> None:
+        """Embeds and indexes documents."""
+        ...
+
+    def search(self, query: str, k: int = 5, filter_type: DocumentType | None = None) -> list[Document]:
+        """Semantic search."""
+        ...
+
+
+@runtime_checkable
+class LLMModel(Protocol):
+    """Synchronous Interface for LLM/Agent operations.
+
+    Wraps pydantic-ai.Agent or other engines.
+    """
+
+    def generate(self, prompt: str, system_prompt: str | None = None, tools: list[Any] | None = None) -> str:
+        """Generates text completion synchronously."""
+        ...
+
+    def embed(self, text: str) -> list[float]:
+        """Generates vector embedding synchronously."""
+        ...
+
+
+@runtime_checkable
+class Agent(Protocol):
+    """Cognitive Agent that processes FeedItems into Documents."""
+
+    def process(self, items: list[FeedItem]) -> list[Document]:
+        """Processes a batch of items (e.g. a window of chat messages) and produces derived Documents.
+
+        Example: Post, Journal entry.
+        """
+        ...
+
+
+@runtime_checkable
+class UrlConvention(Protocol):
+    """Pure logical protocol for determining URL paths for Documents.
+
+    Separate from I/O.
+    """
+
+    def resolve(self, doc: Document) -> str:
+        """Returns the logical URL path (e.g., 'posts/2023/my-post')."""
+        ...
+
+
+@runtime_checkable
+class OutputSink(Protocol):
+    """Final destination for published Documents (e.g. Markdown files)."""
+
+    def persist(self, doc: Document) -> Path:
+        """Writes document to disk/storage and returns the location."""
+        ...

--- a/src/egregora_v3/core/types.py
+++ b/src/egregora_v3/core/types.py
@@ -1,0 +1,87 @@
+import hashlib
+import uuid
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DocumentType(str, Enum):
+    POST = "post"
+    PROFILE = "profile"
+    JOURNAL = "journal"
+    ENRICHMENT = "enrichment"
+    MEDIA = "media"
+
+
+class FeedItem(BaseModel):
+    """Represents a single item in the input feed (Chat message, RSS entry, etc.).
+
+    Immutable primitive.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: uuid.UUID = Field(..., description="Unique ID of the item")
+    timestamp: datetime = Field(..., description="Timestamp of publication/creation")
+    source: str = Field(..., description="Source identifier (Author Name, Feed Title)")
+    content: str = Field(..., description="Main content (Body text)")
+
+    # Optional fields for RSS/Blog support
+    title: str | None = Field(default=None, description="Title of the item (if applicable)")
+    url: str | None = Field(default=None, description="URL to the original item")
+
+    # Attachments/Enrichments
+    attachments: list[str] = Field(default_factory=list, description="List of attachment paths")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Extra metadata")
+
+    @property
+    def word_count(self) -> int:
+        return len(self.content.split())
+
+
+class Document(BaseModel):
+    """Unified Document primitive.
+
+    Used for Posts, Profiles, Journals, Enrichments, and Media.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: uuid.UUID = Field(..., description="Unique ID of the document")
+    type: DocumentType = Field(..., description="Type of the document")
+    content: str = Field(..., description="Main content (Markdown, JSON, etc.)")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Metadata key-values")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Creation time")
+
+    @classmethod
+    def create(cls,
+               content: str,
+               doc_type: DocumentType,
+               metadata: dict[str, Any] | None = None,
+               id_override: uuid.UUID | None = None) -> "Document":
+        """Factory method to create a Document.
+
+        If id_override is not provided, generates a content-addressed ID.
+        """
+        if metadata is None:
+            metadata = {}
+
+        if id_override:
+            doc_id = id_override
+        else:
+            # Content-addressed ID based on content + type
+            hasher = hashlib.sha256()
+            hasher.update(content.encode('utf-8'))
+            hasher.update(doc_type.value.encode('utf-8'))
+            # We use the hash to generate a UUID
+            doc_id = uuid.uuid5(uuid.NAMESPACE_DNS, hasher.hexdigest())
+
+        return cls(
+            id=doc_id,
+            type=doc_type,
+            content=content,
+            metadata=metadata,
+            created_at=datetime.now(UTC)
+        )

--- a/tests/v3/core/test_config.py
+++ b/tests/v3/core/test_config.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from egregora_v3.core.config import EgregoraConfig, PathsSettings
+
+
+def test_default_config():
+    config = EgregoraConfig()
+    assert config.models.writer == "google-gla:gemini-2.0-flash"
+    assert config.pipeline.step_unit == "days"
+    assert config.paths.site_root == Path()
+
+def test_path_resolution(tmp_path):
+    site_root = tmp_path / "mysite"
+    paths = PathsSettings(site_root=site_root, posts_dir=Path("content/posts"))
+
+    assert paths.abs_posts_dir == site_root / "content/posts"
+    assert paths.abs_db_path == site_root / ".egregora/pipeline.duckdb"
+
+def test_load_from_yaml(tmp_path):
+    # Setup a mock site
+    site_root = tmp_path / "mysite"
+    egregora_dir = site_root / ".egregora"
+    egregora_dir.mkdir(parents=True)
+
+    config_data = {
+        "pipeline": {
+            "step_size": 7,
+            "step_unit": "days"
+        },
+        "models": {
+            "writer": "custom-model"
+        }
+    }
+
+    with (egregora_dir / "config.yml").open("w") as f:
+        yaml.dump(config_data, f)
+
+    # Load config
+    config = EgregoraConfig.load(site_root)
+
+    assert config.pipeline.step_size == 7
+    assert config.models.writer == "custom-model"
+    assert config.paths.site_root == site_root
+    assert config.paths.abs_posts_dir == site_root / "posts"
+
+def test_load_missing_file(tmp_path):
+    site_root = tmp_path / "empty_site"
+    site_root.mkdir()
+
+    config = EgregoraConfig.load(site_root)
+    assert config.pipeline.step_size == 1  # Default
+    assert config.paths.site_root == site_root
+
+def test_load_invalid_paths_config(tmp_path):
+    site_root = tmp_path / "bad_site"
+    egregora_dir = site_root / ".egregora"
+    egregora_dir.mkdir(parents=True)
+
+    # paths is a string, not a dict
+    config_data = {
+        "paths": "invalid_string"
+    }
+
+    with (egregora_dir / "config.yml").open("w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Configuration 'paths' must be a dictionary"):
+        EgregoraConfig.load(site_root)

--- a/tests/v3/core/test_ports.py
+++ b/tests/v3/core/test_ports.py
@@ -1,0 +1,70 @@
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from egregora_v3.core.ports import (
+    Agent,
+    DocumentRepository,
+    InputAdapter,
+    LLMModel,
+    OutputSink,
+    UrlConvention,
+    VectorStore,
+)
+from egregora_v3.core.types import Document, DocumentType, FeedItem
+
+
+def test_input_adapter_protocol():
+    class MockAdapter:
+        def parse(self, source: Path) -> Iterator[FeedItem]:
+            yield FeedItem(id=UUID(int=1), timestamp=datetime.now(), source="a", content="b")
+
+    assert isinstance(MockAdapter(), InputAdapter)
+
+def test_repo_protocol():
+    class MockRepo:
+        def save(self, doc: Document) -> None: pass
+        def get(self, doc_id: UUID) -> Document | None: return None
+        def list_by_type(self, doc_type: DocumentType) -> list[Document]: return []
+        def exists(self, doc_id: UUID) -> bool: return False
+
+        def save_item(self, item: FeedItem) -> None: pass
+        def get_item(self, item_id: UUID) -> FeedItem | None: return None
+        def get_items_by_source(self, source: str) -> list[FeedItem]: return []
+
+    assert isinstance(MockRepo(), DocumentRepository)
+
+def test_vector_store_protocol():
+    class MockVector:
+        def add(self, docs: list[Document]) -> None: pass
+        def search(self, query: str, k: int = 5, filter_type: DocumentType | None = None) -> list[Document]: return []
+
+    assert isinstance(MockVector(), VectorStore)
+
+def test_llm_model_protocol():
+    class MockLLM:
+        def generate(self, prompt: str, system_prompt: str | None = None, tools: list[Any] | None = None) -> str: return ""
+        def embed(self, text: str) -> list[float]: return []
+
+    assert isinstance(MockLLM(), LLMModel)
+
+def test_agent_protocol():
+    class MockAgent:
+        def process(self, items: list[FeedItem]) -> list[Document]:
+            return []
+
+    assert isinstance(MockAgent(), Agent)
+
+def test_url_convention_protocol():
+    class MockConvention:
+        def resolve(self, doc: Document) -> str: return "path/to/doc"
+
+    assert isinstance(MockConvention(), UrlConvention)
+
+def test_output_sink_protocol():
+    class MockSink:
+        def persist(self, doc: Document) -> Path: return Path()
+
+    assert isinstance(MockSink(), OutputSink)

--- a/tests/v3/core/test_types.py
+++ b/tests/v3/core/test_types.py
@@ -1,0 +1,48 @@
+import uuid
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from egregora_v3.core.types import Document, DocumentType, FeedItem
+
+
+def test_feed_item_immutability():
+    msg = FeedItem(
+        id=uuid.uuid4(),
+        timestamp=datetime.now(),
+        source="User A",
+        content="Hello world"
+    )
+
+    with pytest.raises(ValidationError):
+        msg.content = "New content"
+
+def test_document_create_factory():
+    content = "# Hello"
+    doc = Document.create(content=content, doc_type=DocumentType.POST)
+
+    assert doc.content == content
+    assert doc.type == DocumentType.POST
+    assert isinstance(doc.id, uuid.UUID)
+
+def test_document_content_addressed_id():
+    content = "Same Content"
+    doc1 = Document.create(content=content, doc_type=DocumentType.POST)
+    doc2 = Document.create(content=content, doc_type=DocumentType.POST)
+    doc3 = Document.create(content=content, doc_type=DocumentType.PROFILE)
+
+    assert doc1.id == doc2.id
+    assert doc1.id != doc3.id
+
+def test_document_immutability():
+    doc = Document.create(content="Test", doc_type=DocumentType.POST)
+    with pytest.raises(ValidationError):
+        doc.content = "Changed"
+
+def test_document_types_exist():
+    assert DocumentType.POST == "post"
+    assert DocumentType.PROFILE == "profile"
+    assert DocumentType.JOURNAL == "journal"
+    assert DocumentType.ENRICHMENT == "enrichment"
+    assert DocumentType.MEDIA == "media"


### PR DESCRIPTION
- Fix security issue S108 in tests by using `tmp_path` fixture.
- Fix PTH123 by using `Path.open()`.
- Fix D200, D205 docstring issues.
- Fix INP001 by adding `__init__.py` files.
- Refactor `EgregoraConfig.load` to avoid mutation and explicitly handle invalid paths.
- Add negative test case for invalid paths config.