### PR TITLE
Add repomix download links to docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,23 @@ Welcome to the Egregora documentation! Transform your WhatsApp group chats into 
 
     [:octicons-arrow-right-24: Development](development/contributing.md)
 
+-   :material-package-down:{ .lg .middle } __Repomix Bundle__
+
+    ---
+
+    Download the latest consolidated source bundle for offline review or model uploads
+
+    [:octicons-download-24: Download Repomix Build](bundles/code.bundle.md)
+
 </div>
+
+## Repomix bundles
+
+Download consolidated markdown bundles generated from the repository:
+
+- [Full code bundle](bundles/code.bundle.md)
+- [Tests bundle](bundles/tests.bundle.md)
+- [Documentation bundle](bundles/docs.bundle.md)
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- add a quick link card for downloading the Repomix code bundle from the docs homepage
- list all available Repomix bundle downloads in a dedicated section on the homepage

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930860c80b883258dfd028567836641)