### PR TITLE
Fix: GitHub Actions checkout for local composite actions

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -12,8 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     name: Ruff (lint)
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -41,6 +44,9 @@ jobs:
     name: Ruff (format)
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -55,6 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -101,6 +110,9 @@ jobs:
     timeout-minutes: 30
     needs: [lint-ruff-check, lint-ruff-format]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -151,6 +163,9 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -179,6 +194,9 @@ jobs:
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -204,6 +222,9 @@ jobs:
     permissions:
       contents: write  # Required for GitHub Pages deployment
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:
@@ -249,6 +270,9 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-uv
         with:


### PR DESCRIPTION
This PR resolves critical GitHub Actions workflow failures by correcting the `actions/checkout` steps, specifically addressing an issue with local composite actions.

### Problem
Composite actions referenced with local paths (e.g., `./.github/actions/*`) require the repository to be checked out *before* the action definition can be found. The `setup-python-uv` composite action was incorrectly attempting to perform its own `checkout`, leading to a circular dependency and workflow failures.

### Solution
- Removed the redundant `actions/checkout` step from the `setup-python-uv` composite action.
- Added explicit `actions/checkout` steps to all CI workflow jobs *before* calling the `setup-python-uv` composite action.

### Impact
This fixes workflow failures in:
- CI workflow (lint, test, build jobs)
- Gemini PR Code Review workflow
- CodeQL Security Analysis workflow