### PR TITLE
Fix enrichment scheduling and authors parsing

### DIFF
--- a/src/egregora/agents/enricher.py
+++ b/src/egregora/agents/enricher.py
@@ -365,13 +365,17 @@ def schedule_enrichment(
         current_run_id,
         enable_url=enrichment_settings.enable_url,
     )
+    media_config = MediaEnrichmentConfig(
+        media_mapping=media_mapping,
+        max_enrichments=max_enrichments,
+        enable_media=enrichment_settings.enable_media,
+    )
+
     media_count = _enqueue_media_enrichments(
         messages_table,
-        media_mapping,
-        max_enrichments,
         context,
         current_run_id,
-        enrichment_settings.enable_media,
+        media_config,
     )
     logger.info("Scheduled %d URL tasks and %d Media tasks", url_count, media_count)
 

--- a/src/egregora/utils/filesystem.py
+++ b/src/egregora/utils/filesystem.py
@@ -96,16 +96,16 @@ def _find_authors_yml(output_dir: Path) -> Path:
 
 def _load_authors_yml(path: Path) -> dict:
     try:
-        return yaml.safe_load(path.read_text(encoding="utf-8")) or {{}}
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
-        return {{}}
+        return {}
 
 
 def _register_new_authors(authors: dict, author_ids: list[str]) -> list[str]:
     new_ids = []
     for author_id in author_ids:
         if author_id and author_id not in authors:
-            authors[author_id] = {{"name": author_id}}
+            authors[author_id] = {"name": author_id}
             new_ids.append(author_id)
     return new_ids
 


### PR DESCRIPTION
### Summary
- Fix media enrichment scheduling to use the new configuration object
- Correct `.authors.yml` handling to avoid set construction and allow author registration

### Motivation / Context
- Media enrichment scheduling was calling `_enqueue_media_enrichments` with outdated arguments, causing runtime failures in the pipeline tests
- Author metadata bootstrap used malformed literals, raising `TypeError` and blocking profile statistics generation

### Changes
- Wrap media enrichment parameters in `MediaEnrichmentConfig` before enqueueing tasks
- Replace set-style placeholders in author YAML helpers with proper dictionaries

### Implementation Details
- `schedule_enrichment` now builds a `MediaEnrichmentConfig` and passes it to `_enqueue_media_enrichments`, matching its signature
- `_load_authors_yml` and `_register_new_authors` now return and store plain dicts, ensuring missing files are handled gracefully

### Testing
- `uv run pytest tests/e2e/pipeline/test_write_pipeline_e2e.py::test_full_pipeline_smoke_test tests/e2e/pipeline/test_write_pipeline_e2e.py::test_pipeline_with_rag_enabled tests/e2e/test_mkdocs_adapter_coverage.py::test_get_profiles_data_generates_stats -q`

### Risks & Rollback Plan
- Low risk; changes are limited to enrichment scheduling call site and author YAML helpers
- Rollback by reverting this commit

### Breaking Changes / Migrations (if applicable)
- None

### Release Notes (optional)
- Fix media enrichment scheduling and author metadata initialization

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937227dea80832584fb46265341b663)