### PR TITLE
fix: Integrate demo blog into main pages workflow and add prominent link

### DIFF
--- a/.github/workflows/demo-blog.yml
+++ b/.github/workflows/demo-blog.yml
@@ -1,4 +1,8 @@
-name: Demo Blog (Auto-Deploy)
+name: Demo Blog (DEPRECATED - Integrated into pages.yml)
+
+# DEPRECATED: This workflow has been integrated into pages.yml
+# The demo blog is now built and deployed together with the main documentation
+# Keeping this file for reference but it will never trigger
 
 # Security: Limit permissions to minimum required for deployment
 permissions:
@@ -12,15 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  # Rebuild demo on every push to main
-  push:
-    branches: [main]
-
-  # Nightly rebuild to catch regressions
-  schedule:
-    - cron: '0 2 * * *'  # 2 AM UTC daily
-
-  # Allow manual trigger from Actions UI
+  # Disabled - only manual trigger available for testing/reference
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python 3.12
         run: uv python install 3.12
 
-      - name: Build site
+      - name: Build documentation site
         run: uvx --python 3.12 --with ".[docs]" mkdocs build --clean
 
       - name: Generate Repomix bundles
@@ -50,6 +50,58 @@ jobs:
           npx repomix -c repomix-docs.json --output site/bundles/docs.bundle.md
           npx repomix -c repomix-tests.json --output site/bundles/tests.bundle.md
           npx repomix -c repomix-code.json --output site/bundles/code.bundle.md
+
+      # Build demo blog and add to /demo path
+      - name: Install egregora with all dependencies
+        run: uv sync --all-extras
+
+      - name: Restore pipeline cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            pipeline.duckdb
+            pipeline.duckdb.wal
+            .egregora-cache/
+            .egregora/lancedb/
+          key: demo-pipeline-${{ hashFiles('tests/fixtures/Conversa do WhatsApp com Teste.zip') }}-v2
+          restore-keys: |
+            demo-pipeline-${{ hashFiles('tests/fixtures/Conversa do WhatsApp com Teste.zip') }}-
+            demo-pipeline-
+
+      - name: Generate demo blog
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: |
+          echo "🚀 Generating demo blog from fixture..."
+          uv run egregora write \
+            "tests/fixtures/Conversa do WhatsApp com Teste.zip" \
+            --output=./demo-output \
+            --resume
+          echo "✅ Blog generation complete"
+
+      - name: Validate demo output quality
+        run: |
+          POST_COUNT=$(find demo-output/posts -name "*.md" -type f ! -name "index.md" | wc -l)
+          echo "📊 Generated $POST_COUNT blog posts"
+          if [ "$POST_COUNT" -lt 6 ]; then
+            echo "⚠️  WARNING: Only $POST_COUNT posts generated (minimum: 6)"
+            echo "Demo blog may be incomplete but continuing deployment"
+          else
+            echo "✅ Quality check passed: $POST_COUNT posts generated"
+          fi
+
+      - name: Build demo MkDocs site
+        run: |
+          cd demo-output
+          uvx --with mkdocs-material --with mkdocs-blogging-plugin mkdocs build
+          echo "✅ Demo MkDocs site built successfully"
+
+      - name: Integrate demo into docs site
+        run: |
+          # Move demo site to /demo subfolder in the main site
+          mv demo-output/site site/demo
+          echo "✅ Demo blog integrated at /demo path"
+          ls -lah site/demo/ | head -20
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,11 @@
 
 Welcome to the Egregora documentation! Transform your WhatsApp group chats into intelligent, privacy-first blogs where collective conversations emerge as beautifully written articles.
 
+!!! tip "🌟 Try the Live Demo"
+    **See Egregora in action!** Check out our [**live demo blog**](demo/) generated from real WhatsApp conversations. Experience how collective chats transform into beautifully organized articles.
+
+    [:octicons-arrow-right-24: Explore the Demo Blog](demo/){ .md-button .md-button--primary }
+
 ## Features
 
 - 🧠 **Emergent Intelligence**: Collective conversations synthesize into coherent articles


### PR DESCRIPTION
The demo blog workflow was conflicting with the main pages workflow because both were trying to deploy to GitHub Pages independently. This caused the demo site to not be published properly.

Changes:
- Integrated demo blog build into pages.yml workflow
- Demo blog now deploys alongside docs at /demo path
- Deprecated demo-blog.yml (kept for reference, disabled auto-triggers)
- Added prominent "Try the Live Demo" callout on docs homepage
- Demo will now update whenever docs are rebuilt

The unified deployment ensures both docs and demo are always in sync.