### PR TITLE
Potential fix for code scanning alert no. 47: Clear-text logging of sensitive information

### DIFF
--- a/src/egregora/agents/enricher.py
+++ b/src/egregora/agents/enricher.py
@@ -1017,7 +1017,7 @@ class EnrichmentWorker(BaseWorker):
             )
             response_text = response.text or ""
 
-        logger.debug("[URLEnricher] Single-call response: %s", response_text[:500])
+        logger.debug("[URLEnricher] Single-call response received (length: %d)", len(response_text) if response_text else 0)
 
         # Parse JSON response
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/franklinbaldo/egregora/security/code-scanning/47](https://github.com/franklinbaldo/egregora/security/code-scanning/47)

To resolve the issue, we should avoid logging the full (or partial) `response_text` returned by the model API, as it could contain sensitive information such as API keys (due to possible echoes in external service errors or logs, or misconfiguration). Instead, log only non-sensitive, high-level information—like whether a response was successfully received, the length of the response, or a generic success/failure indicator. If some insight into the content is absolutely necessary for debugging, consider sanitizing the text first (e.g., by running it through a filter that removes anything that looks like an API key, but this is inherently brittle and best avoided).  
Specifically, remove or heavily restrict the information logged in line 1020 of `src/egregora/agents/enricher.py`, replacing it with a message that avoids echoing any of the actual response content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
