### PR TITLE
Ensure Repomix bundles are published with docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd egregora
           uv sync --extra docs
 
       - name: Build Documentation
         run: |
-          cd egregora
           uv run mkdocs build
 
       - name: Setup Node.js
@@ -163,7 +161,6 @@ jobs:
       - name: Generate Repomix bundles
         run: |
           mkdir -p /tmp/bundles
-          cd egregora
           npx repomix -c repomix-docs.json --output /tmp/bundles/docs.bundle.md
           npx repomix -c repomix-tests.json --output /tmp/bundles/tests.bundle.md
           npx repomix -c repomix-code.json --output /tmp/bundles/code.bundle.md
@@ -174,7 +171,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./egregora/site
+          publish_dir: ./site
 
       - name: Upload bundles artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -35,6 +40,13 @@ jobs:
 
       - name: Build site
         run: uvx --python 3.12 --with ".[docs]" mkdocs build --clean
+
+      - name: Generate Repomix bundles
+        run: |
+          mkdir -p site/bundles
+          npx repomix -c repomix-docs.json --output site/bundles/docs.bundle.md
+          npx repomix -c repomix-tests.json --output site/bundles/tests.bundle.md
+          npx repomix -c repomix-code.json --output site/bundles/code.bundle.md
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,23 @@ Welcome to the Egregora documentation! Transform your WhatsApp group chats into 
 
     [:octicons-arrow-right-24: Development](development/contributing.md)
 
+-   :material-package-down:{ .lg .middle } __Repomix Bundle__
+
+    ---
+
+    Download the latest consolidated source bundle for offline review or model uploads
+
+    [:octicons-download-24: Download Repomix Build](bundles/code.bundle.md)
+
 </div>
+
+## Repomix bundles
+
+Download consolidated markdown bundles generated from the repository:
+
+- [Full code bundle](bundles/code.bundle.md)
+- [Tests bundle](bundles/tests.bundle.md)
+- [Documentation bundle](bundles/docs.bundle.md)
 
 ## Architecture Overview
 


### PR DESCRIPTION
### Summary
- Ensure the GitHub Pages build workflow generates and packages Repomix bundles alongside the docs site.
- Fix the CI docs deployment job paths so bundles publish correctly.

### Motivation / Context
- The Repomix bundle link on the published docs returned 404 because the Pages workflow did not build or ship the bundle files.
- The CI docs job that generates bundles also pointed to an incorrect directory, preventing successful publication.

### Changes
- CI: remove incorrect `cd` usage and fix the GitHub Pages publish directory so the docs job can deploy bundled artifacts.
- CI: keep Repomix bundle generation in the docs job and upload bundles as artifacts.
- Pages: add Node setup and Repomix generation so the default docs deployment includes all bundles in `site/bundles`.

### Implementation Details
- Generate bundles after `mkdocs build` to avoid them being cleaned, and write outputs directly into `site/bundles` before uploading the Pages artifact.
- Align `publish_dir` with the actual site path to avoid missing files during deployment.

### Testing
- Not run (workflow-only changes).

### Risks & Rollback Plan
- Workflow failures could block docs deployment; revert this PR to restore the previous pipeline if issues arise.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- Docs deployments now include Repomix bundle downloads.

### Checklist
- [ ] Tests added or updated
- [x] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930860c80b883258dfd028567836641)