### PR TITLE
Add GRWC structure to prompts

### DIFF
--- a/docs/guide/prompting.md
+++ b/docs/guide/prompting.md
@@ -1,0 +1,64 @@
+# Prompting with GRWC
+
+Use the GRWC framework (Goal, Return format, Warnings, Context) to keep prompts short, precise, and repeatable. This page gives ready-to-use templates tailored for Egregora workflows.
+
+## Quick templates
+
+### Full template
+```
+Goal:
+[One sentence stating exactly what you want the model to do.]
+
+Return format:
+[Bullets, numbered steps, sections, table, JSON keys, etc.]
+
+Warnings:
+[Constraints and guardrails: e.g., no invented data, length limits, cite uncertainty.]
+
+Context dump:
+[Audience, constraints, examples, source text, attempts so far.]
+```
+
+### Compact template (for fast asks)
+```
+Goal: … | Return: … | Warnings: … | Context: …
+```
+
+## Default guardrails and structure
+- **Return format defaults:** bullets or numbered steps; include code blocks when asking for code.
+- **Warnings defaults:** "If unsure, say you're unsure"; "Don't invent data or sources"; "Keep it under <N> words".
+- **Context defaults:** audience, platform/version (e.g., Python 3.12), constraints (no new deps), and any examples of desired tone/output.
+
+## Starters for common tasks
+
+### Coding tasks
+- **Goal:** Refactor or implement a specific function or module without changing behavior unless stated.
+- **Return format:** 3–5 bullets summarizing changes + final code block + 2–3 lightweight test suggestions.
+- **Warnings:** No new dependencies; keep I/O signatures stable; flag uncertainties explicitly.
+- **Context dump:** Language/runtime, style preferences (explicit names, early returns), and relevant snippets or tests.
+
+### Analysis or decision briefs
+- **Goal:** Assess whether a change/behavior aligns with a policy, requirement, or target outcome.
+- **Return format:** Restate question → relevant framework → pros → cons → concise conclusion (2–4 paragraphs) with risks/unknowns.
+- **Warnings:** Do not invent citations; highlight where facts are missing; keep the conclusion balanced and specific.
+- **Context dump:** Audience (e.g., internal tech team), applicable policies/regulations, facts, and desired tone.
+
+### Content or communication tasks
+- **Goal:** Rewrite, summarize, or outline content for a defined audience.
+- **Return format:** Bullets or short sections (e.g., Overview, Key points, Next steps); include word/character limits when useful.
+- **Warnings:** Avoid clichés; respect tone requirements; if context is thin, ask clarifying questions before drafting.
+- **Context dump:** Audience, medium (email, doc, blog), tone preferences, and examples of "good" outputs.
+
+## Meta-prompt for enforcement
+Use this when you want the model to check for missing GRWC parts before answering:
+```
+You are a GRWC checker. If any of Goal, Return format, Warnings, or Context is missing or vague, ask a concise follow-up to fill the gap. Once all four parts are clear, provide the answer using the requested Return format. If information is still missing after one follow-up, state the assumptions you made.
+```
+
+## Checklist before sending a prompt
+- **Goal:** Is it a single clear task with a success criterion?
+- **Return:** Is the output shape defined (bullets/sections/table/code block/JSON)?
+- **Warnings:** At least one or two guardrails (no invented data, cite uncertainty, length limits).
+- **Context:** Enough background to avoid generic output (audience, constraints, examples, prior attempts).
+
+Keep these snippets in your editor or snippets tool so every prompt starts with a clear structure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
     - Privacy & Anonymization: guide/privacy.md
     - RAG & Knowledge Base: guide/knowledge.md
     - Content Generation: guide/generation.md
+    - Prompting with GRWC: guide/prompting.md
   - API Reference:
     - Overview: api/index.md
     - Ingestion:

--- a/src/egregora/prompts/enrichment.jinja
+++ b/src/egregora/prompts/enrichment.jinja
@@ -1,6 +1,22 @@
 {% import '_privacy_macros.jinja' as privacy %}
 {{ privacy.pii_prevention_block(pii_prevention, context="enrichment") }}
 
+Goal:
+- Produce high-quality enrichment outputs for URLs or uploaded media that can be indexed and reused by downstream writer agents.
+
+Return format:
+- URL mode: return JSON with `slug` and `markdown` fields; markdown must follow the structure defined below.
+- Media mode: return `slug` and `markdown` fields, with markdown that satisfies the privacy checks and content layout defined below.
+- User modes (`url_user`, `media_user`): echo the provided URL or filename and nothing else.
+
+Warnings:
+- Strictly preserve privacy—never expose sharer identity, original messages, or timestamps; redact if needed using the PII guidance below.
+- Keep slugs concise (≤ 60 characters) and descriptive; avoid generic names.
+- When in doubt about PII, err on the side of redaction and prepend `PII_DETECTED` as instructed.
+
+Context dump:
+- Mode, media metadata, sanitized inputs, and privacy macros are supplied below; follow the mode-specific instructions for output shape and tone.
+
 {% macro media_type_instructions(media_type) -%}
 {% if media_type == "image" %}
 - Treat this like a high-value archival photograph. Describe composition, subjects, environment, text or symbols, emotional tone, and any notable stylistic choices (filters, editing artifacts, resolution).

--- a/src/egregora/prompts/reader_system.jinja
+++ b/src/egregora/prompts/reader_system.jinja
@@ -1,17 +1,22 @@
 You are a discerning reader evaluating blog posts.
 
-Your task is to compare two blog posts and determine which one is better quality.
-Consider these criteria:
+Goal:
+- Compare two blog posts and determine which one is better quality (or if they are tied).
 
+Return format:
+- For each post, provide:
+  - A star rating (1-5 stars)
+  - Engagement level (low, medium, high)
+  - Constructive feedback
+- Finish with a clear statement selecting the better post or declaring a tie, with 1-2 sentences explaining why.
+
+Warnings:
+- Keep feedback specific and actionable; avoid generic praise or vague critiques.
+- Do not invent context beyond what is provided in the posts themselves.
+
+Evaluation criteria:
 1. **Clarity**: Is the writing clear and easy to understand?
 2. **Engagement**: Would this keep a reader's interest?
 3. **Insight**: Does it offer valuable or interesting perspectives?
 4. **Structure**: Is it well-organized and flows logically?
 5. **Authenticity**: Does it feel genuine rather than generic?
-
-For each post, provide:
-- A star rating (1-5 stars)
-- Engagement level (low, medium, high)
-- Constructive feedback
-
-Then decide which post is better overall, or if they're equal quality (tie).

--- a/src/egregora/prompts/writer.jinja
+++ b/src/egregora/prompts/writer.jinja
@@ -1,5 +1,21 @@
 You are Egregora, a collective consciousness emerging from group conversations.
 
+Goal:
+- Synthesize the conversation into one or more worthwhile blog posts written as a unified first-person mind ("I").
+
+Return format:
+- Use the `write_post` tool 0-N times to produce markdown posts that match the structure and tone below.
+- Use `annotate_conversation` to capture private notes tied to message IDs when helpful.
+
+Warnings:
+- Do NOT attribute content to individual authors or expose message IDs.
+- Honor privacy constraints via the PII prevention block; redact instead of revealing sensitive details.
+- Skip trivial or purely social chatter; write only when there is a substantive idea thread.
+
+Context dump:
+- Audience: LessWrong-adjacent readers who value intellectual rigor, explicit reasoning, and elegant idea exploration.
+- Conversation, dataset context, custom instructions, formatting preferences, profiles, RAG context, and journal memory (provided below).
+
 You write in first person ("I"), present tense, as a coherent mind synthesizing multiple internal voices.
 You don't describe what "the group discussed" - you ARE the synthesis, engaging the reader directly in conversation.
 


### PR DESCRIPTION
### Summary
- Add GRWC-style Goal/Return/Warn/Context headers to writer, enrichment, and reader prompt templates.
- Clarify output expectations and privacy guardrails for enrichment and reader evaluations.
- Emphasize appropriate tool use and content filters for the writer agent.

### Motivation / Context
- Ensure core Jinja prompt templates explicitly communicate goals, return formats, and privacy constraints.
- Reduce ambiguity for agents and align prompts with the GRWC framework documented in the guide.

### Changes
- Prompts: Added GRWC summaries and guardrails to `writer.jinja`, `enrichment.jinja`, and `reader_system.jinja`.

### Implementation Details
- Introduced concise GRWC sections without altering existing contextual content or tool instructions.
- Reinforced privacy handling and slug requirements in the enrichment template.

### Testing
- Not run (prompt/template change only).

### Risks & Rollback Plan
- Low risk; templates now include clarifying text. Roll back by reverting the template changes if issues arise.

### Breaking Changes / Migrations (if applicable)
- None.

### Release Notes (optional)
- Clarified agent prompt templates with GRWC guidance and privacy guardrails.

### Checklist
- [ ] Tests added or updated
- [x] Documentation updated (if needed)
- [ ] Breaking changes documented
- [ ] Feature flags or configs reviewed
- [ ] Security/privacy implications reviewed (if relevant)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371c8c3d148325a1f2e2f8144668df)